### PR TITLE
Pukeko-ize tests

### DIFF
--- a/test/expr.jl
+++ b/test/expr.jl
@@ -1,3 +1,183 @@
+#  Copyright 2017, Iain Dunning, Joey Huchette, Miles Lubin, and contributors
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#############################################################################
+# JuMP
+# An algebraic modeling language for Julia
+# See http://github.com/JuliaOpt/JuMP.jl
+#############################################################################
+# test/expr.jl
+#############################################################################
+
+module ExpressionTests
+
+using JuMP
+using Pukeko
+import Test: @inferred
+
+include("utilities.jl")
+include("JuMPExtension.jl")
+const BOTH_VAR = [VariableRef, JuMPExtension.MyVariableRef]
+
+function test_isequal_hash_affexpr()
+    m = Model()
+    @variable(m, x)
+    @test isequal(x + 1, x + 1)
+    @test hash(x + 1) == hash(x + 1)
+end
+
+function test_isequal_hash_quadexpr()
+    m = Model()
+    @variable(m, x)
+    @test isequal(x^2 + 1, x^2 + 1)
+    @test hash(x^2 + 1) == hash(x^2 + 1)
+end
+
+function test_value_affexpr()
+    expr1 = JuMP.GenericAffExpr(3.0, 3 => -5.0, 2 => 4.0)
+    @test @inferred(JuMP.value(expr1, -)) == 10.0
+    expr2 = JuMP.GenericAffExpr{Int,Int}(2)
+    @test typeof(@inferred(JuMP.value(expr2, i -> 1.0))) == Float64
+    @test @inferred(JuMP.value(expr2, i -> 1.0)) == 2.0
+end
+
+function test_value_quadexpr()
+    # 1 + 2x(1) + 3x(2)
+    affine_term = JuMP.GenericAffExpr(1.0, 1 => 2.0, 2 => 3.0)
+    # 1 + 2x(1) + 3x(2) + 4x(1)^2 + 5x(1)*x(2) + 6x(2)^2
+    expr = JuMP.GenericQuadExpr(affine_term,
+        JuMP.UnorderedPair(1, 1) => 4.0,
+        JuMP.UnorderedPair(1, 2) => 5.0,
+        JuMP.UnorderedPair(2, 2) => 6.0)
+    @test typeof(@inferred(JuMP.value(expr, i -> 1.0))) == Float64
+    @test @inferred(JuMP.value(expr, i -> 1.0)) == 21
+    @test @inferred(JuMP.value(expr, i -> 2.0)) == 71
+end
+
+function test_add_to_expr_by_var()
+    # add_to_expression!(::GenericAffExpr{C,V}, ::V)
+    aff = JuMP.GenericAffExpr(1.0, :a => 2.0)
+    @test JuMP.isequal_canonical(JuMP.add_to_expression!(aff, :b),
+                                    JuMP.GenericAffExpr(1.0, :a => 2.0, :b => 1.0))
+end
+
+function test_add_to_expr_coef()
+    # add_to_expression!(::GenericAffExpr{C,V}, ::C)
+    aff = JuMP.GenericAffExpr(1.0, :a => 2.0)
+    @test JuMP.isequal_canonical(JuMP.add_to_expression!(aff, 1.0),
+                                    JuMP.GenericAffExpr(2.0, :a => 2.0))
+end
+
+function test_linear_terms_affexpr()
+    m = Model()
+    @variable(m, x[1:10])
+    aff = 1*x[1] + 2*x[2]
+    k = 0
+    @test length(linear_terms(aff)) == 2
+    for (coeff, var) in linear_terms(aff)
+        if k == 0
+            @test coeff == 1
+            @test var === x[1]
+        elseif k == 1
+            @test coeff == 2
+            @test var === x[2]
+        end
+        k += 1
+    end
+    @test k == 2
+end
+
+function linear_terms_affexpr_empty(VariableRefType)
+    AffExprType = JuMP.GenericAffExpr{Float64, VariableRefType}
+    k = 0
+    aff = zero(AffExprType)
+    @test length(linear_terms(aff)) == 0
+    for (coeff, var) in linear_terms(aff)
+        k += 1
+    end
+    @test k == 0
+end
+@parametric linear_terms_affexpr_empty BOTH_VAR
+
+function test_copy_affexpr_between_models()
+    m = Model()
+    @variable(m, x)
+    m2 = Model()
+    aff = copy(2x + 1, m2)
+    aff_expected = 2*copy(x, m2) + 1
+    @test JuMP.isequal_canonical(aff, aff_expected)
+end
+
+function test_destructive_add_affexpr()
+    # destructive_add!(ex::Number, c::Number, x::GenericAffExpr)
+    aff = JuMP.destructive_add!(1.0, 2.0, JuMP.GenericAffExpr(1.0, :a => 1.0))
+    @test JuMP.isequal_canonical(aff, JuMP.GenericAffExpr(3.0, :a => 2.0))
+end
+
+function destructive_add_quadexpr(VariableRefType)
+    QuadExprType = JuMP.GenericQuadExpr{Float64, VariableRefType}
+    # destructive_add!(ex::Number, c::Number, x::GenericQuadExpr) with c == 0
+    quad = JuMP.destructive_add!(2.0, 0.0, QuadExprType())
+    @test JuMP.isequal_canonical(quad, convert(QuadExprType, 2.0))
+end
+@parametric destructive_add_quadexpr BOTH_VAR
+
+function test_destructive_add_products()
+    m = Model()
+    @variable(m, x)
+    @variable(m, y)
+    # destructive_add!(ex::Number, c::VariableRef, x::VariableRef)
+    @test_expression_with_string JuMP.destructive_add!(5.0, x, y) "x*y + 5"
+    # destructive_add!(ex::Number, c::T, x::T) where T<:GenericAffExpr
+    @test_expression_with_string JuMP.destructive_add!(1.0, 2x, x+1) "2 x² + 2 x + 1"
+    # destructive_add!(ex::Number, c::GenericAffExpr{C,V}, x::V) where {C,V}
+    @test_expression_with_string JuMP.destructive_add!(1.0, 2x, x) "2 x² + 1"
+    # destructive_add!(ex::Number, c::GenericQuadExpr, x::Number)
+    @test_expression_with_string JuMP.destructive_add!(0.0, x^2, 1.0) "x²"
+    # destructive_add!(ex::Number, c::GenericQuadExpr, x::Number) with c == 0
+    @test_expression_with_string JuMP.destructive_add!(0.0, x^2, 0.0) "0"
+    # destructive_add!(aff::AffExpr,c::VariableRef,x::AffExpr)
+    @test_expression_with_string JuMP.destructive_add!(2x, x, x + 1) "x² + 3 x"
+    # destructive_add!(aff::GenericAffExpr{C,V},c::GenericAffExpr{C,V},x::Number) where {C,V}
+    @test_expression_with_string JuMP.destructive_add!(2x, x, 1) "3 x"
+    # destructive_add!(aff::GenericAffExpr{C,V}, c::GenericQuadExpr{C,V}, x::Number) where {C,V}
+    @test_expression_with_string JuMP.destructive_add!(2x, x^2, 1) "x² + 2 x"
+    # destructive_add!(aff::GenericAffExpr{C,V}, c::GenericQuadExpr{C,V}, x::Number) where {C,V} with x == 0
+    @test_expression_with_string JuMP.destructive_add!(2x, x^2, 0) "2 x"
+    # destructive_add!(aff::GenericAffExpr{C,V}, c::Number, x::GenericQuadExpr{C,V}) where {C,V} with c == 0
+    @test_expression_with_string JuMP.destructive_add!(2x, 0, x^2) "2 x"
+    # destructive_add!(ex::GenericAffExpr{C,V}, c::GenericAffExpr{C,V}, x::GenericAffExpr{C,V}) where {C,V}
+    @test_expression_with_string JuMP.destructive_add!(2x, x + 1, x + 0) "x² + 3 x"
+    # destructive_add!(quad::GenericQuadExpr{C,V},c::GenericAffExpr{C,V},x::Number) where {C,V}
+    @test_expression_with_string JuMP.destructive_add!(x^2, x + 1, 1) "x² + x + 1"
+    # destructive_add!(quad::GenericQuadExpr{C,V},c::V,x::GenericAffExpr{C,V}) where {C,V}
+    @test_expression_with_string JuMP.destructive_add!(x^2, x, x+1) "2 x² + x"
+    # destructive_add!(quad::GenericQuadExpr{C,V},c::GenericQuadExpr{C,V},x::Number) where {C,V}
+    @test_expression_with_string JuMP.destructive_add!(x^2 + x, x^2 + x, 2.0) "3 x² + 3 x"
+    # destructive_add!(ex::GenericQuadExpr{C,V}, c::GenericAffExpr{C,V}, x::GenericAffExpr{C,V}) where {C,V}
+    @test_expression_with_string JuMP.destructive_add!(x^2 + x, x + 0, x + 1) "2 x² + 2 x"
+end
+
+function test_singleton_add_affexpr()
+    m = Model()
+    @variable(m, x)
+    @test_expression_with_string (+)(x + 1) "x + 1"
+end
+
+function test_singleton_add_quadexpr()
+    m = Model()
+    @variable(m, x)
+    @test_expression_with_string (+)(x^2 + 1) "x² + 1"
+end
+
+function test_sum_vector_variableref()
+    m = Model()
+    @variable(m, x[1:2])
+    @test_expression_with_string sum(x) "x[1] + x[2]"  # sum(::Vector{VR})
+end
+
+
 # For "expression^3 and unary*"
 struct PowVariable <: JuMP.AbstractVariableRef
     pow::Int
