### PR TITLE
Add `rewrite_call_expression` through `_rewrite_expr`.

### DIFF
--- a/benchmark/parse_constraints.jl
+++ b/benchmark/parse_constraints.jl
@@ -1,0 +1,32 @@
+using BenchmarkTools
+using JuMP
+
+function model0()
+    eval(quote
+        m = Model()
+        @variable(m, a)
+        @variable(m, b)
+        @variable(m, c)
+        @variable(m, x[1:3])
+        @constraint(m, a + b + c <= 1)
+        @constraint(m, x[1] + x[2] + x[3] <= 1)
+        return m
+    end)
+end
+
+function model1()
+    eval(quote
+        m = Model()
+        @variable(m, x[1:10])
+        @variable(m, y[1:10])
+        @constraint(m, sum(x) <= 1)
+        @constraint(m, sum(x .* y) <= sum(y))
+        return m
+    end)
+end
+
+suite = BenchmarkGroup()
+suite["model0"] = @benchmarkable model0()
+suite["model1"] = @benchmarkable model1()
+# tune!(suite)
+results = run(suite, verbose=true)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -159,25 +159,43 @@ function parse_one_operator_constraint(_error::Function, args...)
     _unknown_constraint_expr(_error)
 end
 
+function rewrite_call_expression(_error::Function, head::Val{F}, args...) where F
+    _error("function $F not implemented.")
+end
+
 _functionize(v::VariableRef) = convert(AffExpr, v)
 _functionize(v::AbstractArray{VariableRef}) = _functionize.(v)
 _functionize(x) = x
 _functionize(::MutableArithmetics.Zero) = 0.0
 function parse_one_operator_constraint(_error::Function, vectorized::Bool, sense::Val, lhs, rhs)
+    parse_code_rhs, build_code_rhs, new_rhs = :(), :(), rhs
+    if isexpr(rhs, :call) && applicable(rewrite_call_expression, Val(rhs.args[1]), rhs.args[2:end]...)
+        parse_code_rhs, build_code_rhs, new_rhs = rewrite_call_expression(_error, Val(rhs.args[1]), rhs.args[2:end]...)
+    end
+
     # Simple comparison - move everything to the LHS.
     #
     # `_functionize` deals with the pathological case where the `lhs` is a `VariableRef`
     # and the `rhs` is a summation with no terms. `_build_call` should be passed a
     # `GenericAffExpr` or a `GenericQuadExpr`, and not a `VariableRef` as would be the case
     # without `_functionize`.
-    if vectorized
-        func = :($lhs .- $rhs)
+    # TODO: bug in MutableArithmetics? The returned code does not find $new_rhs (ERROR: UndefVarError: #642###976 not defined).
+
+    if rhs == new_rhs
+        if vectorized
+            func = :($lhs .- $rhs)
+        else
+            func = :($lhs - $rhs)
+        end
+        variable, parse_code = _MA.rewrite(func)
     else
-        func = :($lhs - $rhs)
+        variable, parse_code = _MA.rewrite(lhs)
+        build_code = _build_call(_error, vectorized, :(_functionize($variable)), set)
+        parse_code = :($parse_code; $variable = _MA.mutable_operate!(-, convert(AffExpr, $variable), $new_rhs))
     end
+
     set = sense_to_set(_error, sense)
-    variable, parse_code = _MA.rewrite(func)
-    return parse_code, _build_call(_error, vectorized, :(_functionize($variable)), set)
+    return :($parse_code_rhs; $parse_code), :($build_code_rhs; $build_code)
 end
 
 function parse_constraint_expr(_error::Function, expr::Expr)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -161,7 +161,7 @@ end
 
 # To be defined if such a function must be rewritten; otherwise,
 # rewrite_call_expression will never be called.
-expression_to_rewrite(head::Val, args...) = true # false
+expression_to_rewrite(head::Val, args...) = false # true
 
 # When `expression_to_rewrite` called with the same arguments save the first one,
 # returns three things:
@@ -169,7 +169,8 @@ expression_to_rewrite(head::Val, args...) = true # false
 # - code for building the required constraints, if needed; otherwise, :().
 # - the symbol of the variable that replaces the expression (<: VariableRef).
 function rewrite_call_expression(_error::Function, head::Val{F}, args...) where F
