### PR TITLE
Defined Base.keys for SparseAxisArrays

### DIFF
--- a/src/Containers/SparseAxisArray.jl
+++ b/src/Containers/SparseAxisArray.jl
@@ -114,6 +114,9 @@ Base.IndexStyle(::Type{<:SparseAxisArray}) = IndexAnyCartesian()
 # eachindex redirect to keys
 Base.keys(::IndexAnyCartesian, d::SparseAxisArray) = keys(d)
 
+# Redirect Base.keys to the underlying dictionary
+Base.keys(d::SparseAxisArray) = keys(d.data)
+
 ################
 # Broadcasting #
 ################

--- a/test/Containers/SparseAxisArray.jl
+++ b/test/Containers/SparseAxisArray.jl
@@ -75,6 +75,9 @@ SparseAxisArray{$Int,1,Tuple{Symbol}} with 2 entries:
             @test 3 * (d2 / 2) == d3
             @test (d2 / 2) * 3 == d3
         end
+        @testset "Keys" begin
+            @test sort([d[k] for k in keys(d)]) == [1, 2]
+        end
     end
     @testset "2-dimensional" begin
         SA = SparseAxisArray
@@ -94,5 +97,8 @@ SparseAxisArray{Float64,2,Tuple{Symbol,Char}} with 2 entries:
         dc = @inferred SA(Dict((:a, 'u') => 1.0, (:b, 'v') => 2.0,
                                (:c, 'w') => 3.0))
         sparse_test(d, 2.5, d2, d3, dsqr, [da, db, dc])
+        @testset "Keys" begin
+            @test sort([d[k] for k in keys(d)]) == [0.5, 2.0]
+        end
     end
 end


### PR DESCRIPTION
As per https://discourse.julialang.org/t/jump-container-functionality-feature-requests/37771, `Base.keys` is defined for `SparseAxisArray`s by returning the keys of the underlying dictionary. This allows for one method to provide the indices to iterate over `Array`s, `DenseAxisArray`s, and `SparseAxisArray`s.

Closes #2117 