### PR TITLE
Add model_from

### DIFF
--- a/src/file_formats.jl
+++ b/src/file_formats.jl
@@ -60,6 +60,26 @@ function Base.write(
 end
 
 """
+    model_from(moi_model::MOI.ModelLike; kws...)
+
+Create a new JuMP model `model = Model(; kws...)` and copies `moi_model` to
+`model`. The function return `model`.
+
+## Examples
+
+Given an MOI model `moi_model`, the following lines creates a JuMP model
+in MANUAL mode from this model.
+```julia
+model_from(moi_model, caching_mode = MOIU.MANUAL)
+```
+"""
+function model_from(moi_model::MOI.ModelLike; kws...)
+    model = Model(; kws...)
+    MOI.copy_to(model, moi_model)
+    return model
+end
+
+"""
     read_from_file(
         filename::String;
         format::MOI.FileFormats.FileFormat = MOI.FileFormats.FORMAT_AUTOMATIC
@@ -76,9 +96,7 @@ function read_from_file(
 )
     src = MOI.FileFormats.Model(format = format, filename = filename)
     MOI.read_from_file(src, filename)
-    model = Model()
-    MOI.copy_to(model, src)
-    return model
+    return model_from(src)
 end
 
 """
@@ -92,7 +110,5 @@ function Base.read(io::IO, ::Type{Model}; format::MOI.FileFormats.FileFormat)
     end
     src = MOI.FileFormats.Model(format = format)
     read!(io, src)
-    model = Model()
-    MOI.copy_to(model, src)
-    return model
+    return model_from(src)
 end


### PR DESCRIPTION
One target use case would be to allow to easily create JuMP from matrix input with https://github.com/JuliaOpt/MatrixOptInterface.jl/tree/master/src, e.g. to replace MathProgBase's `linprog`.
For instance:
```julia
using JuMP, MatrixOptInterface
model = model_from(LPStandardForm(MOI.MAX_SENSE, c, A, b))
set_optimizer(model, GLPK.Optimizer)
optimize!(model)
sol = value.(all_variables(model))
```