### PR TITLE
Parametrize JuMP model in optimizer type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ addons:
         - libblas-dev
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'Pkg.add("MathOptInterface")'
-    - julia -e 'Pkg.checkout("MathOptInterface")'
-    - julia -e 'Pkg.checkout("MathOptInterface", "bl/cachingoptOT")'
     - julia -e 'Pkg.clone(pwd())'
     - julia -e 'Pkg.test("JuMP", coverage=true)'
 #    - julia test/hygiene.jl

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ addons:
         - libblas-dev
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+    - julia -e 'Pkg.add("MathOptInterface")'
+    - julia -e 'Pkg.checkout("MathOptInterface")'
+    - julia -e 'Pkg.checkout("MathOptInterface", "bl/cachingoptOT")'
     - julia -e 'Pkg.clone(pwd())'
     - julia -e 'Pkg.test("JuMP", coverage=true)'
 #    - julia test/hygiene.jl

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -179,7 +179,7 @@ end
 
 # Getters/setters
 
-const NonDirectBackendType = MOIU.CachingOptimizer{Union{Void, MOI.AbstractOptimizer}, MOIU.UniversalFallback{JuMP.JuMPMOIModel{Float64}}}
+const NonDirectBackendType = MOIU.CachingOptimizer{MOIU.UniversalFallback{JuMP.JuMPMOIModel{Float64}}}
 mode(m::Model) = Direct
 function mode(m::Model{NonDirectBackendType})
     if m.moibackend.mode == MOIU.Automatic

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -113,7 +113,7 @@ function initNLP(m::Model)
     end
 end
 
-function resultdual(c::ConstraintRef{Model,NonlinearConstraintIndex})
+function resultdual(c::ConstraintRef{<:Model,NonlinearConstraintIndex})
     initNLP(c.m)
     nldata::NLPData = c.m.nlpdata
     if !MOI.canget(c.m, MOI.NLPBlockDual())

--- a/src/parseexpr.jl
+++ b/src/parseexpr.jl
@@ -36,7 +36,7 @@ function destructive_add! end
 
 destructive_add!(ex::Number, c::Number, x::Number) = ex + c*x
 
-destructive_add!(ex::Number, c::Number, x::VariableRef) = AffExpr(ex, x => c)
+destructive_add!(ex::Number, c::Number, x::VariableRef) = GenericAffExpr{Float64, typeof(x)}(ex, x => c)
 
 function destructive_add!(ex::Number, c::Number, x::T) where T<:GenericAffExpr
     # It's only safe to mutate the first argument.
@@ -123,13 +123,13 @@ destructive_add!(aff::GenericAffExpr{C,V},c::V,x::V) where {C,V} =
     GenericQuadExpr{C,V}(aff, UnorderedPair(c,x) => 1.0)
 
 # TODO: add generic versions of following two methods
-function destructive_add!(aff::AffExpr,c::AffExpr,x::VariableRef)
+function destructive_add!(aff::GenericAffExpr,c::GenericAffExpr,x::VariableRef)
     quad = c*x
     quad.aff = destructive_add!(quad.aff, 1.0, aff)
     quad
 end
 
-function destructive_add!(aff::AffExpr,c::VariableRef,x::AffExpr)
+function destructive_add!(aff::GenericAffExpr,c::VariableRef,x::GenericAffExpr)
     quad = c*x
     # TODO: Consider implementing the add_to_expression! method for cases like
     # this and below.

--- a/src/print.jl
+++ b/src/print.jl
@@ -170,10 +170,10 @@ function aff_str(mode, a::GenericAffExpr{C, V}, show_constant=true) where {C, V}
     end
 end
 # Precompile for faster boot times
-Base.precompile(aff_str, (Type{JuMP.REPLMode}, AffExpr, Bool))
-Base.precompile(aff_str, (Type{JuMP.IJuliaMode}, AffExpr, Bool))
-Base.precompile(aff_str, (Type{JuMP.REPLMode}, AffExpr))
-Base.precompile(aff_str, (Type{JuMP.IJuliaMode}, AffExpr))
+Base.precompile(aff_str, (Type{JuMP.REPLMode}, GenericAffExpr{Float64, VariableRef{Model{NonDirectBackendType}}}, Bool))
+Base.precompile(aff_str, (Type{JuMP.IJuliaMode}, GenericAffExpr{Float64, VariableRef{Model{NonDirectBackendType}}}, Bool))
+Base.precompile(aff_str, (Type{JuMP.REPLMode}, GenericAffExpr{Float64, VariableRef{Model{NonDirectBackendType}}}))
+Base.precompile(aff_str, (Type{JuMP.IJuliaMode}, GenericAffExpr{Float64, VariableRef{Model{NonDirectBackendType}}}))
 
 
 #------------------------------------------------------------------------

