### PR TITLE
added note of GAMS solvers to installation doc

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -66,11 +66,13 @@ Where:
 -   SDP = Semidefinite programming
 -   MISDP = Mixed-integer semidefinite programming
 
-You may also use [AmplNLWriter](https://github.com/JuliaOpt/AmplNLWriter.jl) to
-access solvers that support the [nl format](https://en.wikipedia.org/wiki/Nl_(format)).
-Such solvers include [Bonmin](https://github.com/coin-or/Bonmin) and
-[Couenne](https://github.com/coin-or/Couenne). See a more complete list
-[here](https://ampl.com/products/solvers/all-solvers-for-ampl/).
+You may also use [AmplNLWriter](https://github.com/JuliaOpt/AmplNLWriter.jl) or
+[GAMS](https://github.com/GAMS-dev/gams.jl) to access additional solvers.
+Such solvers include for example [Antigone](https://www.gams.com/latest/docs/S_ANTIGONE.html),
+[Bonmin](https://github.com/coin-or/Bonmin), [CONOPT](http://www.conopt.com/) and
+[Couenne](https://github.com/coin-or/Couenne). See a more complete list of AMPL
+solvers [here](https://ampl.com/products/solvers/all-solvers-for-ampl/) and of
+GAMS solvers [here](https://www.gams.com/latest/docs/S_MAIN.html).
 
 To install Gurobi, for example, and use it with a JuMP model `model`, run:
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -66,13 +66,24 @@ Where:
 -   SDP = Semidefinite programming
 -   MISDP = Mixed-integer semidefinite programming
 
-You may also use [AmplNLWriter](https://github.com/JuliaOpt/AmplNLWriter.jl) or
-[GAMS](https://github.com/GAMS-dev/gams.jl) to access additional solvers.
-Such solvers include for example [Antigone](https://www.gams.com/latest/docs/S_ANTIGONE.html),
-[Bonmin](https://github.com/coin-or/Bonmin), [CONOPT](http://www.conopt.com/) and
-[Couenne](https://github.com/coin-or/Couenne). See a more complete list of AMPL
-solvers [here](https://ampl.com/products/solvers/all-solvers-for-ampl/) and of
-GAMS solvers [here](https://www.gams.com/latest/docs/S_MAIN.html).
+You may also use [AmplNLWriter](https://github.com/JuliaOpt/AmplNLWriter.jl) to
+access solvers that support the [nl format](https://en.wikipedia.org/wiki/Nl_(format)).
+Such solvers include [Bonmin](https://github.com/coin-or/Bonmin) and
+[Couenne](https://github.com/coin-or/Couenne). See a more complete list
+[here](https://ampl.com/products/solvers/all-solvers-for-ampl/).
+
+Additionally, you may use [GAMS](https://github.com/GAMS-dev/gams.jl) to access additional solvers. Among them are 
+[AlphaECP](https://www.gams.com/latest/docs/S_ALPHAECP.html), 
+[Antigone](https://www.gams.com/latest/docs/S_ANTIGONE.html), 
+[BARON](https://www.gams.com/latest/docs/S_BARON.html), 
+[CONOPT](https://www.gams.com/latest/docs/S_CONOPT.html), 
+[Couenne](https://www.gams.com/latest/docs/S_COUENNE.html), 
+[LocalSolver](https://www.gams.com/latest/docs/S_LOCALSOLVER.html), 
+[PATHNLP](https://www.gams.com/latest/docs/S_PATHNLP.html),
+[SHOT](https://www.gams.com/latest/docs/S_SHOT.html), 
+[SNOPT](https://www.gams.com/latest/docs/S_SNOPT.html), 
+[SoPlex](https://www.gams.com/latest/docs/S_SOPLEX.html). 
+See a complete list [here](https://www.gams.com/latest/docs/S_MAIN.html).
 
 To install Gurobi, for example, and use it with a JuMP model `model`, run:
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -72,7 +72,8 @@ Such solvers include [Bonmin](https://github.com/coin-or/Bonmin) and
 [Couenne](https://github.com/coin-or/Couenne). See a more complete list
 [here](https://ampl.com/products/solvers/all-solvers-for-ampl/).
 
-Additionally, you may use [GAMS](https://github.com/GAMS-dev/gams.jl) to access additional solvers. Among them are 
+Additionally, you may use [GAMS](https://www.gams.com) (Julia package:
+[GAMS.jl](https://github.com/GAMS-dev/gams.jl)) to access additional solvers. Among them are 
 [AlphaECP](https://www.gams.com/latest/docs/S_ALPHAECP.html), 
 [Antigone](https://www.gams.com/latest/docs/S_ANTIGONE.html), 
 [BARON](https://www.gams.com/latest/docs/S_BARON.html), 
@@ -83,7 +84,11 @@ Additionally, you may use [GAMS](https://github.com/GAMS-dev/gams.jl) to access 
 [SHOT](https://www.gams.com/latest/docs/S_SHOT.html), 
 [SNOPT](https://www.gams.com/latest/docs/S_SNOPT.html), 
 [SoPlex](https://www.gams.com/latest/docs/S_SOPLEX.html). 
-See a complete list [here](https://www.gams.com/latest/docs/S_MAIN.html).
+See a complete list [here](https://www.gams.com/latest/docs/S_MAIN.html). Note, 
+that [GAMS.jl](https://github.com/GAMS-dev/gams.jl) requires an installation of 
+the commercial software [GAMS](https://www.gams.com) for which a 
+[free community license](https://www.gams.com/latest/docs/UG_License.html#GAMS_Community_Licenses) 
+exists.
 
 To install Gurobi, for example, and use it with a JuMP model `model`, run:
 


### PR DESCRIPTION
I updated the installation doc section about AMPL to also refer to the option of using GAMS. Because the AMPL and GAMS options are very similar I tried to cover this in the same paragraph. If you like me to write about GAMS in a separate paragraph, let me know. I haven't updated any solvers that are supported by GAMS and are not supported by JuMP (without GAMS.jl) in the README.md, like Antigone.