@@ -6,240 +186,17 @@ Base.:^(x::PowVariable, i::Int) = PowVariable(x.pow*i)
 Base.:*(x::PowVariable, y::PowVariable) = PowVariable(x.pow + y.pow)
 Base.copy(x::PowVariable) = x
 
-function expressions_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::Type{<:JuMP.AbstractVariableRef})
-    AffExprType = JuMP.GenericAffExpr{Float64, VariableRefType}
-    QuadExprType = JuMP.GenericQuadExpr{Float64, VariableRefType}
-
-    @testset "isequal(::GenericAffExpr)" begin
-        m = Model()
-        @variable(m, x)
-        @test isequal(x + 1, x + 1)
-    end
-
-    @testset "hash(::GenericAffExpr)" begin
-        m = Model()
-        @variable(m, x)
-        @test hash(x + 1) == hash(x + 1)
-    end
-
-    @testset "isequal(::GenericQuadExpr)" begin
-        m = Model()
-        @variable(m, x)
-        @test isequal(x^2 + 1, x^2 + 1)
-    end
-
-    @testset "hash(::GenericQuadExpr)" begin
-        m = Model()
-        @variable(m, x)
-        @test hash(x^2 + 1) == hash(x^2 + 1)
-    end
-
-    @testset "value for GenericAffExpr" begin
-        expr1 = JuMP.GenericAffExpr(3.0, 3 => -5.0, 2 => 4.0)
-        @test @inferred(JuMP.value(expr1, -)) == 10.0
-        expr2 = JuMP.GenericAffExpr{Int,Int}(2)
-        @test typeof(@inferred(JuMP.value(expr2, i -> 1.0))) == Float64
-        @test @inferred(JuMP.value(expr2, i -> 1.0)) == 2.0
-    end
-
-    @testset "value for GenericQuadExpr" begin
-        # 1 + 2x(1) + 3x(2)
-        affine_term = JuMP.GenericAffExpr(1.0, 1 => 2.0, 2 => 3.0)
-        # 1 + 2x(1) + 3x(2) + 4x(1)^2 + 5x(1)*x(2) + 6x(2)^2
-        expr = JuMP.GenericQuadExpr(affine_term,
-            JuMP.UnorderedPair(1, 1) => 4.0,
-            JuMP.UnorderedPair(1, 2) => 5.0,
-            JuMP.UnorderedPair(2, 2) => 6.0)
-        @test typeof(@inferred(JuMP.value(expr, i -> 1.0))) == Float64
-        @test @inferred(JuMP.value(expr, i -> 1.0)) == 21
-        @test @inferred(JuMP.value(expr, i -> 2.0)) == 71
-    end
-
-    @testset "add_to_expression!(::GenericAffExpr{C,V}, ::V)" begin
-        aff = JuMP.GenericAffExpr(1.0, :a => 2.0)
-        @test JuMP.isequal_canonical(JuMP.add_to_expression!(aff, :b),
-                                     JuMP.GenericAffExpr(1.0, :a => 2.0, :b => 1.0))
-    end
-
-    @testset "add_to_expression!(::GenericAffExpr{C,V}, ::C)" begin
-        aff = JuMP.GenericAffExpr(1.0, :a => 2.0)
-        @test JuMP.isequal_canonical(JuMP.add_to_expression!(aff, 1.0),
-                                     JuMP.GenericAffExpr(2.0, :a => 2.0))
-    end
-
-    @testset "linear_terms(::AffExpr)" begin
-        m = Model()
-        @variable(m, x[1:10])
-
-        aff = 1*x[1] + 2*x[2]
-        k = 0
-        @test length(linear_terms(aff)) == 2
-        for (coeff, var) in linear_terms(aff)
-            if k == 0
-                @test coeff == 1
-                @test var === x[1]
-            elseif k == 1
-                @test coeff == 2
-                @test var === x[2]
-            end
-            k += 1
-        end
-        @test k == 2
-    end
-
-    @testset "linear_terms(::AffExpr) for empty expression" begin
-        k = 0
-        aff = zero(AffExprType)
-        @test length(linear_terms(aff)) == 0
-        for (coeff, var) in linear_terms(aff)
-            k += 1
-        end
-        @test k == 0
-    end
-
-    @testset "Copy AffExpr between models" begin
-        m = Model()
-        @variable(m, x)
-        m2 = Model()
-        aff = copy(2x + 1, m2)
-        aff_expected = 2*copy(x, m2) + 1
-        @test JuMP.isequal_canonical(aff, aff_expected)
-    end
-
-    @testset "destructive_add!(ex::Number, c::Number, x::GenericAffExpr)" begin
-        aff = JuMP.destructive_add!(1.0, 2.0, JuMP.GenericAffExpr(1.0, :a => 1.0))
-        @test JuMP.isequal_canonical(aff, JuMP.GenericAffExpr(3.0, :a => 2.0))
-    end
-
-    @testset "destructive_add!(ex::Number, c::Number, x::GenericQuadExpr) with c == 0" begin
-        quad = JuMP.destructive_add!(2.0, 0.0, QuadExprType())
-        @test JuMP.isequal_canonical(quad, convert(QuadExprType, 2.0))
-    end
-
-    @testset "destructive_add!(ex::Number, c::VariableRef, x::VariableRef)" begin
-        m = Model()
-        @variable(m, x)
-        @variable(m, y)
-        @test_expression_with_string JuMP.destructive_add!(5.0, x, y) "x*y + 5"
-    end
-
-    @testset "destructive_add!(ex::Number, c::T, x::T) where T<:GenericAffExpr" begin
-        m = Model()
-        @variable(m, x)
-        @test_expression_with_string JuMP.destructive_add!(1.0, 2x, x+1) "2 x² + 2 x + 1"
-    end
-
-    @testset "destructive_add!(ex::Number, c::GenericAffExpr{C,V}, x::V) where {C,V}" begin
-        m = Model()
-        @variable(m, x)
-        @test_expression_with_string JuMP.destructive_add!(1.0, 2x, x) "2 x² + 1"
-    end
-
-    @testset "destructive_add!(ex::Number, c::GenericQuadExpr, x::Number)" begin
-        m = Model()
-        @variable(m, x)
-        @test_expression_with_string JuMP.destructive_add!(0.0, x^2, 1.0) "x²"
-    end
-
-    @testset "destructive_add!(ex::Number, c::GenericQuadExpr, x::Number) with c == 0" begin
-        m = Model()
-        @variable(m, x)
-        @test_expression_with_string JuMP.destructive_add!(0.0, x^2, 0.0) "0"
-    end
-
-    @testset "destructive_add!(aff::AffExpr,c::VariableRef,x::AffExpr)" begin
-        m = Model()
-        @variable(m, x)
-        @test_expression_with_string JuMP.destructive_add!(2x, x, x + 1) "x² + 3 x"
-    end
-
-    @testset "destructive_add!(aff::GenericAffExpr{C,V},c::GenericAffExpr{C,V},x::Number) where {C,V}" begin
-        m = Model()
-        @variable(m, x)
-        @test_expression_with_string JuMP.destructive_add!(2x, x, 1) "3 x"
-    end
-
-    @testset "destructive_add!(aff::GenericAffExpr{C,V}, c::GenericQuadExpr{C,V}, x::Number) where {C,V}" begin
-        m = Model()
-        @variable(m, x)
-        @test_expression_with_string JuMP.destructive_add!(2x, x^2, 1) "x² + 2 x"
-    end
-
-    @testset "destructive_add!(aff::GenericAffExpr{C,V}, c::GenericQuadExpr{C,V}, x::Number) where {C,V} with x == 0" begin
-        m = Model()
-        @variable(m, x)
-        @test_expression_with_string JuMP.destructive_add!(2x, x^2, 0) "2 x"
-    end
-
-    @testset "destructive_add!(aff::GenericAffExpr{C,V}, c::Number, x::GenericQuadExpr{C,V}) where {C,V} with c == 0" begin
-        m = Model()
-        @variable(m, x)
-        @test_expression_with_string JuMP.destructive_add!(2x, 0, x^2) "2 x"
-    end
-
-    @testset "destructive_add!(ex::GenericAffExpr{C,V}, c::GenericAffExpr{C,V}, x::GenericAffExpr{C,V}) where {C,V}" begin
-        m = Model()
-        @variable(m, x)
-        @test_expression_with_string JuMP.destructive_add!(2x, x + 1, x + 0) "x² + 3 x"
-    end
-
-    @testset "destructive_add!(quad::GenericQuadExpr{C,V},c::GenericAffExpr{C,V},x::Number) where {C,V}" begin
-        m = Model()
-        @variable(m, x)
-        @test_expression_with_string JuMP.destructive_add!(x^2, x + 1, 1) "x² + x + 1"
-    end
-
-    @testset "destructive_add!(quad::GenericQuadExpr{C,V},c::V,x::GenericAffExpr{C,V}) where {C,V}" begin
-        m = Model()
-        @variable(m, x)
-        @test_expression_with_string JuMP.destructive_add!(x^2, x, x+1) "2 x² + x"
-    end
-
-    @testset "destructive_add!(quad::GenericQuadExpr{C,V},c::GenericQuadExpr{C,V},x::Number) where {C,V}" begin
-        m = Model()
-        @variable(m, x)
-        @test_expression_with_string JuMP.destructive_add!(x^2 + x, x^2 + x, 2.0) "3 x² + 3 x"
-    end
-
-    @testset "destructive_add!(ex::GenericQuadExpr{C,V}, c::GenericAffExpr{C,V}, x::GenericAffExpr{C,V}) where {C,V}" begin
-        m = Model()
-        @variable(m, x)
-        @test_expression_with_string JuMP.destructive_add!(x^2 + x, x + 0, x + 1) "2 x² + 2 x"
-    end
-
-    @testset "(+)(::AffExpr)" begin
-        m = Model()
-        @variable(m, x)
-        @test_expression_with_string (+)(x + 1) "x + 1"
-    end
-
-    @testset "(+)(::QuadExpr)" begin
-        m = Model()
-        @variable(m, x)
-        @test_expression_with_string (+)(x^2 + 1) "x² + 1"
-    end
-
-    @testset "sum(::Vector{VariableRef})" begin
-        m = Model()
-        @variable(m, x[1:2])
-        @test_expression_with_string sum(x) "x[1] + x[2]"
-    end
-
-    @testset "expression^3 and unary*" begin
-        m = Model()
-        x = PowVariable(1)
-        # Calls (*)((x*x)^6)
-        y = @expression m (x*x)^3
-        @test y.pow == 6
-        z = @inferred (x*x)^3
-        @test z.pow == 6
-    end
+function test_expression_cubed_and_unary_mult()
+    m = Model()
+    x = PowVariable(1)
+    # Calls (*)((x*x)^6)
+    y = @expression m (x*x)^3
+    @test y.pow == 6
+    z = @inferred (x*x)^3
+    @test z.pow == 6
 end
 