--- a/src/print.jl
+++ b/src/print.jl
@@ -130,17 +130,7 @@ function var_str(::Type{IJuliaMode}, v::AbstractVariableRef; mathmode=true)
         return math("noname", mathmode)
     end
 end
-# We want arrays of variables to be printed with `JuMP.VariableRef` as eltype
-# instead of `JuMP.VariableRef{...}`.
-# For show/print, we just need the following method
-Base.print_without_params(::Type{<:JuMP.VariableRef}) = true
-# For display, we need to redefine summary
-Base.summary(a::AbstractArray{<:JuMP.VariableRef}) = _summary(a, Compat.axes(a))
-# Taken from Base.show but we replace typeof(a) by vrefarraytype(a)
-_summary(a, inds::Tuple{Vararg{Base.OneTo}}) = string(Base.dims2string(length.(inds)), " ", vrefarraytype(a))
-_summary(a, inds) = string(vrefarraytype(a), " with indices ", Base.inds2string(inds))
-# Array type shown for array of JuMP.VariableRef
-vrefarraytype(::AbstractArray{<:JuMP.VariableRef, N}) where N = string("AbstractArray{JuMP.VariableRef,", N, "}")
+
 
 Base.show(io::IO, a::GenericAffExpr) = print(io, aff_str(REPLMode,a))
 Base.show(io::IO, ::MIME"text/latex", a::GenericAffExpr) =

--- a/src/print.jl
+++ b/src/print.jl
@@ -130,7 +130,17 @@ function var_str(::Type{IJuliaMode}, v::AbstractVariableRef; mathmode=true)
         return math("noname", mathmode)
     end
 end
-
+# We want arrays of variables to be printed with `JuMP.VariableRef` as eltype
+# instead of `JuMP.VariableRef{...}`.
+# For show/print, we just need the following method
+Base.print_without_params(::Type{<:JuMP.VariableRef}) = true
+# For display, we need to redefine summary
+Base.summary(a::AbstractArray{<:JuMP.VariableRef}) = _summary(a, Compat.axes(a))
+# Taken from Base.show but we replace typeof(a) by vrefarraytype(a)
+_summary(a, inds::Tuple{Vararg{Base.OneTo}}) = string(Base.dims2string(length.(inds)), " ", vrefarraytype(a))
+_summary(a, inds) = string(vrefarraytype(a), " with indices ", Base.inds2string(inds))
+# Array type shown for array of JuMP.VariableRef
+vrefarraytype(::AbstractArray{<:JuMP.VariableRef, N}) where N = string("AbstractArray{JuMP.VariableRef,", N, "}")
 
 Base.show(io::IO, a::GenericAffExpr) = print(io, aff_str(REPLMode,a))
 Base.show(io::IO, ::MIME"text/latex", a::GenericAffExpr) =

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -251,7 +251,7 @@ function constraints_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType
 end
 
 @testset "Constraints for JuMP.Model" begin
-    constraints_test(Model, VariableRef, ConstraintRef{Model})
+    constraints_test(Model, VariableRef{Model{JuMP.NonDirectBackendType}}, ConstraintRef{Model{JuMP.NonDirectBackendType}})
 end
 
 @testset "Constraints for JuMPExtension.MyModel" begin

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -224,7 +224,7 @@ function expressions_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType
 end
 
 @testset "Expressions for JuMP.Model" begin
-    expressions_test(Model, VariableRef)
+    expressions_test(Model, VariableRef{Model{JuMP.NonDirectBackendType}})
 end
 
 @testset "Expressions for JuMPExtension.MyModel" begin

--- a/test/generate_and_solve.jl
+++ b/test/generate_and_solve.jl
@@ -76,7 +76,13 @@
     @testset "LP (Direct mode)" begin
         mocksolver = MOIU.MockOptimizer(JuMP.JuMPMOIModel{Float64}(), evalobjective=false)
 
-        m = Model(mode = JuMP.Direct, backend = mocksolver)
+        m = Model(mocksolver)
+        @test m isa Model{typeof(mocksolver)}
+        # Direct mode so these functions are not supported
+        @test_throws AssertionError MOIU.dropoptimizer!(m)
+        @test_throws AssertionError MOIU.resetoptimizer!(m, mocksolver)
+        @test_throws AssertionError MOIU.attachoptimizer!(m)
+        @test_throws AssertionError MOIU.resetoptimizer!(m)
         @variable(m, x <= 2.0)
         @variable(m, y >= 0.0)
         @objective(m, Min, -x)

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -125,10 +125,7 @@ function macros_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::Typ
         @test JuMP.isequal_canonical(@expression(m, 3x - y - 3.3(w + 2z) + 5), 3*x - y - 3.3*w - 6.6*z + 5)
         @test JuMP.isequal_canonical(@expression(m, quad, (w+3)*(2x+1)+10), 2*w*x + 6*x + w + 13)
 
