### PR TITLE
[Extension] Implement set_objective_function instead of set_objective

### DIFF
--- a/src/objective.jl
+++ b/src/objective.jl
@@ -116,7 +116,7 @@ function set_objective_function(model::Model, func::Real)
 end
 
 function set_objective(
-    model::Model,
+    model::AbstractModel,
     sense::MOI.OptimizationSense,
     func::Union{AbstractJuMPScalar, Real}
 )

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -115,23 +115,17 @@ function set_objective_function(model::Model, func::Real)
         MOI.ScalarAffineTerm{Float64}[], Float64(func)))
 end
 
-function set_objective(
-    model::AbstractModel,
-    sense::MOI.OptimizationSense,
-    func::Union{AbstractJuMPScalar, Real}
-)
+function set_objective_function(model::AbstractModel, ::MutableArithmetics.Zero)
+    set_objective_function(model, 0.0)
+end
+
+function set_objective_function(model::AbstractModel, func)
+    error("The objective function `$(func)` is not supported by JuMP.")
+end
+
+function set_objective(model::AbstractModel, sense::MOI.OptimizationSense, func)
     set_objective_sense(model, sense)
     set_objective_function(model, func)
-end
-
-function set_objective(
-    model::Model, sense::MOI.OptimizationSense, ::MutableArithmetics.Zero
-)
-    set_objective(model, sense, 0.0)
-end
-
-function set_objective(model::Model, sense::MOI.OptimizationSense, func)
-    error("The objective function `$(func)` is not supported by JuMP.")
 end
 
 """

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -253,13 +253,10 @@ end
 
 
 # Objective
-function JuMP.set_objective(m::MyModel, sense::MOI.OptimizationSense,
-                            f::JuMP.AbstractJuMPScalar)
-    m.objectivesense = sense
+function JuMP.set_objective_function(m::MyModel, f::JuMP.AbstractJuMPScalar)
     m.objective_function = f
 end
-function JuMP.set_objective(m::MyModel, sense::MOI.OptimizationSense, f::Real)
-    m.objectivesense = sense
+function JuMP.set_objective_function(m::MyModel, f::Real)
     m.objective_function = JuMP.GenericAffExpr{Float64, MyVariableRef}(f)
 end
 JuMP.objective_sense(model::MyModel) = model.objectivesense


### PR DESCRIPTION
It implement `set_objective_sense` so implementing `set_objective` was not appropriate as there is a fallback to `set_objective_sense` and `set_objective_function`.