-@testset "Expressions for JuMP.Model" begin
-    expressions_test(Model, VariableRef)
-end
+end  # module ExpressionTests
 
-@testset "Expressions for JuMPExtension.MyModel" begin
-    expressions_test(JuMPExtension.MyModel, JuMPExtension.MyVariableRef)
-end
+import Pukeko
+Pukeko.run_tests(ExpressionTests)

--- a/test/model.jl
+++ b/test/model.jl
@@ -10,9 +10,11 @@
 # test/model.jl
 #############################################################################
 
+module ModelTests
+
 using JuMP
 
-using Test
+using Pukeko
 
 using MathOptInterface
 const MOI = MathOptInterface
@@ -38,110 +40,107 @@ function opt_build(a::Int; b::Int = 1)
     return Optimizer(a, b)
 end
 
-function test_model()
-    @testset "optimize_hook" begin
-        m = Model()
-        @test m.optimize_hook === nothing
-        called = false
-        function hook(m)
-            called = true
-        end
-        JuMP.set_optimize_hook(m, hook)
-        @test !called
-        optimize!(m)
-        @test called
+function test_optimize_hook()
+    model = Model()
+    @test model.optimize_hook === nothing
+    called = false
+    function hook(model)
+        called = true
     end
-
-    @testset "UniversalFallback" begin
-        m = Model()
-        MOI.set(m, MOIT.UnknownModelAttribute(), 1)
-        @test MOI.get(m, MOIT.UnknownModelAttribute()) == 1
-    end
-
-    @testset "Bridges" begin
-        @testset "Automatic bridging" begin
-            # optimizer not supporting Interval
-            model = Model(with_optimizer(MOIU.MockOptimizer,
-                                         SimpleLPModel{Float64}()))
-            @test JuMP.bridge_constraints(model)
-            @test JuMP.backend(model) isa MOIU.CachingOptimizer
-            @test JuMP.backend(model).optimizer isa MOI.Bridges.LazyBridgeOptimizer
-            @test JuMP.backend(model).optimizer.model isa MOIU.MockOptimizer
-            @variable model x
-            cref = @constraint model 0 <= x + 1 <= 1
-            @test cref isa JuMP.ConstraintRef{JuMP.Model,MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.Interval{Float64}}}
-            JuMP.optimize!(model)
-        end
-        @testset "Automatic bridging with cache for bridged model" begin
-            # optimizer not supporting Interval and not supporting `default_copy_to`
-            model = Model(with_optimizer(MOIU.MockOptimizer,
-                                         SimpleLPModel{Float64}(),
-                                         needs_allocate_load=true))
-            @test JuMP.bridge_constraints(model)
-            @test JuMP.backend(model) isa MOIU.CachingOptimizer
-            @test JuMP.backend(model).optimizer isa MOI.Bridges.LazyBridgeOptimizer
-            @test JuMP.backend(model).optimizer.model isa MOIU.CachingOptimizer
-            @test JuMP.backend(model).optimizer.model.optimizer isa MOIU.MockOptimizer
-            @variable model x
-            cref = @constraint model 0 <= x + 1 <= 1
-            @test cref isa JuMP.ConstraintRef{JuMP.Model,MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.Interval{Float64}}}
-            JuMP.optimize!(model)
-        end
-        @testset "Automatic bridging disabled with `bridge_constraints` keyword" begin
-            model = Model(with_optimizer(MOIU.MockOptimizer,
-                                         SimpleLPModel{Float64}()),
-                          bridge_constraints=false)
-            @test !JuMP.bridge_constraints(model)
-            @test JuMP.backend(model) isa MOIU.CachingOptimizer
-            @test !(JuMP.backend(model).optimizer isa MOI.Bridges.LazyBridgeOptimizer)
-            @variable model x
-            err = ErrorException("Constraints of type MathOptInterface.ScalarAffineFunction{Float64}-in-MathOptInterface.Interval{Float64} are not supported by the solver, try using `bridge_constraints=true` in the `JuMP.Model` constructor if you believe the constraint can be reformulated to constraints supported by the solver.")
-            @test_throws err @constraint model 0 <= x + 1 <= 1
-        end
-        @testset "No bridge automatically added in Direct mode" begin
-            optimizer = MOIU.MockOptimizer(SimpleLPModel{Float64}())
-            model = JuMP.direct_model(optimizer)
-            @test !JuMP.bridge_constraints(model)
-            @variable model x
-            err = ErrorException("Constraints of type MathOptInterface.ScalarAffineFunction{Float64}-in-MathOptInterface.Interval{Float64} are not supported by the solver.")
-            @test_throws err @constraint model 0 <= x + 1 <= 1
-        end
-    end
-
-    @testset "Factories" begin
-        factory = with_optimizer(Optimizer, 1, 2)
-        @test factory.constructor == Optimizer
-        @test factory.args == (1, 2)
-        optimizer = factory()
-        @test optimizer isa Optimizer
-        @test optimizer.a == 1
-        @test optimizer.b == 2
-        @test_throws ErrorException factory = with_optimizer(opt_build, 1, 2)
-        factory = with_optimizer(opt_build, 1, b = 2)
-        @test factory.constructor == opt_build
-        @test factory.args == (1,)
-        optimizer = factory()
-        @test optimizer isa Optimizer
-        @test optimizer.a == 1
-        @test optimizer.b == 2
-    end
-
-    @testset "solver_name" begin
-        @testset "Not attached" begin
-            model = Model()
-            @test JuMP.solver_name(model) == "No optimizer attached."
-        end
-
-        @testset "Mock" begin
-            model = Model(with_optimizer(MOIU.MockOptimizer,
-                                         SimpleLPModel{Float64}()))
-            @test JuMP.solver_name(model) == "Mock"
-        end
-    end
+    JuMP.set_optimize_hook(model, hook)
+    @test !called
+    optimize!(model)
+    @test called
 end
 
