### PR TITLE
Reduce CI load by skipping Julia 1.1, 1.2, and 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ julia:
 # matrix:
 #     allow_failures:
 #         - julia: 0.7
+branches:
+  only:
+    - master
+    - /^release-.*$/
 notifications:
     email: false
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ os:
           # with osx and linux should be similar.
 julia:
     - 1.0
-    - 1.1
-    - 1.2
-    - 1.3
+    # - 1.1 # Disable to speed up CI
+    # - 1.2
+    # - 1.3
     - 1.4
 # This is left as an example for the next big version switch.
 # matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ os:
           # with osx and linux should be similar.
 julia:
     - 1.0
-    # - 1.1 # Disable to speed up CI
+    # - 1.1 # Disabled to speed up CI
     # - 1.2
     # - 1.3
     - 1.4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 environment:
   matrix:
   - julia_version: 1.0
-# - julia_version: 1.1 # Disabled to speed up CI, tested on Linux with Travis
-# - julia_version: 1.2 # Disabled to speed up CI, tested on Linux with Travis
-  - julia_version: 1.3
+# - julia_version: 1.1 # Disabled to speed up CI
+# - julia_version: 1.2 # Disabled to speed up CI
+# - julia_version: 1.3 # Disabled to speed up CI
   - julia_version: 1.4
 
 platform:


### PR DESCRIPTION
I think it is fine for us to only test the LTS release and the most current minor release.