-        cref = @constraint(m, 3 + 5*7 <= 0)
-        c = JuMP.constraintobject(cref, AffExpr, MOI.LessThan)
-        @test JuMP.isequal_canonical(c.func, zero(AffExpr))
-        @test c.set == MOI.LessThan(-38.0)
+        @test_throws ErrorException @constraint(m, 3 + 5*7 <= 0)
     end
 
     @testset "Helpful error for variable declaration with misplaced constant" begin

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -136,7 +136,7 @@ function macros_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::Typ
 end
 
 @testset "Macros for JuMP.Model" begin
-    macros_test(Model, VariableRef)
+    macros_test(Model, VariableRef{Model{JuMP.NonDirectBackendType}})
 end
 
 @testset "Macros for JuMPExtension.MyModel" begin

--- a/test/objective.jl
+++ b/test/objective.jl
@@ -41,7 +41,7 @@ end
 
 
 @testset "Objectives for JuMP.Model" begin
-    objectives_test(Model, VariableRef)
+    objectives_test(Model, VariableRef{Model{JuMP.NonDirectBackendType}})
 end
 
 @testset "Objectives for JuMPExtension.MyModel" begin

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -659,7 +659,7 @@ function operators_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::
 end
 
 @testset "Operators for JuMP.Model" begin
-    operators_test(Model, VariableRef)
+    operators_test(Model, VariableRef{Model{JuMP.NonDirectBackendType}})
 end
 
 @testset "Operators for JuMPExtension.MyModel" begin

--- a/test/perf/backend_overhead.jl
+++ b/test/perf/backend_overhead.jl
@@ -1,0 +1,25 @@
+# This benchmarks measures the overhead in accessing `moibackend`.
+# See https://github.com/JuliaOpt/JuMP.jl/pull/1348
+
+using BenchmarkTools
+using MathOptInterface
+const MOI = MathOptInterface
+const MOIU = MOI.Utilities
+using JuMP
+
+function modif(m::Model, cref)
+    MOI.modifyconstraint!(m.moibackend, cref.index, MOI.EqualTo(0.0))
+end
+
+function bench(m::Model, cref)
+    @btime JuMP.num_variables($m)
+    @btime modif($m, $cref)
+end
+
+optimizer = MOIU.MockOptimizer(JuMP.JuMPMOIModel{Float64}())
+#m = Model(backend=optimizer, mode=JuMP.Direct) # syntax before #1348
+m = Model(optimizer) # syntax after #1348
+@variable m x
+@variable m y
+cref = @constraint m x + y == 1
+bench(m, cref)

--- a/test/print.jl
+++ b/test/print.jl
@@ -116,10 +116,10 @@ end
 
         v = [x,y,x]
         A = [x y; y x]
-        io_test(REPLMode,   v, "JuMP.VariableRef{JuMP.Model{MathOptInterface.Utilities.CachingOptimizer{Union{MathOptInterface.AbstractOptimizer, Void},MathOptInterface.Utilities.UniversalFallback{JuMP.JuMPMOIModel{Float64}}}}}[x, y, x]")
+        io_test(REPLMode,   v, "JuMP.VariableRef{JuMP.Model{MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.Utilities.UniversalFallback{JuMP.JuMPMOIModel{Float64}}}}}[x, y, x]")
         #io_test(IJuliaMode, v, "JuMP.VariableRef[x, y, x]")
 
-        io_test(REPLMode,   A, "JuMP.VariableRef{JuMP.Model{MathOptInterface.Utilities.CachingOptimizer{Union{MathOptInterface.AbstractOptimizer, Void},MathOptInterface.Utilities.UniversalFallback{JuMP.JuMPMOIModel{Float64}}}}}[x y; y x]")
+        io_test(REPLMode,   A, "JuMP.VariableRef{JuMP.Model{MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.Utilities.UniversalFallback{JuMP.JuMPMOIModel{Float64}}}}}[x y; y x]")
         #io_test(IJuliaMode, A, "JuMP.VariableRef[x y; y x]")
     end
 

--- a/test/print.jl
+++ b/test/print.jl
@@ -116,10 +116,10 @@ end
 
         v = [x,y,x]
         A = [x y; y x]
-        io_test(REPLMode,   v, "JuMP.VariableRef[x, y, x]")
+        io_test(REPLMode,   v, "JuMP.VariableRef{JuMP.Model{MathOptInterface.Utilities.CachingOptimizer{Union{MathOptInterface.AbstractOptimizer, Void},MathOptInterface.Utilities.UniversalFallback{JuMP.JuMPMOIModel{Float64}}}}}[x, y, x]")
         #io_test(IJuliaMode, v, "JuMP.VariableRef[x, y, x]")
 