-@testset "Model" begin
-    test_model()
+function test_universalfallback()
+    model = Model()
+    MOI.set(model, MOIT.UnknownModelAttribute(), 1)
+    @test MOI.get(model, MOIT.UnknownModelAttribute()) == 1
+end
+
+function test_universalfallback()
+    model = Model()
+    MOI.set(model, MOIT.UnknownModelAttribute(), 1)
+    @test MOI.get(model, MOIT.UnknownModelAttribute()) == 1
+end
+
+function test_automatic_bridging()
+    # optimizer not supporting Interval
+    model = Model(with_optimizer(MOIU.MockOptimizer, SimpleLPModel{Float64}()))
+    @test JuMP.bridge_constraints(model)
+    @test JuMP.backend(model) isa MOIU.CachingOptimizer
+    @test JuMP.backend(model).optimizer isa MOI.Bridges.LazyBridgeOptimizer
+    @test JuMP.backend(model).optimizer.model isa MOIU.MockOptimizer
+    @variable model x
+    cref = @constraint model 0 <= x + 1 <= 1
+    @test cref isa JuMP.ConstraintRef{JuMP.Model,MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.Interval{Float64}}}
+    JuMP.optimize!(model)
+end
+
+function test_automatic_bridging_with_cache()
+    # optimizer not supporting Interval and not supporting `default_copy_to`
+    model = Model(with_optimizer(MOIU.MockOptimizer,
+                                 SimpleLPModel{Float64}(),
+                                 needs_allocate_load=true))
+    @test JuMP.bridge_constraints(model)
+    @test JuMP.backend(model) isa MOIU.CachingOptimizer
+    @test JuMP.backend(model).optimizer isa MOI.Bridges.LazyBridgeOptimizer
+    @test JuMP.backend(model).optimizer.model isa MOIU.CachingOptimizer
+    @test JuMP.backend(model).optimizer.model.optimizer isa MOIU.MockOptimizer
+    @variable model x
+    cref = @constraint model 0 <= x + 1 <= 1
+    @test cref isa JuMP.ConstraintRef{JuMP.Model,MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.Interval{Float64}}}
+    JuMP.optimize!(model)
+end
+
+function test_automatic_bridging_disabled_with_keyword()
+    model = Model(with_optimizer(MOIU.MockOptimizer, SimpleLPModel{Float64}()),
+                  bridge_constraints=false)
+    @test !JuMP.bridge_constraints(model)
+    @test JuMP.backend(model) isa MOIU.CachingOptimizer
+    @test !(JuMP.backend(model).optimizer isa MOI.Bridges.LazyBridgeOptimizer)
+    @variable model x
+    err = ErrorException("Constraints of type MathOptInterface.ScalarAffineFunction{Float64}-in-MathOptInterface.Interval{Float64} are not supported by the solver, try using `bridge_constraints=true` in the `JuMP.Model` constructor if you believe the constraint can be reformulated to constraints supported by the solver.")
+    @test_throws err @constraint model 0 <= x + 1 <= 1
+end
+
+function test_no_automatic_bridge_in_direct_mode()
+    optimizer = MOIU.MockOptimizer(SimpleLPModel{Float64}())
+    model = JuMP.direct_model(optimizer)
+    @test !JuMP.bridge_constraints(model)
+    @variable model x
+    err = ErrorException("Constraints of type MathOptInterface.ScalarAffineFunction{Float64}-in-MathOptInterface.Interval{Float64} are not supported by the solver.")
+    @test_throws err @constraint model 0 <= x + 1 <= 1
+end
+
+function test_factories()
+    factory = with_optimizer(Optimizer, 1, 2)
+    @test factory.constructor == Optimizer
+    @test factory.args == (1, 2)
+    optimizer = factory()
+    @test optimizer isa Optimizer
+    @test optimizer.a == 1
+    @test optimizer.b == 2
+    @test_throws ErrorException factory = with_optimizer(opt_build, 1, 2)
+    factory = with_optimizer(opt_build, 1, b = 2)
+    @test factory.constructor == opt_build
+    @test factory.args == (1,)
+    optimizer = factory()
+    @test optimizer isa Optimizer
+    @test optimizer.a == 1
+    @test optimizer.b == 2
+end
+
+function test_solver_name_not_attached()
+    model = Model()
+    @test JuMP.solver_name(model) == "No optimizer attached."
+end
+
+function test_solver_name_mock()
+    model = Model(with_optimizer(MOIU.MockOptimizer,
+                                    SimpleLPModel{Float64}()))
+    @test JuMP.solver_name(model) == "Mock"
 end
 
 struct DummyExtensionData
