### PR TITLE
No need for localvar with Julia >= 1.0

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -235,7 +235,7 @@ function getloopedcode(varname, code, condition, idxvars, idxsets, idxpairs, sym
 end
 
 # There is no need for localvar with >=0.7 since the loop variable are always local
-if VERSION < v"0.7"
+if VERSION < v"1.0"
     localvar(x::Symbol) = _localvar(x)
     localvar(x::Expr) = Expr(:block, _localvar(x)...)
     _localvar(x::Symbol) = :(local $(esc(x)))

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -234,7 +234,8 @@ function getloopedcode(varname, code, condition, idxvars, idxsets, idxpairs, sym
     end
 end
 
-# There is no need for localvar with >=0.7 since the loop variable are always local
+# There is no need for localvar with >=1.0 since the loop variable are always local
+# Julia 0.7 just warns about the change in scope, but still has the old behaviour
 if VERSION < v"1.0"
     localvar(x::Symbol) = _localvar(x)
     localvar(x::Expr) = Expr(:block, _localvar(x)...)


### PR DESCRIPTION
As noted in
https://github.com/JuliaOpt/JuMP.jl/pull/1216#issuecomment-379089680
there is no need for localvar anymore.

This change is need for the EMP.jl package, in which I have macros that are calling JuMP macros. Without this fix, the JuMP macros is trying to create a local variable like ```EMP:.##43##``` with Julia >= 0.7, and it fails. With Julia 0.6, the code works fine.

There may be another way to fix this, but removing the function call seems to be the way forward.

This pass all tests. If this change is accepted, I'll do a PR for the master branch ( where localvar is also marked as removable, see https://github.com/JuliaOpt/JuMP.jl/blob/master/src/macros.jl#L192 )