### PR TITLE
Update callbacks.jl

### DIFF
--- a/examples/callbacks.jl
+++ b/examples/callbacks.jl
@@ -28,12 +28,14 @@ function example_lazy_constraint()
         lazy_called = true
         x_val = callback_value(cb_data, x)
         y_val = callback_value(cb_data, y)
-        if y_val - x_val > 1 + 1e-6
-            con = @build_constraint(y - x <= 1)
-            MOI.submit(model, MOI.LazyConstraint(cb_data), con)
-        elseif y_val + x_val > 3 + 1e-6
-            con = @build_constraint(y - x <= 1)
-            MOI.submit(model, MOI.LazyConstraint(cb_data), con)
+        if (isinteger.(x_val) == true) && (isinteger.(y_val) == true) # Add the cut only on integral solutions
+            if y_val - x_val > 1 + 1e-6
+                con = @build_constraint(y - x <= 1)
+                MOI.submit(model, MOI.LazyConstraint(cb_data), con)
+            elseif y_val + x_val > 3 + 1e-6
+                con = @build_constraint(y - x <= 1)
+                MOI.submit(model, MOI.LazyConstraint(cb_data), con)
+            end
         end
     end
     MOI.set(model, MOI.LazyConstraintCallback(), my_callback_function)


### PR DESCRIPTION
Related to #2123 :  A small update on example_lazy_constraint() function to make sure the cuts are added only at integral solutions (see https://www.juliaopt.org/JuMP.jl/dev/callbacks/#Lazy-constraints-1)