@@ -155,62 +154,63 @@ function JuMP.copy_extension_data(data::DummyExtensionData,
 end
 function dummy_optimizer_hook(::JuMP.AbstractModel) end
 
-@testset "Model copy" begin
+function copy_model_by_caching_mode(caching_mode)
     for copy_model in (true, true)
-        @testset "Using $(copy_model ? "JuMP.copy_model" : "Base.copy")" begin
-            for caching_mode in (MOIU.AUTOMATIC, MOIU.MANUAL)
-                @testset "In $caching_mode mode" begin
-                    model = Model(caching_mode = caching_mode)
-                    model.optimize_hook = dummy_optimizer_hook
-                    data = DummyExtensionData(model)
-                    model.ext[:dummy] = data
-                    @variable(model, x ≥ 0, Bin)
-                    @variable(model, y ≤ 1, Int)
-                    @variable(model, z == 0)
-                    @constraint(model, cref, x + y == 1)
+        model = Model(caching_mode = caching_mode)
+        model.optimize_hook = dummy_optimizer_hook
+        data = DummyExtensionData(model)
+        model.ext[:dummy] = data
+        @variable(model, x ≥ 0, Bin)
+        @variable(model, y ≤ 1, Int)
+        @variable(model, z == 0)
+        @constraint(model, cref, x + y == 1)
 
-                    if copy_model
-                        new_model, reference_map = JuMP.copy_model(model)
-                    else
-                        new_model = copy(model)
-                        reference_map = Dict{Union{JuMP.VariableRef,
-                                                   JuMP.ConstraintRef},
-                                             Union{JuMP.VariableRef,
-                                                   JuMP.ConstraintRef}}()
-                        reference_map[x] = new_model[:x]
-                        reference_map[y] = new_model[:y]
-                        reference_map[z] = new_model[:z]
-                        reference_map[cref] = new_model[:cref]
-                    end
-                    @test MOIU.mode(JuMP.backend(new_model)) == caching_mode
-                    @test new_model.optimize_hook === dummy_optimizer_hook
-                    @test new_model.ext[:dummy].model === new_model
-                    x_new = reference_map[x]
-                    @test JuMP.owner_model(x_new) === new_model
-                    @test JuMP.name(x_new) == "x"
-                    y_new = reference_map[y]
-                    @test JuMP.owner_model(y_new) === new_model
-                    @test JuMP.name(y_new) == "y"
-                    z_new = reference_map[z]
-                    @test JuMP.owner_model(z_new) === new_model
-                    @test JuMP.name(z_new) == "z"
-                    if copy_model
-                        @test JuMP.LowerBoundRef(x_new) == reference_map[JuMP.LowerBoundRef(x)]
-                        @test JuMP.BinaryRef(x_new) == reference_map[JuMP.BinaryRef(x)]
-                        @test JuMP.UpperBoundRef(y_new) == reference_map[JuMP.UpperBoundRef(y)]
-                        @test JuMP.IntegerRef(y_new) == reference_map[JuMP.IntegerRef(y)]
-                        @test JuMP.FixRef(z_new) == reference_map[JuMP.FixRef(z)]
-                    end
-                    cref_new = reference_map[cref]
-                    @test cref_new.model === new_model
-                    @test JuMP.name(cref_new) == "cref"
-                end
-            end
+        if copy_model
+            new_model, reference_map = JuMP.copy_model(model)
+        else
+            new_model = copy(model)
+            reference_map = Dict{Union{JuMP.VariableRef,
+                                        JuMP.ConstraintRef},
+                                    Union{JuMP.VariableRef,
+                                        JuMP.ConstraintRef}}()
+            reference_map[x] = new_model[:x]
+            reference_map[y] = new_model[:y]
+            reference_map[z] = new_model[:z]
+            reference_map[cref] = new_model[:cref]
         end
-    end
-    @testset "In Direct mode" begin
-        mock = MOIU.MockOptimizer(JuMP.JuMPMOIModel{Float64}())
-        model = JuMP.direct_model(mock)
-        @test_throws ErrorException JuMP.copy(model)
+        @test MOIU.mode(JuMP.backend(new_model)) == caching_mode
+        @test new_model.optimize_hook === dummy_optimizer_hook
+        @test new_model.ext[:dummy].model === new_model
+        x_new = reference_map[x]
+        @test JuMP.owner_model(x_new) === new_model
+        @test JuMP.name(x_new) == "x"
+        y_new = reference_map[y]
+        @test JuMP.owner_model(y_new) === new_model
+        @test JuMP.name(y_new) == "y"
+        z_new = reference_map[z]
+        @test JuMP.owner_model(z_new) === new_model
+        @test JuMP.name(z_new) == "z"
+        if copy_model
+            @test JuMP.LowerBoundRef(x_new) == reference_map[JuMP.LowerBoundRef(x)]
+            @test JuMP.BinaryRef(x_new) == reference_map[JuMP.BinaryRef(x)]
+            @test JuMP.UpperBoundRef(y_new) == reference_map[JuMP.UpperBoundRef(y)]
+            @test JuMP.IntegerRef(y_new) == reference_map[JuMP.IntegerRef(y)]
+            @test JuMP.FixRef(z_new) == reference_map[JuMP.FixRef(z)]
+        end
+        cref_new = reference_map[cref]
+        @test cref_new.model === new_model
+        @test JuMP.name(cref_new) == "cref"
     end
 end
+@parametric copy_model_by_caching_mode (MOIU.AUTOMATIC, MOIU.MANUAL)
+
+function test_model_copy_direct_mode()
+    mock = MOIU.MockOptimizer(JuMP.JuMPMOIModel{Float64}())
+    model = JuMP.direct_model(mock)
+    @test_throws ErrorException JuMP.copy(model)
+end
+
+end  # module ModelTests
+
+import Pukeko
+Pukeko.run_tests(ModelTests)


### PR DESCRIPTION
Requires master of Pukeko, one commit ahead of 0.2.0, will tag if I find any more glitches.

I did find two strange things:
* expr.jl is, as written, run basically twice but it seems like most of the tests don't use the extensions? I reduced it down to running only things once if possible.
* A `(true, true)` in `test/model.jl` that is probably a mistake?

Going to do more.

Running tests in parallel with

```
#! /bin/bash

PUKEKO_TESTS=$'expr.jl\nmodel.jl\nvariable.jl\n'
echo "$PUKEKO_TESTS" | xargs -P 8 -I % julia --project=. test/%
```
