### PR TITLE
Add speed notebook

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,1 @@
+.ipynb_checkpoints

--- a/test/perf/speed.ipynb
+++ b/test/perf/speed.ipynb
@@ -1,0 +1,272 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using Random\n",
+    "using JuMP\n",
+    "using TimerOutputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "p_median (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "function p_median(to, num_facilities, num_customers, num_locations)\n",
+    "    @timeit to \"constants\" begin\n",
+    "        Random.seed!(10)\n",
+    "        customer_locations = [rand(1:num_locations) for _ in 1:num_customers]\n",
+    "    end\n",
+    "\n",
+    "    @timeit to \"model\" begin\n",
+    "        model = Model()\n",
+    "    end\n",
+    "    @timeit to \"variable\" begin\n",
+    "        @timeit to \"facility\" begin\n",
+    "            has_facility = @variable(model, [1:num_locations], Bin)\n",
+    "        end\n",
+    "        @timeit to \"closest\" begin\n",
+    "            is_closest = @variable(model, [1:num_locations, 1:num_customers], Bin)\n",
+    "        end\n",
+    "    end\n",
+    "\n",
+    "    @timeit to \"objective\" begin\n",
+    "        @objective(model, Min,\n",
+    "        sum(abs(customer_locations[customer] - location)\n",
+    "            * is_closest[location, customer]\n",
+    "            for customer in 1:num_customers, location in 1:num_locations))\n",
+    "    end\n",
+    "\n",
+    "    @timeit to \"constraint\" begin\n",
+    "        @timeit to \"customer loop\" begin\n",
+    "            for customer in 1:num_customers\n",
+    "                @timeit to \"facility\" begin\n",
+    "                    # `location` can't be closest for `customer` if there is no facility.\n",
+    "                    @constraint(model,\n",
+    "                        [location in 1:num_locations],\n",
+    "                        is_closest[location, customer] <= has_facility[location])\n",
+    "                end\n",
+    "                @timeit to \"closest\" begin\n",
+    "                    # One facility must be the closest for `customer`.\n",
+    "                    @constraint(model,\n",
+    "                        sum(is_closest[location, customer]\n",
+    "                            for location in 1:num_locations) == 1)\n",
+    "                end\n",
+    "            end\n",
+    "        end\n",
+    "\n",
+    "        @timeit to \"sum facility\" begin\n",
+    "            # Must place all facilities.\n",
+    "            @constraint(model, sum(has_facility) == num_facilities)\n",
+    "        end\n",
+    "    end\n",
+    "    \n",
+    "    return\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       " \u001b[1m────────────────────────────────────────────────────────────────────────────\u001b[22m\n",
+       " \u001b[1m                            \u001b[22m        Time                   Allocations      \n",
+       "                             ──────────────────────   ───────────────────────\n",
+       "      Tot / % measured:           2.22s / 99.5%           1.01GiB / 100%     \n",
+       "\n",
+       " Section             ncalls     time   %tot     avg     alloc   %tot      avg\n",
+       " ────────────────────────────────────────────────────────────────────────────\n",
+       " P median                 1    2.21s   100%   2.21s   1.01GiB  100%   1.01GiB\n",
+       "   constraint             1    1.61s  73.0%   1.61s    898MiB  86.8%   898MiB\n",
+       "     customer loop        1    1.61s  72.9%   1.61s    897MiB  86.7%   897MiB\n",
+       "       facility         100    1.44s  65.4%  14.4ms    848MiB  82.0%  8.48MiB\n",
+       "       closest          100    166ms  7.53%  1.66ms   48.9MiB  4.73%   501KiB\n",
+       "     sum facility         1    658μs  0.03%   658μs    870KiB  0.08%   870KiB\n",
+       "   variable               1    402ms  18.2%   402ms    104MiB  10.1%   104MiB\n",
+       "     closest              1    401ms  18.2%   401ms    103MiB  9.93%   103MiB\n",
+       "     facility             1   1.12ms  0.05%  1.12ms   1.34MiB  0.13%  1.34MiB\n",
+       "   objective              1    194ms  8.81%   194ms   32.6MiB  3.15%  32.6MiB\n",
+       "   model                  1   25.8μs  0.00%  25.8μs   22.3KiB  0.00%  22.3KiB\n",
+       "   constants              1   20.8μs  0.00%  20.8μs   0.98KiB  0.00%  0.98KiB\n",
+       " \u001b[1m────────────────────────────────────────────────────────────────────────────\u001b[22m"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "to = TimerOutput()\n",
+    "@timeit to \"P median\" begin\n",
+    "    p_median(to, 100, 100, 5000);\n",
+    "end\n",
+    "to"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "cont5 (generic function with 2 methods)"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "function cont5(to, n)\n",
+    "    @timeit to \"constants\" begin\n",
+    "        m = n\n",
+    "        n1 = n-1\n",
+    "        m1 = m-1\n",
+    "        dx = 1/n\n",
+    "        T = 1.58\n",
+    "        dt = T/m\n",
+    "        h2 = dx^2\n",
+    "        a = 0.001\n",
+    "        yt = [0.5*(1 - (j*dx)^2) for j in 0:n]\n",
+    "    end\n",
+    "\n",
+    "    @timeit to \"model\" begin\n",
+    "        model = Model()\n",
+    "    end\n",
+    "    @timeit to \"variable\" begin\n",
+    "        @timeit to \"y\" begin\n",
+    "            y = @variable(model, [0:m,0:n], lower_bound=0, upper_bound=1)\n",
+    "        end\n",
+    "        @timeit to \"u\" begin\n",
+    "            u = @variable(model, [1:m], lower_bound=-1, upper_bound=1)\n",
+    "        end\n",
+    "    end\n",
+    "\n",
+    "    @timeit to \"objective\" begin\n",
+    "        @objective(model, Min, y[0,0])\n",
+    "    end\n",
+    "\n",
+    "    @timeit to \"constraint\" begin\n",
+    "        @timeit to \"PDE\" begin\n",
+    "            for i in 0:m1\n",
+    "                for j in 1:n1\n",
+    "                    @constraint(model,\n",
+    "                        h2*(y[i+1,j] - y[i,j])\n",
+    "                        == 0.5*dt*(y[i,j-1] - 2*y[i,j] +\n",
+    "                            y[i,j+1] + y[i+1,j-1] - 2*y[i+1,j] + y[i+1,j+1]) )\n",
+    "                end\n",
+    "            end\n",
+    "        end\n",
+    "\n",
+    "        @timeit to \"Initial conditions\" begin\n",
+    "            for j in 0:n\n",
+    "                @constraint(model, y[0,j] == 0)\n",
+    "            end\n",
+    "        end\n",
+    "\n",
+    "        @timeit to \"Boundary conditions\" begin\n",
+    "            for i in 1:m\n",
+    "                @constraint(model,\n",
+    "                    y[i,2]   - 4*y[i,1]  + 3*y[i,0] == 0)\n",
+    "                @constraint(model,\n",
+    "                    y[i,n-2] - 4*y[i,n1] + 3*y[i,n]== (2*dx)*(u[i] - y[i,n]))\n",
+    "            end\n",
+    "        end\n",
+    "    end\n",
+    "    \n",
+    "    return\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       " \u001b[1m──────────────────────────────────────────────────────────────────────────────\u001b[22m\n",
+       " \u001b[1m                              \u001b[22m        Time                   Allocations      \n",
+       "                               ──────────────────────   ───────────────────────\n",
+       "       Tot / % measured:            1.18s / 98.7%            452MiB / 100%     \n",
+       "\n",
+       " Section               ncalls     time   %tot     avg     alloc   %tot      avg\n",
+       " ──────────────────────────────────────────────────────────────────────────────\n",
+       " cont5                      1    1.17s   100%   1.17s    452MiB  100%    452MiB\n",
+       "   constraint               1    923ms  79.1%   923ms    360MiB  79.6%   360MiB\n",
+       "     PDE                    1    921ms  78.9%   921ms    357MiB  79.0%   357MiB\n",
+       "     Boundary condi...      1   1.88ms  0.16%  1.88ms   2.04MiB  0.45%  2.04MiB\n",
+       "     Initial condit...      1    459μs  0.04%   459μs    540KiB  0.12%   540KiB\n",
+       "   variable                 1    244ms  20.9%   244ms   92.3MiB  20.4%  92.3MiB\n",
+       "     y                      1    244ms  20.9%   244ms   92.3MiB  20.4%  92.3MiB\n",
+       "     u                      1    284μs  0.02%   284μs   74.4KiB  0.02%  74.4KiB\n",
+       "   constants                1   54.9μs  0.00%  54.9μs   35.5KiB  0.01%  35.5KiB\n",
+       "   model                    1   25.2μs  0.00%  25.2μs   22.3KiB  0.00%  22.3KiB\n",
+       "   objective                1   3.07μs  0.00%  3.07μs         -  0.00%        -\n",
+       " \u001b[1m──────────────────────────────────────────────────────────────────────────────\u001b[22m"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "to = TimerOutput()\n",
+    "@timeit to \"cont5\" begin\n",
+    "    cont5(to, 500);\n",
+    "end\n",
+    "to"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 1.0.3-pre",
+   "language": "julia",
+   "name": "julia-1.0"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.0.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
It helps to see where time is spent and allocations are done thanks to TimerOutputs to help resolve the regressions at https://github.com/JuliaOpt/JuMP.jl/issues/1403.
For P-median:
With Julia v1.0.2 and JuMP and MOI master:
```
────────────────────────────────────────────────────────────────────────────
                                     Time                   Allocations      
                             ──────────────────────   ───────────────────────
      Tot / % measured:           2.22s / 99.5%           1.01GiB / 100%     

 Section             ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────
 P median                 1    2.21s   100%   2.21s   1.01GiB  100%   1.01GiB
   constraint             1    1.61s  73.0%   1.61s    898MiB  86.8%   898MiB
     customer loop        1    1.61s  72.9%   1.61s    897MiB  86.7%   897MiB
       facility         100    1.44s  65.4%  14.4ms    848MiB  82.0%  8.48MiB
       closest          100    166ms  7.53%  1.66ms   48.9MiB  4.73%   501KiB
     sum facility         1    658μs  0.03%   658μs    870KiB  0.08%   870KiB
   variable               1    402ms  18.2%   402ms    104MiB  10.1%   104MiB
     closest              1    401ms  18.2%   401ms    103MiB  9.93%   103MiB
     facility             1   1.12ms  0.05%  1.12ms   1.34MiB  0.13%  1.34MiB
   objective              1    194ms  8.81%   194ms   32.6MiB  3.15%  32.6MiB
   model                  1   25.8μs  0.00%  25.8μs   22.3KiB  0.00%  22.3KiB
   constants              1   20.8μs  0.00%  20.8μs   0.98KiB  0.00%  0.98KiB
 ────────────────────────────────────────────────────────────────────────────
```
With JuMP v0.18
```
 ────────────────────────────────────────────────────────────────────────────
                                     Time                   Allocations      
                             ──────────────────────   ───────────────────────
      Tot / % measured:           686ms / 73.7%            269MiB / 100%     

 Section             ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────
 P median                 1    506ms   100%   506ms    269MiB  100%    269MiB
   constraint             1    432ms  85.4%   432ms    210MiB  77.9%   210MiB
     customer loop        1    432ms  85.4%   432ms    209MiB  77.9%   209MiB
       facility         100    328ms  64.9%  3.28ms    184MiB  68.5%  1.84MiB
       closest          100    104ms  20.5%  1.04ms   25.1MiB  9.35%   257KiB
     sum facility         1   40.6μs  0.01%  40.6μs    118KiB  0.04%   118KiB
   variable               1   60.4ms  11.9%  60.4ms   49.3MiB  18.4%  49.3MiB
     closest              1   60.0ms  11.9%  60.0ms   48.4MiB  18.0%  48.4MiB
     facility             1    344μs  0.07%   344μs   0.98MiB  0.37%  0.98MiB
   objective              1   13.5ms  2.66%  13.5ms   10.0MiB  3.72%  10.0MiB
   constants              1   20.4μs  0.00%  20.4μs   0.98KiB  0.00%  0.98KiB
   model                  1   7.79μs  0.00%  7.79μs   4.37KiB  0.00%  4.37KiB
 ────────────────────────────────────────────────────────────────────────────
```
For `cont5`:
With Julia v1.0.2 and JuMP and MOI master:
```
──────────────────────────────────────────────────────────────────────────────
                                       Time                   Allocations      
                               ──────────────────────   ───────────────────────
       Tot / % measured:            1.18s / 98.7%            452MiB / 100%     

 Section               ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────────────────
 cont5                      1    1.17s   100%   1.17s    452MiB  100%    452MiB
   constraint               1    923ms  79.1%   923ms    360MiB  79.6%   360MiB
     PDE                    1    921ms  78.9%   921ms    357MiB  79.0%   357MiB
     Boundary condi...      1   1.88ms  0.16%  1.88ms   2.04MiB  0.45%  2.04MiB
     Initial condit...      1    459μs  0.04%   459μs    540KiB  0.12%   540KiB
   variable                 1    244ms  20.9%   244ms   92.3MiB  20.4%  92.3MiB
     y                      1    244ms  20.9%   244ms   92.3MiB  20.4%  92.3MiB
     u                      1    284μs  0.02%   284μs   74.4KiB  0.02%  74.4KiB
   constants                1   54.9μs  0.00%  54.9μs   35.5KiB  0.01%  35.5KiB
   model                    1   25.2μs  0.00%  25.2μs   22.3KiB  0.00%  22.3KiB
   objective                1   3.07μs  0.00%  3.07μs         -  0.00%        -
 ──────────────────────────────────────────────────────────────────────────────
```
With JuMP v0.18 (replacing `lower_bound` by `lowerbound` and `upper_bound` by `upperbound`)
```
──────────────────────────────────────────────────────────────────────────────
                                       Time                   Allocations      
                               ──────────────────────   ───────────────────────
       Tot / % measured:            648ms / 71.2%            180MiB / 100%     

 Section               ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────────────────
 cont5                      1    461ms   100%   461ms    180MiB  100%    180MiB
   constraint               1    414ms  89.8%   414ms    152MiB  84.6%   152MiB
     PDE                    1    413ms  89.7%   413ms    151MiB  84.2%   151MiB
     Boundary condi...      1    598μs  0.13%   598μs    602KiB  0.33%   602KiB
     Initial condit...      1    174μs  0.04%   174μs    180KiB  0.10%   180KiB
   variable                 1   46.8ms  10.1%  46.8ms   27.6MiB  15.4%  27.6MiB
     y                      1   46.7ms  10.1%  46.7ms   27.6MiB  15.3%  27.6MiB
     u                      1   33.9μs  0.01%  33.9μs   23.9KiB  0.01%  23.9KiB
   constants                1   70.9μs  0.02%  70.9μs   35.5KiB  0.02%  35.5KiB
   model                    1   7.97μs  0.00%  7.97μs   4.37KiB  0.00%  4.37KiB
   objective                1   5.03μs  0.00%  5.03μs         -  0.00%        -
 ──────────────────────────────────────────────────────────────────────────────
```

[ci skip]