-        io_test(REPLMode,   A, "JuMP.VariableRef[x y; y x]")
+        io_test(REPLMode,   A, "JuMP.VariableRef{JuMP.Model{MathOptInterface.Utilities.CachingOptimizer{Union{MathOptInterface.AbstractOptimizer, Void},MathOptInterface.Utilities.UniversalFallback{JuMP.JuMPMOIModel{Float64}}}}}[x y; y x]")
         #io_test(IJuliaMode, A, "JuMP.VariableRef[x y; y x]")
     end
 

--- a/test/print.jl
+++ b/test/print.jl
@@ -116,11 +116,11 @@ end
 
         v = [x,y,x]
         A = [x y; y x]
-        io_test(REPLMode,   v, "JuMP.VariableRef{JuMP.Model{MathOptInterface.Utilities.CachingOptimizer{Union{MathOptInterface.AbstractOptimizer, Void},MathOptInterface.Utilities.UniversalFallback{JuMP.JuMPMOIModel{Float64}}}}}[x, y, x]")
-        #io_test(IJuliaMode, v, "JuMP.VariableRef[x, y, x]")
+        io_test(REPLMode,   v, "JuMP.VariableRef[x, y, x]")
+        #io_test(IJuliaMode, v, "3-element AbstractArray{JuMP.VariableRef,1}:\n x\n y\n x")
 
-        io_test(REPLMode,   A, "JuMP.VariableRef{JuMP.Model{MathOptInterface.Utilities.CachingOptimizer{Union{MathOptInterface.AbstractOptimizer, Void},MathOptInterface.Utilities.UniversalFallback{JuMP.JuMPMOIModel{Float64}}}}}[x y; y x]")
-        #io_test(IJuliaMode, A, "JuMP.VariableRef[x y; y x]")
+        io_test(REPLMode,   A, "JuMP.VariableRef[x y; y x]")
+        #io_test(IJuliaMode, A, "2×2 AbstractArray{JuMP.VariableRef,2}:\n z  y\n y  z")
     end
 
     @testset "basename keyword argument" begin

--- a/test/print.jl
+++ b/test/print.jl
@@ -116,11 +116,11 @@ end
 
         v = [x,y,x]
         A = [x y; y x]
-        io_test(REPLMode,   v, "JuMP.VariableRef[x, y, x]")
-        #io_test(IJuliaMode, v, "3-element AbstractArray{JuMP.VariableRef,1}:\n x\n y\n x")
+        io_test(REPLMode,   v, "JuMP.VariableRef{JuMP.Model{MathOptInterface.Utilities.CachingOptimizer{Union{MathOptInterface.AbstractOptimizer, Void},MathOptInterface.Utilities.UniversalFallback{JuMP.JuMPMOIModel{Float64}}}}}[x, y, x]")
+        #io_test(IJuliaMode, v, "JuMP.VariableRef[x, y, x]")
 
-        io_test(REPLMode,   A, "JuMP.VariableRef[x y; y x]")
-        #io_test(IJuliaMode, A, "2×2 AbstractArray{JuMP.VariableRef,2}:\n z  y\n y  z")
+        io_test(REPLMode,   A, "JuMP.VariableRef{JuMP.Model{MathOptInterface.Utilities.CachingOptimizer{Union{MathOptInterface.AbstractOptimizer, Void},MathOptInterface.Utilities.UniversalFallback{JuMP.JuMPMOIModel{Float64}}}}}[x y; y x]")
+        #io_test(IJuliaMode, A, "JuMP.VariableRef[x y; y x]")
     end
 
     @testset "basename keyword argument" begin

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -372,7 +372,7 @@ end
 end
 
 @testset "Variables for JuMP.Model" begin
-    variables_test(Model, VariableRef)
+    variables_test(Model, VariableRef{Model{JuMP.NonDirectBackendType}})
 end
 
 @testset "Variables for JuMPExtension.MyModel" begin


### PR DESCRIPTION
The optimizer type allows zero overhead on the JuMP side.
The variable type therefore now need to be parametrized on the model type so that its field are concretely typed which induces many changes of this PR.

### Benchmarking results
This use the benchmarking file in `test/perf/backend_overhead.jl`.
Before this change:
```
v0.6
14.526 ns (0 allocations: 0 bytes)
43.865 ns (5 allocations: 96 bytes)
v0.7
19.497 ns (0 allocations: 0 bytes)
35.113 ns (3 allocations: 64 bytes)
```
After this change:
```
v0.6
1.832 ns (0 allocations: 0 bytes)
24.567 ns (3 allocations: 64 bytes)
v0.7
1.824 ns (0 allocations: 0 bytes)
11.284 ns (1 allocation: 32 bytes)
```

Related to https://github.com/JuliaOpt/MathOptInterface.jl/issues/321