-    return :(), :(), Expr(:call, [F, args...])
+    _error("function $F not implemented.")
+    # return :(), :(), Expr(:call, [F, args...])
 end
 
 _functionize(v::VariableRef) = convert(AffExpr, v)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -179,9 +179,9 @@ function parse_one_operator_constraint(_error::Function, vectorized::Bool, sense
     # and the `rhs` is a summation with no terms. `_build_call` should be passed a
     # `GenericAffExpr` or a `GenericQuadExpr`, and not a `VariableRef` as would be the case
     # without `_functionize`.
-    # TODO: bug in MutableArithmetics? The returned code does not find $new_rhs (ERROR: UndefVarError: #642###976 not defined).
 
     if rhs == new_rhs
+    # TODO: bug in MutableArithmetics? The returned code does not find $new_rhs (ERROR: UndefVarError: #642###976 not defined) when only using the first code path.
         if vectorized
             func = :($lhs .- $rhs)
         else
@@ -190,12 +190,12 @@ function parse_one_operator_constraint(_error::Function, vectorized::Bool, sense
         variable, parse_code = _MA.rewrite(func)
     else
         variable, parse_code = _MA.rewrite(lhs)
-        build_code = _build_call(_error, vectorized, :(_functionize($variable)), set)
         parse_code = :($parse_code; $variable = _MA.mutable_operate!(-, convert(AffExpr, $variable), $new_rhs))
     end
 
     set = sense_to_set(_error, sense)
     return :($parse_code_rhs; $parse_code), :($build_code_rhs; $build_code)
+    build_code = _build_call(_error, vectorized, :(_functionize($variable)), set)
 end
 
 function parse_constraint_expr(_error::Function, expr::Expr)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -163,16 +163,14 @@ end
 # - code for parsing (which must be called first), if needed; otherwise, :().
 # - code for building the required constraints, if needed; otherwise, :().
 # - the symbol of the variable that replaces the expression (<: VariableRef).
-_rewrite_expr(_error::Function, ::Val{:call}, ::Val{OP}, args...) where OP = :(), :(), Expr(:call, OP, args...)
+_rewrite_expr(_error::Function, e::Union{Symbol, Number}) = :(), :(), e
 _rewrite_expr(_error::Function, ::Val{HEAD}, args...) where HEAD = :(), :(), Expr(HEAD, args...)
-_rewrite_expr(_error::Function, e::Symbol) = :(), :(), e
-_rewrite_expr(_error::Function, e::Number) = :(), :(), e
 
 _rewrite_expr(_error::Function, e::Expr) = _rewrite_expr(_error, Val(e.head), e.args...)
 _rewrite_expr(_error::Function, head::Val{:call}, args...) =
     _rewrite_expr(_error, Val(:call), Val(args[1]), args[2:end]...)
 
-function _rewrite_expr(_error::Function, ::Val{:call}, op::Union{Val{:+}, Val{:-}, Val{:*}, Val{:/}}, args...)
+function _rewrite_expr(_error::Function, ::Val{:call}, op::Val, args...) # ::Union{Val{:+}, Val{:-}, Val{:*}, Val{:/}}
     parse_code = :()
     build_code = :()
     new_args = []

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -161,7 +161,7 @@ end
 
 # To be defined if such a function must be rewritten; otherwise,
 # rewrite_call_expression will never be called.
-expression_to_rewrite(head::Val, args...) = false
+expression_to_rewrite(head::Val, args...) = true # false
 
 # When `expression_to_rewrite` called with the same arguments save the first one,
 # returns three things:
@@ -169,7 +169,7 @@ expression_to_rewrite(head::Val, args...) = false
 # - code for building the required constraints, if needed; otherwise, :().
 # - the symbol of the variable that replaces the expression (<: VariableRef).
 function rewrite_call_expression(_error::Function, head::Val{F}, args...) where F
-    _error("function $F not implemented.")
+    return :(), :(), Expr(:call, [F, args...])
 end
 
 _functionize(v::VariableRef) = convert(AffExpr, v)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -159,6 +159,7 @@ function parse_one_operator_constraint(_error::Function, args...)
     _unknown_constraint_expr(_error)
 end
 
+expression_to_rewrite(head::Val{F}, args...) where F = false
 function rewrite_call_expression(_error::Function, head::Val{F}, args...) where F
     _error("function $F not implemented.")
 end
@@ -170,10 +171,10 @@ _functionize(::MutableArithmetics.Zero) = 0.0
 function parse_one_operator_constraint(_error::Function, vectorized::Bool, sense::Val, lhs, rhs)
     parse_code_rhs, build_code_rhs, new_rhs = :(), :(), rhs
     parse_code_lhs, build_code_lhs, new_lhs = :(), :(), lhs
-    if isexpr(rhs, :call) && applicable(rewrite_call_expression, Val(rhs.args[1]), rhs.args[2:end]...)
+    if isexpr(rhs, :call) && expression_to_rewrite(Val(rhs.args[1]), rhs.args[2:end]...)
         parse_code_rhs, build_code_rhs, new_rhs = rewrite_call_expression(_error, Val(rhs.args[1]), rhs.args[2:end]...)
     end
-    if isexpr(lhs, :call) && applicable(rewrite_call_expression, Val(lhs.args[1]), lhs.args[2:end]...)
+    if isexpr(lhs, :call) && expression_to_rewrite(Val(lhs.args[1]), lhs.args[2:end]...)
         parse_code_lhs, build_code_lhs, new_lhs = rewrite_call_expression(_error, Val(lhs.args[1]), lhs.args[2:end]...)
     end
 
@@ -197,7 +198,7 @@ function parse_one_operator_constraint(_error::Function, vectorized::Bool, sense
         parse_code = :($parse_code; $variable = _MA.mutable_operate!(-, convert(AffExpr, $variable), $new_rhs))
     elseif lhs != new_lhs && rhs == new_rhs
         variable, parse_code = _MA.rewrite(rhs)
-        parse_code = :($parse_code; $variable = _MA.mutable_operate!(-, $new_lhs, convert(AffExpr, $variable)))
+        parse_code = :($parse_code; $variable = _MA.mutable_operate!(-, convert(AffExpr, $new_lhs), $variable))
     else
         @assert rhs != new_rhs
         @assert lhs != new_lhs

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -161,7 +161,7 @@ end
 
 # To be defined if such a function must be rewritten; otherwise,
 # rewrite_call_expression will never be called.
-expression_to_rewrite(head::Val{F}, args...) where F = false
+expression_to_rewrite(head::Val, args...) = false
 
 # When `expression_to_rewrite` called with the same arguments save the first one,
 # returns three things:
@@ -207,7 +207,7 @@ function parse_one_operator_constraint(_error::Function, vectorized::Bool, sense
         parse_code = :($parse_code; $variable = _MA.operate!(-, $variable, $new_rhs))
     elseif lhs != new_lhs && rhs == new_rhs
         variable, parse_code = _MA.rewrite(rhs)
-        parse_code = :($parse_code; $variable = _MA.operate!(-, $variable, $new_lhs))
+        parse_code = :($parse_code; $variable = _MA.operate!(-, $new_lhs, $variable))
     else
         @assert rhs != new_rhs
         @assert lhs != new_lhs

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -191,6 +191,46 @@ function custom_function_test(ModelType::Type{<:JuMP.AbstractModel})
         @test_macro_throws ErrorException @constraint(model, g(x))
     end
 end
+function JuMP.rewrite_call_expression(errorf::Function, head::Val{:donothing}, var)
+    m = gensym()
+    vi = gensym()
+    nvar = gensym()
+
+    parse_code_var = quote
+      $m = owner_model($(esc(index)))
+      $vi = VariableInfo(false, NaN, false, NaN, false, NaN, false, NaN, false, false)
+      $nvar = add_variable($m, build_variable($errorf, $vi), "")
+    end
+
+    idx, parse_code_index = JuMP._MA.rewrite(index)
+    build_code_con = quote
+      add_constraint($m, build_constraint($errorf, _MA.mutable_operate!(-, $var, $nvar), MOI.EqualTo(0.0)))
+    end
+
+    return :($parse_code_var; $parse_code_index), build_code_con, var
+end
+function build_constraint_test(ModelType::Type{<:JuMP.AbstractModel})
+    @testset "Extension of @constraint with rewrite_call_expression #2229" begin
+        # RHS
+        model = ModelType()
+        @variable(model, x)
+        @variable(model, y)
+        cref = @constraint(model, y == donothing(x))
+
+        # LHS
+        model = ModelType()
+        @variable(model, x)
+        @variable(model, y)
+        cref = @constraint(model, donothing(x) == y)
+
+        # Both sides.
+        # TODO.
+        # model = ModelType()
+        # @variable(model, x)
+        # @variable(model, y)
+        # cref = @constraint(model, donothing(x) == donothing(y))
+    end
+end
 
 function macros_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::Type{<:JuMP.AbstractVariableRef})
     @testset "build_constraint on variable" begin

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -207,7 +207,11 @@ function build_constraint_test(ModelType::Type{<:JuMP.AbstractModel})
         model = ModelType()
         @variable(model, x)
         @variable(model, y)
-        cref = @constraint(model, y == donothing(x))
+        cref = @constraint(model, x == donothing(y))
+
+        c = JuMP.constraint_object(cref)
+        @test JuMP.isequal_canonical(c.func, x - y)
+        @test c.set == MOI.EqualTo(0.0)
 
         # LHS
         model = ModelType()
@@ -215,11 +219,19 @@ function build_constraint_test(ModelType::Type{<:JuMP.AbstractModel})
         @variable(model, y)
         cref = @constraint(model, donothing(x) == y)
 
+        c = JuMP.constraint_object(cref)
+        @test JuMP.isequal_canonical(c.func, x - y)
+        @test c.set == MOI.EqualTo(0.0)
+
         # Both sides.
         model = ModelType()
         @variable(model, x)
         @variable(model, y)
         cref = @constraint(model, donothing(x) == donothing(y))
+
+        c = JuMP.constraint_object(cref)
+        @test JuMP.isequal_canonical(c.func, x - y)
+        @test c.set == MOI.EqualTo(0.0)
     end
 end
 

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -155,7 +155,6 @@ function build_constraint_keyword_test(ModelType::Type{<:JuMP.AbstractModel})
     end
 end
 
-<<<<<<< HEAD
 struct CustomType
 end
 function JuMP.parse_constraint_head(_error::Function, ::Val{:(:=)}, lhs, rhs)
@@ -177,7 +176,6 @@ function custom_expression_test(ModelType::Type{<:JuMP.AbstractModel})
     end
 end
 
-<<<<<<< HEAD
 function JuMP.parse_one_operator_constraint(_error::Function, ::Bool, ::Val{:f}, x)
     return :(), :(build_constraint($_error, $(esc(x)), $(esc(CustomType()))))
 end
@@ -193,14 +191,13 @@ function custom_function_test(ModelType::Type{<:JuMP.AbstractModel})
         @test_macro_throws ErrorException @constraint(model, g(x))
     end
 end
-=======
-=======
+
 JuMP.expression_to_rewrite(head::Val{:donothing}, var) = true
->>>>>>> 00c7836c... Make the tests pass.
->>>>>>> e8726d59... Make the tests pass.
+JuMP.expression_to_rewrite(head::Val{:donothing}, var) = true
 function JuMP.rewrite_call_expression(errorf::Function, head::Val{:donothing}, var)
     return :(), :(), esc(var)
 end
+
 function build_constraint_test(ModelType::Type{<:JuMP.AbstractModel})
     @testset "Extension of @constraint with rewrite_call_expression #2229" begin
         # RHS

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -192,12 +192,7 @@ function custom_function_test(ModelType::Type{<:JuMP.AbstractModel})
     end
 end
 
-JuMP.expression_to_rewrite(head::Val{:donothing}, var) = true
-JuMP.expression_to_rewrite(head::Val{:donothing}, var) = true
-function JuMP.rewrite_call_expression(errorf::Function, head::Val{:donothing}, var)
-    return :(), :(), esc(var)
-end
-
+JuMP._rewrite_expr(_error::Function, ::Val{:call}, ::Val{:donothing}, arg) = :(), :(), arg
 function build_constraint_test(ModelType::Type{<:JuMP.AbstractModel})
     @testset "Extension of @constraint with rewrite_call_expression #2229" begin
         @testset "Simple: only the function in rhs/lhs" begin
@@ -240,8 +235,8 @@ function build_constraint_test(ModelType::Type{<:JuMP.AbstractModel})
             cref = @constraint(model, x == 1 + donothing(y))
 
             c = JuMP.constraint_object(cref)
-            @test JuMP.isequal_canonical(c.func, x - y - 1)
-            @test c.set == MOI.EqualTo(0.0)
+            @test JuMP.isequal_canonical(c.func, x - y)
+            @test c.set == MOI.EqualTo(1.0)
 
             # LHS
             model = ModelType()
@@ -250,8 +245,8 @@ function build_constraint_test(ModelType::Type{<:JuMP.AbstractModel})
             cref = @constraint(model, donothing(x) - 1 == y)
 
             c = JuMP.constraint_object(cref)
-            @test JuMP.isequal_canonical(c.func, x - y - 1)
-            @test c.set == MOI.EqualTo(0.0)
+            @test JuMP.isequal_canonical(c.func, x - y)
+            @test c.set == MOI.EqualTo(1.0)
 
             # Both sides.
             model = ModelType()
@@ -260,8 +255,8 @@ function build_constraint_test(ModelType::Type{<:JuMP.AbstractModel})
             cref = @constraint(model, donothing(x) - 0.5 == donothing(y) + 0.5)
 
             c = JuMP.constraint_object(cref)
-            @test JuMP.isequal_canonical(c.func, x - y - 1)
-            @test c.set == MOI.EqualTo(0.0)
+            @test JuMP.isequal_canonical(c.func, x - y)
+            @test c.set == MOI.EqualTo(1.0)
         end
     end
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -155,6 +155,7 @@ function build_constraint_keyword_test(ModelType::Type{<:JuMP.AbstractModel})
     end
 end
 
+<<<<<<< HEAD
 struct CustomType
 end
 function JuMP.parse_constraint_head(_error::Function, ::Val{:(:=)}, lhs, rhs)
@@ -176,6 +177,7 @@ function custom_expression_test(ModelType::Type{<:JuMP.AbstractModel})
     end
 end
 
+<<<<<<< HEAD
 function JuMP.parse_one_operator_constraint(_error::Function, ::Bool, ::Val{:f}, x)
     return :(), :(build_constraint($_error, $(esc(x)), $(esc(CustomType()))))
 end
@@ -191,23 +193,13 @@ function custom_function_test(ModelType::Type{<:JuMP.AbstractModel})
         @test_macro_throws ErrorException @constraint(model, g(x))
     end
 end
+=======
+=======
+JuMP.expression_to_rewrite(head::Val{:donothing}, var) = true
+>>>>>>> 00c7836c... Make the tests pass.
+>>>>>>> e8726d59... Make the tests pass.
 function JuMP.rewrite_call_expression(errorf::Function, head::Val{:donothing}, var)
-    m = gensym()
-    vi = gensym()
-    nvar = gensym()
-
-    parse_code_var = quote
-      $m = owner_model($(esc(index)))
-      $vi = VariableInfo(false, NaN, false, NaN, false, NaN, false, NaN, false, false)
-      $nvar = add_variable($m, build_variable($errorf, $vi), "")
-    end
-
-    idx, parse_code_index = JuMP._MA.rewrite(index)
-    build_code_con = quote
-      add_constraint($m, build_constraint($errorf, _MA.mutable_operate!(-, $var, $nvar), MOI.EqualTo(0.0)))
-    end
-
-    return :($parse_code_var; $parse_code_index), build_code_con, var
+    return :(), :(), esc(var)
 end
 function build_constraint_test(ModelType::Type{<:JuMP.AbstractModel})
     @testset "Extension of @constraint with rewrite_call_expression #2229" begin
@@ -415,6 +407,7 @@ function macros_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::Typ
     build_constraint_keyword_test(ModelType)
     custom_expression_test(ModelType)
     custom_function_test(ModelType)
+    build_constraint_test(ModelType)
 end
 
 @testset "Macros for JuMP.Model" begin

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -216,11 +216,10 @@ function build_constraint_test(ModelType::Type{<:JuMP.AbstractModel})
         cref = @constraint(model, donothing(x) == y)
 
         # Both sides.
-        # TODO.
-        # model = ModelType()
-        # @variable(model, x)
-        # @variable(model, y)
-        # cref = @constraint(model, donothing(x) == donothing(y))
+        model = ModelType()
+        @variable(model, x)
+        @variable(model, y)
+        cref = @constraint(model, donothing(x) == donothing(y))
     end
 end
 


### PR DESCRIPTION
Excerpt from #2051. New take on #2229, much more general (and not much longer — unless you take https://github.com/JuliaOpt/JuMP.jl/pull/2229/commits/fdef385b6b5de779208124f991c9a221f74ae925, which unfortunately does not work…). 

I'd prefer to see this PR merged instead of #2229, due to the functionalities that are possible with this, but maybe this is not the best way to implement it… 

The general goal is to allow rewriting expressions at the JuMP level, only based on syntactic information, to provide more convenience for users. This only provides more points for extensions to plug into JuMP. 

More in details (based on the current developments of the CP sets): the modelling layer can decide to rewrite an expression like `y <= count(x .== 5)` as two constraints, a CP one (say `z == count(x .== 5))`, and a purely linear one (say `y <= z`), all of this at JuMP layer. These new constraints can then be bridged by MOI if needed. The constraints to model in the first hand (like `y <= count(x .== 5))`) should not have MOI equivalents (because that would create a very very large number of sets to support: instead of just Count, you would need LessThanCount, maybe AffineLessThanCount later on, and so on). 

This thus raises the issue of deleting the new constraints: as a user, it only makes sense to have a reference to the constraint `y <= count(x .== 5)`; to delete it, two constraints and a variable must be deleted. The existing system of bridges does not work, as it takes as input a MOI constraint (which, by design, the user-specified constraint have a low likelihood to be). Nothing is implemented regarding this. My idea is to have `_rewrite_expr` to return the new things that the function call created (variables, constraints), so that JuMP can get rid of all of it when deleting the constraint. 