### PR TITLE
WIP: make tests run faster

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,16 +22,10 @@ ForwardDiff = "~0.5.0, ~0.6, ~0.7, ~0.8, ~0.9, ~0.10"
 MathOptInterface = "~0.9.11"
 MutableArithmetics = "0.2"
 NaNMath = "0.3"
-OffsetArrays = "≥ 0.2.13"
 julia = "1"
 
 [extras]
-DualNumbers = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["OffsetArrays", "LinearAlgebra", "DualNumbers", "Random", "SparseArrays", "Test"]
+test = ["Test"]

--- a/test/Containers/Containers.jl
+++ b/test/Containers/Containers.jl
@@ -1,13 +1,15 @@
 using Test
-using JuMP
-using JuMP.Containers
 
 @testset "Containers" begin
-    include("DenseAxisArray.jl")
-    include("SparseAxisArray.jl")
-    include("generate_container.jl")
-    include("vectorized_product_iterator.jl")
-    include("nested_iterator.jl")
-    include("no_duplicate_dict.jl")
-    include("macro.jl")
+    @testset "$(file)" for file in filter(f -> endswith(f, ".jl"), readdir(@__DIR__))
+        if file in [
+            "Containers.jl",
+        ]
+            continue
+        end
+        filename = joinpath(@__DIR__, file)
+        t = time()
+        include(filename)
+        println("$(filename) took $(round(time() - t; digits = 1)) seconds.")
+    end
 end

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -1,3 +1,6 @@
+using JuMP.Containers
+using Test
+
 @testset "DenseAxisArray" begin
     @testset "undef constructor" begin
         A = @inferred DenseAxisArray{Int}(undef, [:a, :b], 1:2)

--- a/test/Containers/SparseAxisArray.jl
+++ b/test/Containers/SparseAxisArray.jl
@@ -1,3 +1,6 @@
+using JuMP.Containers
+using Test
+
 @testset "SparseAxisArray" begin
     function sparse_test(d, sum_d, d2, d3, dsqr, d_bads)
         sqr(x) = x^2

--- a/test/Containers/generate_container.jl
+++ b/test/Containers/generate_container.jl
@@ -3,9 +3,9 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-using Test
 using JuMP
 using JuMP.Containers
+using Test
 
 macro dummycontainer(expr, requestedtype)
     name = gensym()

--- a/test/Containers/macro.jl
+++ b/test/Containers/macro.jl
@@ -1,6 +1,6 @@
-using Test
 using JuMP
 using JuMP.Containers
+using Test
 
 @testset "Macro" begin
     @testset "Array" begin

--- a/test/Containers/nested_iterator.jl
+++ b/test/Containers/nested_iterator.jl
@@ -1,3 +1,6 @@
+using JuMP.Containers
+using Test
+
 @testset "Nested Iterator" begin
     iterators = (() -> 1:3, i -> 1:i)
     condition(i, j) = j > i

--- a/test/Containers/no_duplicate_dict.jl
+++ b/test/Containers/no_duplicate_dict.jl
@@ -1,3 +1,6 @@
+using JuMP.Containers
+using Test
+
 @testset "Iterator with constant eltype" begin
     f(ij) = ij => sum(ij)
     g = Base.Generator(f, Iterators.product(1:2, 1:2))

--- a/test/Containers/vectorized_product_iterator.jl
+++ b/test/Containers/vectorized_product_iterator.jl
@@ -1,3 +1,6 @@
+using JuMP.Containers
+using Test
+
 @testset "Vectorized Product Iterator" begin
     I = [1 2
          3 4]

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -1,12 +1,11 @@
 module JuMPExtension
+
 # Simple example of JuMP extension used in the tests to check that JuMP works well with extensions
 # The main difference between `JuMP.Model` and `JuMPExtension.MyModel` is the fact that in `add_variable` (resp. `add_constraint`),
 # `JuMP.Model` applies the modification to its `moi_backend` field while
 # `JuMPExtension.MyModel` stores the `AbstractVariable` (resp. `AbstractConstraint`) in a list.
 
-using MathOptInterface
-const MOI = MathOptInterface
-import JuMP
+using JuMP
 
 struct ConstraintIndex
     value::Int # Index in `model.constraints`

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -1,3 +1,13 @@
+using JuMP
+using LinearAlgebra
+using Test
+
+include(joinpath(@__DIR__, "utilities.jl"))
+
+@static if !(:JuMPExtension in names(Main))
+    include(joinpath(@__DIR__, "JuMPExtension.jl"))
+end
+
 function test_constraint_name(constraint, name, F::Type, S::Type)
     @test name == @inferred JuMP.name(constraint)
     model = constraint.model

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -1,14 +1,13 @@
+module TestConstraint
+
 using JuMP
 using LinearAlgebra
 using Test
 
 include(joinpath(@__DIR__, "utilities.jl"))
+include(joinpath(@__DIR__, "JuMPExtension.jl"))
 
-@static if !(:JuMPExtension in names(Main))
-    include(joinpath(@__DIR__, "JuMPExtension.jl"))
-end
-
-function test_constraint_name(constraint, name, F::Type, S::Type)
+function _test_constraint_name_util(constraint, name, F::Type, S::Type)
     @test name == @inferred JuMP.name(constraint)
     model = constraint.model
     @test constraint.index == JuMP.constraint_by_name(model, name).index
@@ -17,708 +16,735 @@ function test_constraint_name(constraint, name, F::Type, S::Type)
     end
 end
 
-function constraints_test(ModelType::Type{<:JuMP.AbstractModel},
-                          VariableRefType::Type{<:JuMP.AbstractVariableRef})
-    AffExprType = JuMP.GenericAffExpr{Float64, VariableRefType}
-    QuadExprType = JuMP.GenericQuadExpr{Float64, VariableRefType}
+function test_SingleVariable_constraints(ModelType, ::Any)
+    m = ModelType()
+    @variable(m, x)
 
-    @testset "SingleVariable constraints" begin
-        m = ModelType()
-        @variable(m, x)
+    # x <= 10.0 doesn't translate to a SingleVariable constraint because
+    # the LHS is first subtracted to form x - 10.0 <= 0.
+    @constraint(m, cref, x in MOI.LessThan(10.0))
+    _test_constraint_name_util(cref, "cref", JuMP.VariableRef,
+                            MOI.LessThan{Float64})
+    c = JuMP.constraint_object(cref)
+    @test c.func == x
+    @test c.set == MOI.LessThan(10.0)
 
-        # x <= 10.0 doesn't translate to a SingleVariable constraint because
-        # the LHS is first subtracted to form x - 10.0 <= 0.
-        @constraint(m, cref, x in MOI.LessThan(10.0))
-        test_constraint_name(cref, "cref", JuMP.VariableRef,
-                             MOI.LessThan{Float64})
-        c = JuMP.constraint_object(cref)
-        @test c.func == x
-        @test c.set == MOI.LessThan(10.0)
+    @variable(m, y[1:2])
+    @constraint(m, cref2[i=1:2], y[i] in MOI.LessThan(float(i)))
+    _test_constraint_name_util(cref2[1], "cref2[1]", JuMP.VariableRef,
+                            MOI.LessThan{Float64})
+    c = JuMP.constraint_object(cref2[1])
+    @test c.func == y[1]
+    @test c.set == MOI.LessThan(1.0)
+end
 
-        @variable(m, y[1:2])
-        @constraint(m, cref2[i=1:2], y[i] in MOI.LessThan(float(i)))
-        test_constraint_name(cref2[1], "cref2[1]", JuMP.VariableRef,
-                             MOI.LessThan{Float64})
-        c = JuMP.constraint_object(cref2[1])
-        @test c.func == y[1]
-        @test c.set == MOI.LessThan(1.0)
+function test_VectorOfVariables_constraints(ModelType, ::Any)
+    m = ModelType()
+    @variable(m, x[1:2])
+
+    cref = @constraint(m, x in MOI.Zeros(2))
+    c = JuMP.constraint_object(cref)
+    @test c.func == x
+    @test c.set == MOI.Zeros(2)
+
+    cref = @constraint(m, [x[2],x[1]] in MOI.Zeros(2))
+    c = JuMP.constraint_object(cref)
+    @test c.func == [x[2],x[1]]
+    @test c.set == MOI.Zeros(2)
+end
+
+function test_AffExpr_scalar_constraints(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, x)
+
+    cref = @constraint(model, 2x <= 10)
+    @test "" == @inferred JuMP.name(cref)
+    JuMP.set_name(cref, "c")
+    _test_constraint_name_util(cref, "c", JuMP.AffExpr, MOI.LessThan{Float64})
+
+    c = JuMP.constraint_object(cref)
+    @test JuMP.isequal_canonical(c.func, 2x)
+    @test c.set == MOI.LessThan(10.0)
+
+    cref = @constraint(model, 3x + 1 ≥ 10)
+    c = JuMP.constraint_object(cref)
+    @test JuMP.isequal_canonical(c.func, 3x)
+    @test c.set == MOI.GreaterThan(9.0)
+
+    cref = @constraint(model, 1 == -x)
+    c = JuMP.constraint_object(cref)
+    @test JuMP.isequal_canonical(c.func, 1.0x)
+    @test c.set == MOI.EqualTo(-1.0)
+
+    cref = @constraint(model, 2 == 1)
+    c = JuMP.constraint_object(cref)
+    @test JuMP.isequal_canonical(c.func, zero(JuMP.AffExpr))
+    @test c.set == MOI.EqualTo(-1.0)
+end
+
+function test_AffExpr_vectorized_constraints(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, x)
+    err = ErrorException("In `@constraint(model, [x, 2x] == [1 - x, 3])`: Unexpected vector in scalar constraint. Did you mean to use the dot comparison operators like .==, .<=, and .>= instead?")
+    @test_throws err @constraint(model, [x, 2x] == [1-x, 3])
+    @test_macro_throws ErrorException begin
+        @constraint(model, [x == 1-x, 2x == 3])
     end
+    cref = @constraint(model, [x, 2x] .== [1-x, 3])
+    c = JuMP.constraint_object.(cref)
+    @test JuMP.isequal_canonical(c[1].func, 2.0x)
+    @test c[1].set == MOI.EqualTo(1.0)
+    @test JuMP.isequal_canonical(c[2].func, 2.0x)
+    @test c[2].set == MOI.EqualTo(3.0)
+end
 
-    @testset "VectorOfVariables constraints" begin
-        m = ModelType()
-        @variable(m, x[1:2])
+function test_AffExpr_vector_constraints(ModelType, ::Any)
+    model = ModelType()
+    cref = @constraint(model, [1, 2] in MOI.Zeros(2))
+    c = JuMP.constraint_object(cref)
+    @test JuMP.isequal_canonical(c.func[1], zero(JuMP.AffExpr) + 1)
+    @test JuMP.isequal_canonical(c.func[2], zero(JuMP.AffExpr) + 2)
+    @test c.set == MOI.Zeros(2)
+    @test c.shape isa JuMP.VectorShape
+end
 
-        cref = @constraint(m, x in MOI.Zeros(2))
-        c = JuMP.constraint_object(cref)
-        @test c.func == x
-        @test c.set == MOI.Zeros(2)
+function test_delete_constraints(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, x)
+    constraint_ref = @constraint(model, 2x <= 1)
+    @test JuMP.is_valid(model, constraint_ref)
+    JuMP.delete(model, constraint_ref)
+    @test !JuMP.is_valid(model, constraint_ref)
+    second_model = ModelType()
+    @test_throws Exception JuMP.delete(second_model, constraint_ref)
+end
 
-        cref = @constraint(m, [x[2],x[1]] in MOI.Zeros(2))
-        c = JuMP.constraint_object(cref)
-        @test c.func == [x[2],x[1]]
-        @test c.set == MOI.Zeros(2)
-    end
+function test_batch_delete_constraints(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, x[1:9])
+    cons = [@constraint(model, sum(x[1:2:9]) <= 3)]
+    push!(cons, @constraint(model, sum(x[2:2:8]) <= 2))
+    push!(cons, @constraint(model, sum(x[1:3:9]) <= 1))
+    @test all(JuMP.is_valid.(model, cons))
+    JuMP.delete(model, cons[[1, 3]])
+    @test all((!JuMP.is_valid).(model, cons[[1, 3]]))
+    @test JuMP.is_valid(model, cons[2])
+    second_model = ModelType()
+    @test_throws Exception JuMP.delete(second_model, cons[[1, 3]])
+    @test_throws Exception JuMP.delete(second_model, [cons[2]])
+end
 
-    @testset "AffExpr constraints" begin
-        @testset "Scalar" begin
-            model = ModelType()
-            @variable(model, x)
+function test_two_sided_constraints(ModelType, ::Any)
+    m = ModelType()
+    @variable(m, x)
+    @variable(m, y)
 
-            cref = @constraint(model, 2x <= 10)
-            @test "" == @inferred JuMP.name(cref)
-            JuMP.set_name(cref, "c")
-            test_constraint_name(cref, "c", JuMP.AffExpr, MOI.LessThan{Float64})
+    @constraint(m, cref, 1.0 <= x + y + 1.0 <= 2.0)
+    _test_constraint_name_util(cref, "cref", JuMP.AffExpr, MOI.Interval{Float64})
 
-            c = JuMP.constraint_object(cref)
-            @test JuMP.isequal_canonical(c.func, 2x)
-            @test c.set == MOI.LessThan(10.0)
+    c = JuMP.constraint_object(cref)
+    @test JuMP.isequal_canonical(c.func, x + y)
+    @test c.set == MOI.Interval(0.0, 1.0)
 
-            cref = @constraint(model, 3x + 1 ≥ 10)
-            c = JuMP.constraint_object(cref)
-            @test JuMP.isequal_canonical(c.func, 3x)
-            @test c.set == MOI.GreaterThan(9.0)
+    cref = @constraint(m, 2x - y + 2.0 ∈ MOI.Interval(-1.0, 1.0))
+    @test "" == @inferred JuMP.name(cref)
 
-            cref = @constraint(model, 1 == -x)
-            c = JuMP.constraint_object(cref)
-            @test JuMP.isequal_canonical(c.func, 1.0x)
-            @test c.set == MOI.EqualTo(-1.0)
+    c = JuMP.constraint_object(cref)
+    @test JuMP.isequal_canonical(c.func, 2x - y)
+    @test c.set == MOI.Interval(-3.0, -1.0)
+end
 
-            cref = @constraint(model, 2 == 1)
-            c = JuMP.constraint_object(cref)
-            @test JuMP.isequal_canonical(c.func, zero(JuMP.AffExpr))
-            @test c.set == MOI.EqualTo(-1.0)
-        end
+function test_broadcasted_constraint_eq(ModelType, ::Any)
+    m = ModelType()
+    @variable(m, x[1:2])
 
-        @testset "Vectorized" begin
-            model = ModelType()
-            @variable(model, x)
+    A = [1.0 2.0; 3.0 4.0]
+    b = [4.0, 5.0]
 
-            err = ErrorException("In `@constraint(model, [x, 2x] == [1 - x, 3])`: Unexpected vector in scalar constraint. Did you mean to use the dot comparison operators like .==, .<=, and .>= instead?")
-            @test_throws err @constraint(model, [x, 2x] == [1-x, 3])
-            @test_macro_throws ErrorException begin
-                @constraint(model, [x == 1-x, 2x == 3])
-            end
+    cref = @constraint(m, A*x .== b)
+    @test (2,) == @inferred size(cref)
 
-            cref = @constraint(model, [x, 2x] .== [1-x, 3])
-            c = JuMP.constraint_object.(cref)
-            @test JuMP.isequal_canonical(c[1].func, 2.0x)
-            @test c[1].set == MOI.EqualTo(1.0)
-            @test JuMP.isequal_canonical(c[2].func, 2.0x)
-            @test c[2].set == MOI.EqualTo(3.0)
-        end
+    c1 = JuMP.constraint_object(cref[1])
+    @test JuMP.isequal_canonical(c1.func, x[1] + 2x[2])
+    @test c1.set == MOI.EqualTo(4.0)
+    c2 = JuMP.constraint_object(cref[2])
+    @test JuMP.isequal_canonical(c2.func, 3x[1] + 4x[2])
+    @test c2.set == MOI.EqualTo(5.0)
+end
 
-        @testset "Vector" begin
-            model = ModelType()
+function test_broadcasted_constraint_leq(ModelType, ::Any)
+    m = ModelType()
+    @variable(m, x[1:2,1:2])
 
-            cref = @constraint(model, [1, 2] in MOI.Zeros(2))
-            c = JuMP.constraint_object(cref)
-            @test JuMP.isequal_canonical(c.func[1], zero(JuMP.AffExpr) + 1)
-            @test JuMP.isequal_canonical(c.func[2], zero(JuMP.AffExpr) + 2)
-            @test c.set == MOI.Zeros(2)
-            @test c.shape isa JuMP.VectorShape
-        end
-    end
-    @testset "delete / is_valid constraints" begin
-        model = ModelType()
-        @variable(model, x)
-        constraint_ref = @constraint(model, 2x <= 1)
-        @test JuMP.is_valid(model, constraint_ref)
-        JuMP.delete(model, constraint_ref)
-        @test !JuMP.is_valid(model, constraint_ref)
-        second_model = ModelType()
-        @test_throws Exception JuMP.delete(second_model, constraint_ref)
-    end
+    UB = [1.0 2.0; 3.0 4.0]
 
-    @testset "batch delete / is_valid constraints" begin
-        model = ModelType()
-        @variable(model, x[1:9])
-        cons = [@constraint(model, sum(x[1:2:9]) <= 3)]
-        push!(cons, @constraint(model, sum(x[2:2:8]) <= 2))
-        push!(cons, @constraint(model, sum(x[1:3:9]) <= 1))
-        @test all(JuMP.is_valid.(model, cons))
-        JuMP.delete(model, cons[[1, 3]])
-        @test all((!JuMP.is_valid).(model, cons[[1, 3]]))
-        @test JuMP.is_valid(model, cons[2])
-        second_model = ModelType()
-        @test_throws Exception JuMP.delete(second_model, cons[[1, 3]])
-        @test_throws Exception JuMP.delete(second_model, [cons[2]])
-    end
-
-    @testset "Two-sided constraints" begin
-        m = ModelType()
-        @variable(m, x)
-        @variable(m, y)
-
-        @constraint(m, cref, 1.0 <= x + y + 1.0 <= 2.0)
-        test_constraint_name(cref, "cref", JuMP.AffExpr, MOI.Interval{Float64})
-
-        c = JuMP.constraint_object(cref)
-        @test JuMP.isequal_canonical(c.func, x + y)
-        @test c.set == MOI.Interval(0.0, 1.0)
-
-        cref = @constraint(m, 2x - y + 2.0 ∈ MOI.Interval(-1.0, 1.0))
-        @test "" == @inferred JuMP.name(cref)
-
-        c = JuMP.constraint_object(cref)
-        @test JuMP.isequal_canonical(c.func, 2x - y)
-        @test c.set == MOI.Interval(-3.0, -1.0)
-    end
-
-    @testset "Broadcasted constraint (.==)" begin
-        m = ModelType()
-        @variable(m, x[1:2])
-
-        A = [1.0 2.0; 3.0 4.0]
-        b = [4.0, 5.0]
-
-        cref = @constraint(m, A*x .== b)
-        @test (2,) == @inferred size(cref)
-
-        c1 = JuMP.constraint_object(cref[1])
-        @test JuMP.isequal_canonical(c1.func, x[1] + 2x[2])
-        @test c1.set == MOI.EqualTo(4.0)
-        c2 = JuMP.constraint_object(cref[2])
-        @test JuMP.isequal_canonical(c2.func, 3x[1] + 4x[2])
-        @test c2.set == MOI.EqualTo(5.0)
-    end
-
-    @testset "Broadcasted constraint (.<=)" begin
-        m = ModelType()
-        @variable(m, x[1:2,1:2])
-
-        UB = [1.0 2.0; 3.0 4.0]
-
-        cref = @constraint(m, x .+ 1 .<= UB)
-        @test (2,2) == @inferred size(cref)
-        for i in 1:2
-            for j in 1:2
-                c = JuMP.constraint_object(cref[i,j])
-                @test JuMP.isequal_canonical(c.func, x[i,j] + 0)
-                @test c.set == MOI.LessThan(UB[i,j] - 1)
-            end
+    cref = @constraint(m, x .+ 1 .<= UB)
+    @test (2,2) == @inferred size(cref)
+    for i in 1:2
+        for j in 1:2
+            c = JuMP.constraint_object(cref[i,j])
+            @test JuMP.isequal_canonical(c.func, x[i,j] + 0)
+            @test c.set == MOI.LessThan(UB[i,j] - 1)
         end
     end
+end
 
-    @testset "Broadcasted two-sided constraint" begin
-        m = ModelType()
-        @variable(m, x[1:2])
-        @variable(m, y[1:2])
-        l = [1.0, 2.0]
-        u = [3.0, 4.0]
+function test_broadcasted_two_sided_constraint(ModelType, ::Any)
+    m = ModelType()
+    @variable(m, x[1:2])
+    @variable(m, y[1:2])
+    l = [1.0, 2.0]
+    u = [3.0, 4.0]
 
-        cref = @constraint(m, l .<= x + y .+ 1 .<= u)
-        @test (2,) == @inferred size(cref)
+    cref = @constraint(m, l .<= x + y .+ 1 .<= u)
+    @test (2,) == @inferred size(cref)
 
-        for i in 1:2
-            c = JuMP.constraint_object(cref[i])
-            @test JuMP.isequal_canonical(c.func, x[i] + y[i])
-            @test c.set == MOI.Interval(l[i]-1, u[i]-1)
-        end
+    for i in 1:2
+        c = JuMP.constraint_object(cref[i])
+        @test JuMP.isequal_canonical(c.func, x[i] + y[i])
+        @test c.set == MOI.Interval(l[i]-1, u[i]-1)
+    end
+end
+
+function test_broadcasted_constraint_with_indices(ModelType, ::Any)
+    m = ModelType()
+    @variable m x[1:2]
+    @constraint m cref1[i=2:4] x .== [i, i+1]
+    ConstraintRefType = eltype(cref1[2])
+    @test cref1 isa JuMP.Containers.DenseAxisArray{Vector{ConstraintRefType}}
+    @constraint m cref2[i=1:3, j=1:4] x .≤ [i+j, i-j]
+    ConstraintRefType = eltype(cref2[1])
+    @test cref2 isa Matrix{Vector{ConstraintRefType}}
+    @variable m y[1:2, 1:2]
+    @constraint m cref3[i=1:2] y[i,:] .== 1
+    ConstraintRefType = eltype(cref3[1])
+    @test cref3 isa Vector{Vector{ConstraintRefType}}
+end
+
+function test_quadexpr_constraints(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, x)
+    @variable(model, y)
+
+    cref = @constraint(model, x^2 + x <= 1)
+    c = JuMP.constraint_object(cref)
+    @test JuMP.isequal_canonical(c.func, x^2 + x)
+    @test c.set == MOI.LessThan(1.0)
+
+    cref = @constraint(model, y*x - 1.0 == 0.0)
+    c = JuMP.constraint_object(cref)
+    @test JuMP.isequal_canonical(c.func, x*y)
+    @test c.set == MOI.EqualTo(1.0)
+
+    cref = @constraint(model, [ 2x - 4x*y + 3x^2 - 1,
+                                -3y + 2x*y - 2x^2 + 1] in SecondOrderCone())
+    c = JuMP.constraint_object(cref)
+    @test JuMP.isequal_canonical(c.func[1], -1 + 3x^2 - 4x*y + 2x)
+    @test JuMP.isequal_canonical(c.func[2],  1 - 2x^2 + 2x*y - 3y)
+    @test c.set == MOI.SecondOrderCone(2)
+end
+
+function test_syntax_error_constraint(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, x[1:2])
+    err = ErrorException(
+        "In `@constraint(model, [3, x] in SecondOrderCone())`: unable to " *
+        "add the constraint because we don't recognize $([3, x]) as a " *
+        "valid JuMP function."
+    )
+    @test_throws err @constraint(model, [3, x] in SecondOrderCone())
+end
+
+function test_indicator_constraint(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, a, Bin)
+    @variable(model, b, Bin)
+    @variable(model, x)
+    @variable(model, y)
+    for cref in [
+        @constraint(model, a => {x + 2y <= 1}),
+        @constraint(model, a ⇒  {x + 2y ≤ 1})
+    ]
+        c = JuMP.constraint_object(cref)
+        @test c.func == [a, x + 2y]
+        @test c.set == MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(1.0))
+    end
+    for cref in [
+        @constraint(model, !b => {2x + y <= 1});
+        @constraint(model, ¬b ⇒  {2x + y ≤ 1});
+        # This returns a vector of constraints that is concatenated.
+        @constraint(model, ![b, b] .=> {[2x + y, 2x + y] .≤ 1});
+    ]
+        c = JuMP.constraint_object(cref)
+        @test c.func == [b, 2x + y]
+        @test c.set == MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO}(MOI.LessThan(1.0))
+    end
+    err = ErrorException("In `@constraint(model, !(a, b) => {x <= 1})`: Invalid binary variable expression `!(a, b)` for indicator constraint.")
+    @test_macro_throws err @constraint(model, !(a, b) => {x <= 1})
+    err = ErrorException("In `@constraint(model, a => x)`: Invalid right-hand side `x` of indicator constraint. Expected constraint surrounded by `{` and `}`.")
+    @test_macro_throws err @constraint(model, a => x)
+    err = ErrorException("In `@constraint(model, a => x <= 1)`: Invalid right-hand side `x <= 1` of indicator constraint. Expected constraint surrounded by `{` and `}`.")
+    @test_macro_throws err @constraint(model, a => x <= 1)
+    err = ErrorException("In `@constraint(model, a => {x <= 1, x >= 0})`: Invalid right-hand side `{x <= 1, x >= 0}` of indicator constraint. Expected constraint surrounded by `{` and `}`.")
+    @test_macro_throws err @constraint(model, a => {x <= 1, x >= 0})
+    err = ErrorException("In `@constraint(model, [a, b] .=> {x + y <= 1})`: Inconsistent use of `.` in symbols to indicate vectorization.")
+    @test_macro_throws err @constraint(model, [a, b] .=> {x + y <= 1})
+end
+
+function test_SDP_constraint(ModelType, VariableRefType)
+    m = ModelType()
+    @variable(m, x)
+    @variable(m, y)
+    @variable(m, z)
+    @variable(m, w)
+
+    cref = @constraint(m, [x y; z w] in PSDCone())
+    c = JuMP.constraint_object(cref)
+    @test c.func == [x, z, y, w]
+    @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
+    @test c.shape isa JuMP.SquareMatrixShape
+
+    @constraint(m, sym_ref, Symmetric([x 1; 1 -y] - [1 x; x -2]) in PSDCone())
+    _test_constraint_name_util(sym_ref, "sym_ref", Vector{AffExpr},
+                            MOI.PositiveSemidefiniteConeTriangle)
+    c = JuMP.constraint_object(sym_ref)
+    @test JuMP.isequal_canonical(c.func[1], x-1)
+    @test JuMP.isequal_canonical(c.func[2], 1-x)
+    @test JuMP.isequal_canonical(c.func[3], 2-y)
+    @test c.set == MOI.PositiveSemidefiniteConeTriangle(2)
+    @test c.shape isa JuMP.SymmetricMatrixShape
+
+    @SDconstraint(m, cref, [x 1; 1 -y] ⪰ [1 x; x -2])
+    _test_constraint_name_util(cref, "cref", Vector{AffExpr},
+                            MOI.PositiveSemidefiniteConeSquare)
+    c = JuMP.constraint_object(cref)
+    @test JuMP.isequal_canonical(c.func[1], x-1)
+    @test JuMP.isequal_canonical(c.func[2], 1-x)
+    @test JuMP.isequal_canonical(c.func[3], 1-x)
+    @test JuMP.isequal_canonical(c.func[4], 2-y)
+    @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
+    @test c.shape isa JuMP.SquareMatrixShape
+
+    @SDconstraint(m, iref[i=1:2], 0 ⪯ [x+i x+y; x+y -y])
+    for i in 1:2
+        _test_constraint_name_util(iref[i], "iref[$i]", Vector{AffExpr},
+                                MOI.PositiveSemidefiniteConeSquare)
+        c = JuMP.constraint_object(iref[i])
+        @test JuMP.isequal_canonical(c.func[1], x+i)
+        @test JuMP.isequal_canonical(c.func[2], x+y)
+        @test JuMP.isequal_canonical(c.func[3], x+y)
+        @test JuMP.isequal_canonical(c.func[4], -y)
+        @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
+        @test c.shape isa JuMP.SquareMatrixShape
     end
 
-    @testset "Broadcasted constraint with indices" begin
-        m = ModelType()
-        @variable m x[1:2]
-        @constraint m cref1[i=2:4] x .== [i, i+1]
-        ConstraintRefType = eltype(cref1[2])
-        @test cref1 isa JuMP.Containers.DenseAxisArray{Vector{ConstraintRefType}}
-        @constraint m cref2[i=1:3, j=1:4] x .≤ [i+j, i-j]
-        ConstraintRefType = eltype(cref2[1])
-        @test cref2 isa Matrix{Vector{ConstraintRefType}}
-        @variable m y[1:2, 1:2]
-        @constraint m cref3[i=1:2] y[i,:] .== 1
-        ConstraintRefType = eltype(cref3[1])
-        @test cref3 isa Vector{Vector{ConstraintRefType}}
+    @SDconstraint(m, con_d, 0 ⪯ Diagonal([x, y]))
+    c = JuMP.constraint_object(con_d)
+    @test c.func isa Vector{GenericAffExpr{Float64, VariableRefType}}
+    @test JuMP.isequal_canonical(c.func[1], 1x)
+    @test iszero(c.func[2])
+    @test iszero(c.func[3])
+    @test JuMP.isequal_canonical(c.func[4], 1y)
+    @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
+
+    @SDconstraint(m, con_d_sym, 0 ⪯ Symmetric(Diagonal([x, y])))
+    c = JuMP.constraint_object(con_d_sym)
+    @test c.func isa Vector{GenericAffExpr{Float64, VariableRefType}}
+    @test JuMP.isequal_canonical(c.func[1], 1x)
+    @test iszero(c.func[2])
+    @test JuMP.isequal_canonical(c.func[3], 1y)
+    @test c.set == MOI.PositiveSemidefiniteConeTriangle(2)
+
+    @SDconstraint(m, con_td, Tridiagonal([z], [x, y], [w]) ⪰ 0)
+    c = JuMP.constraint_object(con_td)
+    @test c.func isa Vector{GenericAffExpr{Float64, VariableRefType}}
+    @test JuMP.isequal_canonical(c.func[1], 1x)
+    @test JuMP.isequal_canonical(c.func[2], 1z)
+    @test JuMP.isequal_canonical(c.func[3], 1w)
+    @test JuMP.isequal_canonical(c.func[4], 1y)
+    @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
+
+    @SDconstraint(m, con_td_sym, Symmetric(Tridiagonal([z], [x, y], [w])) ⪰ 0)
+    c = JuMP.constraint_object(con_td_sym)
+    @test c.func isa Vector{GenericAffExpr{Float64, VariableRefType}}
+    @test JuMP.isequal_canonical(c.func[1], 1x)
+    @test JuMP.isequal_canonical(c.func[2], 1w)
+    @test JuMP.isequal_canonical(c.func[3], 1y)
+    @test c.set == MOI.PositiveSemidefiniteConeTriangle(2)
+
+    @SDconstraint(m, con_ut, UpperTriangular([x y; z w]) ⪰ 0)
+    c = JuMP.constraint_object(con_ut)
+    @test c.func isa Vector{GenericAffExpr{Float64, VariableRefType}}
+    @test JuMP.isequal_canonical(c.func[1], 1x)
+    @test iszero(c.func[2])
+    @test JuMP.isequal_canonical(c.func[3], 1y)
+    @test JuMP.isequal_canonical(c.func[4], 1w)
+    @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
+
+    @SDconstraint(m, con_lt, 0 ⪯ LowerTriangular([x y; z w]))
+    c = JuMP.constraint_object(con_lt)
+    @test c.func isa Vector{GenericAffExpr{Float64, VariableRefType}}
+    @test JuMP.isequal_canonical(c.func[1], 1x)
+    @test JuMP.isequal_canonical(c.func[2], 1z)
+    @test iszero(c.func[3])
+    @test JuMP.isequal_canonical(c.func[4], 1w)
+    @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
+
+    # Should throw "ERROR: function JuMP.add_constraint does not accept keyword arguments"
+    # This tests that the keyword arguments are passed to add_constraint
+    @test_macro_throws ErrorException @SDconstraint(m, [x 1; 1 -y] ⪰ [1 x; x -2], unknown_kw=1)
+    # Invalid sense == in SDP constraint
+    @test_macro_throws ErrorException @SDconstraint(m, [x 1; 1 -y] == [1 x; x -2])
+end
+
+function _test_constraint_name_util(ModelType, VariableRefType)
+    model = ModelType()
+    @variable(model, x)
+    @constraint(model, con, x^2 == 1)
+    _test_constraint_name_util(con, "con", GenericQuadExpr{Float64, VariableRefType}, MOI.EqualTo{Float64})
+    JuMP.set_name(con, "kon")
+    @test JuMP.constraint_by_name(model, "con") isa Nothing
+    _test_constraint_name_util(con, "kon", GenericQuadExpr{Float64, VariableRefType}, MOI.EqualTo{Float64})
+    y = @constraint(model, kon, [x^2, x] in SecondOrderCone())
+    err(name) = ErrorException("Multiple constraints have the name $name.")
+    @test_throws err("kon") JuMP.constraint_by_name(model, "kon")
+    JuMP.set_name(kon, "con")
+    _test_constraint_name_util(con, "kon", GenericQuadExpr{Float64, VariableRefType}, MOI.EqualTo{Float64})
+    _test_constraint_name_util(kon, "con", Vector{GenericQuadExpr{Float64, VariableRefType}},
+                            MOI.SecondOrderCone)
+    JuMP.set_name(con, "con")
+    @test_throws err("con") JuMP.constraint_by_name(model, "con")
+    @test JuMP.constraint_by_name(model, "kon") isa Nothing
+    JuMP.set_name(kon, "kon")
+    _test_constraint_name_util(con, "con", GenericQuadExpr{Float64, VariableRefType}, MOI.EqualTo{Float64})
+    _test_constraint_name_util(kon, "kon", Vector{GenericQuadExpr{Float64, VariableRefType}},
+                            MOI.SecondOrderCone)
+end
+
+function test_PSD_constraint_errors(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, X[1:2, 1:2])
+    err = ErrorException(
+        "In `@constraint(model, X in MOI.PositiveSemidefiniteConeSquare(2))`:" *
+        " instead of `MathOptInterface.PositiveSemidefiniteConeSquare(2)`," *
+        " use `JuMP.PSDCone()`.")
+    @test_throws err @constraint(model, X in MOI.PositiveSemidefiniteConeSquare(2))
+    err = ErrorException(
+        "In `@constraint(model, X in MOI.PositiveSemidefiniteConeTriangle(2))`:" *
+        " instead of `MathOptInterface.PositiveSemidefiniteConeTriangle(2)`," *
+        " use `JuMP.PSDCone()`.")
+    @test_throws err @constraint(model, X in MOI.PositiveSemidefiniteConeTriangle(2))
+end
+
+function test_matrix_constraint_errors(ModelType, VariableRefType)
+    model = ModelType()
+    @variable(model, X[1:2, 1:2])
+    err = ErrorException(
+        "In `@constraint(model, X in MOI.SecondOrderCone(4))`: unexpected " *
+        "matrix in vector constraint. Do you need to flatten the matrix " *
+        "into a vector using `vec()`?")
+    # Note: this should apply to any MOI.AbstractVectorSet. We just pick
+    # SecondOrderCone for convenience.
+    @test_throws err @constraint(model, X in MOI.SecondOrderCone(4))
+end
+
+function test_nonsensical_SDP_constraint(ModelType, ::Any)
+    m = ModelType()
+    @test_throws ErrorException @variable(m, unequal[1:5,1:6], PSD)
+    # Some of these errors happen at compile time, so we can't use @test_throws
+    @test_macro_throws ErrorException @variable(m, notone[1:5,2:6], PSD)
+    @test_macro_throws ErrorException @variable(m, oneD[1:5], PSD)
+    @test_macro_throws ErrorException @variable(m, threeD[1:5,1:5,1:5], PSD)
+    @test_macro_throws ErrorException @variable(m, psd[2] <= rand(2,2), PSD)
+    @test_macro_throws ErrorException @variable(m, -ones(3,4) <= foo[1:4,1:4] <= ones(4,4), PSD)
+    @test_macro_throws ErrorException @variable(m, -ones(3,4) <= foo[1:4,1:4] <= ones(4,4), Symmetric)
+    @test_macro_throws ErrorException @variable(m, -ones(4,4) <= foo[1:4,1:4] <= ones(4,5), Symmetric)
+    @test_macro_throws ErrorException @variable(m, -rand(5,5) <= nonsymmetric[1:5,1:5] <= rand(5,5), Symmetric)
+end
+
+function test_sum_constraint(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, x[1:3,1:3])
+    @variable(model, y)
+    C = [1 2 3; 4 5 6; 7 8 9]
+
+    @test_expression sum( C[i,j]*x[i,j] for i in 1:2, j = 2:3 )
+    @test_expression sum( C[i,j]*x[i,j] for i = 1:3, j in 1:3 if i != j) - y
+    @test JuMP.isequal_canonical(@expression(model, sum( C[i,j]*x[i,j] for i = 1:3, j = 1:i)),
+                                                sum( C[i,j]*x[i,j] for i = 1:3 for j = 1:i))
+    @test_expression sum( C[i,j]*x[i,j] for i = 1:3 for j = 1:i)
+    @test_expression sum( C[i,j]*x[i,j] for i = 1:3 if true for j = 1:i)
+    @test_expression sum( C[i,j]*x[i,j] for i = 1:3 if true for j = 1:i if true)
+    @test_expression sum( 0*x[i,1] for i=1:3)
+    @test_expression sum( 0*x[i,1] + y for i=1:3)
+    @test_expression sum( 0*x[i,1] + y for i=1:3 for j in 1:3)
+end
+
+function test_Model_all_constraints_scalar(::Any, ::Any)
+    model = Model()
+    @variable(model, x >= 0)
+    @test 1 == @inferred num_constraints(model, VariableRef,
+                                            MOI.GreaterThan{Float64})
+    ref = @inferred all_constraints(
+        model, VariableRef, MOI.GreaterThan{Float64})
+    @test ref == [LowerBoundRef(x)]
+    @test 0 == @inferred num_constraints(model, AffExpr,
+                                            MOI.GreaterThan{Float64})
+    aff_constraints = all_constraints(model, AffExpr,
+                                        MOI.GreaterThan{Float64})
+    @test isempty(aff_constraints)
+    err = ErrorException("`MathOptInterface.GreaterThan` is not a " *
+                            "concrete type. Did you miss a type parameter?")
+    @test_throws err num_constraints(model, AffExpr,
+                                        MOI.GreaterThan)
+    @test_throws err all_constraints(model, AffExpr,
+                                        MOI.GreaterThan)
+    err = ErrorException(
+        "`GenericAffExpr` is not a concrete type. Did you miss a type parameter?"
+    )
+    @test_throws err try
+        num_constraints(model, JuMP.GenericAffExpr, MOI.ZeroOne)
+    catch e
+        error(replace(e.msg, "JuMP." => ""))
     end
-
-    @testset "QuadExpr constraints" begin
-        model = ModelType()
-        @variable(model, x)
-        @variable(model, y)
-
-        cref = @constraint(model, x^2 + x <= 1)
-        c = JuMP.constraint_object(cref)
-        @test JuMP.isequal_canonical(c.func, x^2 + x)
-        @test c.set == MOI.LessThan(1.0)
-
-        cref = @constraint(model, y*x - 1.0 == 0.0)
-        c = JuMP.constraint_object(cref)
-        @test JuMP.isequal_canonical(c.func, x*y)
-        @test c.set == MOI.EqualTo(1.0)
-
-        cref = @constraint(model, [ 2x - 4x*y + 3x^2 - 1,
-                                   -3y + 2x*y - 2x^2 + 1] in SecondOrderCone())
-        c = JuMP.constraint_object(cref)
-        @test JuMP.isequal_canonical(c.func[1], -1 + 3x^2 - 4x*y + 2x)
-        @test JuMP.isequal_canonical(c.func[2],  1 - 2x^2 + 2x*y - 3y)
-        @test c.set == MOI.SecondOrderCone(2)
+    @test_throws err try
+        all_constraints(model, JuMP.GenericAffExpr, MOI.ZeroOne)
+    catch e
+        error(replace(e.msg, "JuMP." => ""))
     end
+end
 
-    @testset "Syntax error" begin
-        model = ModelType()
-        @variable(model, x[1:2])
-        err = ErrorException(
-            "In `@constraint(model, [3, x] in SecondOrderCone())`: unable to " *
-            "add the constraint because we don't recognize $([3, x]) as a " *
-            "valid JuMP function."
+function test_Model_all_constraints_vector(::Any, ::Any)
+    model = Model()
+    @variable(model, x[1:2, 1:2], Symmetric)
+    csdp = @constraint(model, x in PSDCone())
+    csoc = @constraint(model, [x[1], 1] in SecondOrderCone())
+    csos = @constraint(model, [x[2]^2, 1] in MOI.SOS1([1.0, 2.0]))
+    @test 1 == @inferred num_constraints(
+        model, Vector{VariableRef}, MOI.PositiveSemidefiniteConeTriangle)
+    ref = all_constraints(model, Vector{VariableRef},
+                            MOI.PositiveSemidefiniteConeTriangle)
+    @test ref == [csdp]
+    @test 1 == @inferred num_constraints(
+        model, Vector{AffExpr}, MOI.SecondOrderCone)
+    ref = all_constraints(model, Vector{AffExpr}, MOI.SecondOrderCone)
+    @test ref == [csoc]
+    @test 1 == @inferred num_constraints(
+            model, Vector{QuadExpr}, MOI.SOS1{Float64})
+    ref = all_constraints(model, Vector{QuadExpr}, MOI.SOS1{Float64})
+    @test ref == [csos]
+    @test 0 == @inferred num_constraints(
+        model, Vector{AffExpr}, MOI.PositiveSemidefiniteConeTriangle)
+    aff_constraints = all_constraints(
+        model, Vector{AffExpr}, MOI.PositiveSemidefiniteConeTriangle)
+    @test isempty(aff_constraints)
+    err = ErrorException(
+        "`GenericAffExpr{Float64,VarType} where VarType` is not a " *
+        "concrete type. Did you miss a type parameter?"
+    )
+    @test_throws err try
+        num_constraints(
+            model,
+            Vector{GenericAffExpr{Float64}},
+            MOI.PositiveSemidefiniteConeTriangle
         )
-        @test_throws err @constraint(model, [3, x] in SecondOrderCone())
+    catch e
+        error(replace(e.msg, "JuMP." => ""))
     end
-
-    @testset "Indicator constraint" begin
-        model = ModelType()
-        @variable(model, a, Bin)
-        @variable(model, b, Bin)
-        @variable(model, x)
-        @variable(model, y)
-        for cref in [
-            @constraint(model, a => {x + 2y <= 1}),
-            @constraint(model, a ⇒  {x + 2y ≤ 1})
-        ]
-            c = JuMP.constraint_object(cref)
-            @test c.func == [a, x + 2y]
-            @test c.set == MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(1.0))
-        end
-        for cref in [
-            @constraint(model, !b => {2x + y <= 1});
-            @constraint(model, ¬b ⇒  {2x + y ≤ 1});
-            # This returns a vector of constraints that is concatenated.
-            @constraint(model, ![b, b] .=> {[2x + y, 2x + y] .≤ 1});
-        ]
-            c = JuMP.constraint_object(cref)
-            @test c.func == [b, 2x + y]
-            @test c.set == MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO}(MOI.LessThan(1.0))
-        end
-        err = ErrorException("In `@constraint(model, !(a, b) => {x <= 1})`: Invalid binary variable expression `!(a, b)` for indicator constraint.")
-        @test_macro_throws err @constraint(model, !(a, b) => {x <= 1})
-        err = ErrorException("In `@constraint(model, a => x)`: Invalid right-hand side `x` of indicator constraint. Expected constraint surrounded by `{` and `}`.")
-        @test_macro_throws err @constraint(model, a => x)
-        err = ErrorException("In `@constraint(model, a => x <= 1)`: Invalid right-hand side `x <= 1` of indicator constraint. Expected constraint surrounded by `{` and `}`.")
-        @test_macro_throws err @constraint(model, a => x <= 1)
-        err = ErrorException("In `@constraint(model, a => {x <= 1, x >= 0})`: Invalid right-hand side `{x <= 1, x >= 0}` of indicator constraint. Expected constraint surrounded by `{` and `}`.")
-        @test_macro_throws err @constraint(model, a => {x <= 1, x >= 0})
-        err = ErrorException("In `@constraint(model, [a, b] .=> {x + y <= 1})`: Inconsistent use of `.` in symbols to indicate vectorization.")
-        @test_macro_throws err @constraint(model, [a, b] .=> {x + y <= 1})
+    @test_throws err try
+        all_constraints(
+            model, Vector{GenericAffExpr{Float64}}, MOI.SecondOrderCone
+        )
+    catch e
+        error(replace(e.msg, "JuMP." => ""))
     end
-
-    @testset "SDP constraint" begin
-        m = ModelType()
-        @variable(m, x)
-        @variable(m, y)
-        @variable(m, z)
-        @variable(m, w)
-
-        cref = @constraint(m, [x y; z w] in PSDCone())
-        c = JuMP.constraint_object(cref)
-        @test c.func == [x, z, y, w]
-        @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
-        @test c.shape isa JuMP.SquareMatrixShape
-
-        @constraint(m, sym_ref, Symmetric([x 1; 1 -y] - [1 x; x -2]) in PSDCone())
-        test_constraint_name(sym_ref, "sym_ref", Vector{AffExpr},
-                             MOI.PositiveSemidefiniteConeTriangle)
-        c = JuMP.constraint_object(sym_ref)
-        @test JuMP.isequal_canonical(c.func[1], x-1)
-        @test JuMP.isequal_canonical(c.func[2], 1-x)
-        @test JuMP.isequal_canonical(c.func[3], 2-y)
-        @test c.set == MOI.PositiveSemidefiniteConeTriangle(2)
-        @test c.shape isa JuMP.SymmetricMatrixShape
-
-        @SDconstraint(m, cref, [x 1; 1 -y] ⪰ [1 x; x -2])
-        test_constraint_name(cref, "cref", Vector{AffExpr},
-                             MOI.PositiveSemidefiniteConeSquare)
-        c = JuMP.constraint_object(cref)
-        @test JuMP.isequal_canonical(c.func[1], x-1)
-        @test JuMP.isequal_canonical(c.func[2], 1-x)
-        @test JuMP.isequal_canonical(c.func[3], 1-x)
-        @test JuMP.isequal_canonical(c.func[4], 2-y)
-        @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
-        @test c.shape isa JuMP.SquareMatrixShape
-
-        @SDconstraint(m, iref[i=1:2], 0 ⪯ [x+i x+y; x+y -y])
-        for i in 1:2
-            test_constraint_name(iref[i], "iref[$i]", Vector{AffExpr},
-                                 MOI.PositiveSemidefiniteConeSquare)
-            c = JuMP.constraint_object(iref[i])
-            @test JuMP.isequal_canonical(c.func[1], x+i)
-            @test JuMP.isequal_canonical(c.func[2], x+y)
-            @test JuMP.isequal_canonical(c.func[3], x+y)
-            @test JuMP.isequal_canonical(c.func[4], -y)
-            @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
-            @test c.shape isa JuMP.SquareMatrixShape
-        end
-
-        @SDconstraint(m, con_d, 0 ⪯ Diagonal([x, y]))
-        c = JuMP.constraint_object(con_d)
-        @test c.func isa Vector{AffExprType}
-        @test JuMP.isequal_canonical(c.func[1], 1x)
-        @test iszero(c.func[2])
-        @test iszero(c.func[3])
-        @test JuMP.isequal_canonical(c.func[4], 1y)
-        @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
-
-        @SDconstraint(m, con_d_sym, 0 ⪯ Symmetric(Diagonal([x, y])))
-        c = JuMP.constraint_object(con_d_sym)
-        @test c.func isa Vector{AffExprType}
-        @test JuMP.isequal_canonical(c.func[1], 1x)
-        @test iszero(c.func[2])
-        @test JuMP.isequal_canonical(c.func[3], 1y)
-        @test c.set == MOI.PositiveSemidefiniteConeTriangle(2)
-
-        @SDconstraint(m, con_td, Tridiagonal([z], [x, y], [w]) ⪰ 0)
-        c = JuMP.constraint_object(con_td)
-        @test c.func isa Vector{AffExprType}
-        @test JuMP.isequal_canonical(c.func[1], 1x)
-        @test JuMP.isequal_canonical(c.func[2], 1z)
-        @test JuMP.isequal_canonical(c.func[3], 1w)
-        @test JuMP.isequal_canonical(c.func[4], 1y)
-        @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
-
-        @SDconstraint(m, con_td_sym, Symmetric(Tridiagonal([z], [x, y], [w])) ⪰ 0)
-        c = JuMP.constraint_object(con_td_sym)
-        @test c.func isa Vector{AffExprType}
-        @test JuMP.isequal_canonical(c.func[1], 1x)
-        @test JuMP.isequal_canonical(c.func[2], 1w)
-        @test JuMP.isequal_canonical(c.func[3], 1y)
-        @test c.set == MOI.PositiveSemidefiniteConeTriangle(2)
-
-        @SDconstraint(m, con_ut, UpperTriangular([x y; z w]) ⪰ 0)
-        c = JuMP.constraint_object(con_ut)
-        @test c.func isa Vector{AffExprType}
-        @test JuMP.isequal_canonical(c.func[1], 1x)
-        @test iszero(c.func[2])
-        @test JuMP.isequal_canonical(c.func[3], 1y)
-        @test JuMP.isequal_canonical(c.func[4], 1w)
-        @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
-
-        @SDconstraint(m, con_lt, 0 ⪯ LowerTriangular([x y; z w]))
-        c = JuMP.constraint_object(con_lt)
-        @test c.func isa Vector{AffExprType}
-        @test JuMP.isequal_canonical(c.func[1], 1x)
-        @test JuMP.isequal_canonical(c.func[2], 1z)
-        @test iszero(c.func[3])
-        @test JuMP.isequal_canonical(c.func[4], 1w)
-        @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
-
-        # Should throw "ERROR: function JuMP.add_constraint does not accept keyword arguments"
-        # This tests that the keyword arguments are passed to add_constraint
-        @test_macro_throws ErrorException @SDconstraint(m, [x 1; 1 -y] ⪰ [1 x; x -2], unknown_kw=1)
-        # Invalid sense == in SDP constraint
-        @test_macro_throws ErrorException @SDconstraint(m, [x 1; 1 -y] == [1 x; x -2])
-    end
-
-    @testset "Constraint name" begin
-        model = ModelType()
-        @variable(model, x)
-        @constraint(model, con, x^2 == 1)
-        test_constraint_name(con, "con", QuadExprType, MOI.EqualTo{Float64})
-        JuMP.set_name(con, "kon")
-        @test JuMP.constraint_by_name(model, "con") isa Nothing
-        test_constraint_name(con, "kon", QuadExprType, MOI.EqualTo{Float64})
-        y = @constraint(model, kon, [x^2, x] in SecondOrderCone())
-        err(name) = ErrorException("Multiple constraints have the name $name.")
-        @test_throws err("kon") JuMP.constraint_by_name(model, "kon")
-        JuMP.set_name(kon, "con")
-        test_constraint_name(con, "kon", QuadExprType, MOI.EqualTo{Float64})
-        test_constraint_name(kon, "con", Vector{QuadExprType},
-                             MOI.SecondOrderCone)
-        JuMP.set_name(con, "con")
-        @test_throws err("con") JuMP.constraint_by_name(model, "con")
-        @test JuMP.constraint_by_name(model, "kon") isa Nothing
-        JuMP.set_name(kon, "kon")
-        test_constraint_name(con, "con", QuadExprType, MOI.EqualTo{Float64})
-        test_constraint_name(kon, "kon", Vector{QuadExprType},
-                             MOI.SecondOrderCone)
-    end
-
-    @testset "Useful PSD error message" begin
-        model = ModelType()
-        @variable(model, X[1:2, 1:2])
-        err = ErrorException(
-            "In `@constraint(model, X in MOI.PositiveSemidefiniteConeSquare(2))`:" *
-            " instead of `MathOptInterface.PositiveSemidefiniteConeSquare(2)`," *
-            " use `JuMP.PSDCone()`.")
-        @test_throws err @constraint(model, X in MOI.PositiveSemidefiniteConeSquare(2))
-        err = ErrorException(
-            "In `@constraint(model, X in MOI.PositiveSemidefiniteConeTriangle(2))`:" *
-            " instead of `MathOptInterface.PositiveSemidefiniteConeTriangle(2)`," *
-            " use `JuMP.PSDCone()`.")
-        @test_throws err @constraint(model, X in MOI.PositiveSemidefiniteConeTriangle(2))
-    end
-
-    @testset "Useful Matrix error message" begin
-        model = ModelType()
-        @variable(model, X[1:2, 1:2])
-        err = ErrorException(
-            "In `@constraint(model, X in MOI.SecondOrderCone(4))`: unexpected " *
-            "matrix in vector constraint. Do you need to flatten the matrix " *
-            "into a vector using `vec()`?")
-        # Note: this should apply to any MOI.AbstractVectorSet. We just pick
-        # SecondOrderCone for convenience.
-        @test_throws err @constraint(model, X in MOI.SecondOrderCone(4))
-    end
-
-    @testset "Nonsensical SDPs" begin
-        m = ModelType()
-        @test_throws ErrorException @variable(m, unequal[1:5,1:6], PSD)
-        # Some of these errors happen at compile time, so we can't use @test_throws
-        @test_macro_throws ErrorException @variable(m, notone[1:5,2:6], PSD)
-        @test_macro_throws ErrorException @variable(m, oneD[1:5], PSD)
-        @test_macro_throws ErrorException @variable(m, threeD[1:5,1:5,1:5], PSD)
-        @test_macro_throws ErrorException @variable(m, psd[2] <= rand(2,2), PSD)
-        @test_macro_throws ErrorException @variable(m, -ones(3,4) <= foo[1:4,1:4] <= ones(4,4), PSD)
-        @test_macro_throws ErrorException @variable(m, -ones(3,4) <= foo[1:4,1:4] <= ones(4,4), Symmetric)
-        @test_macro_throws ErrorException @variable(m, -ones(4,4) <= foo[1:4,1:4] <= ones(4,5), Symmetric)
-        @test_macro_throws ErrorException @variable(m, -rand(5,5) <= nonsymmetric[1:5,1:5] <= rand(5,5), Symmetric)
-    end
-
-    @testset "[macros] sum(generator)" begin
-        model = ModelType()
-        @variable(model, x[1:3,1:3])
-        @variable(model, y)
-        C = [1 2 3; 4 5 6; 7 8 9]
-
-        @test_expression sum( C[i,j]*x[i,j] for i in 1:2, j = 2:3 )
-        @test_expression sum( C[i,j]*x[i,j] for i = 1:3, j in 1:3 if i != j) - y
-        @test JuMP.isequal_canonical(@expression(model, sum( C[i,j]*x[i,j] for i = 1:3, j = 1:i)),
-                                                    sum( C[i,j]*x[i,j] for i = 1:3 for j = 1:i))
-        @test_expression sum( C[i,j]*x[i,j] for i = 1:3 for j = 1:i)
-        @test_expression sum( C[i,j]*x[i,j] for i = 1:3 if true for j = 1:i)
-        @test_expression sum( C[i,j]*x[i,j] for i = 1:3 if true for j = 1:i if true)
-        @test_expression sum( 0*x[i,1] for i=1:3)
-        @test_expression sum( 0*x[i,1] + y for i=1:3)
-        @test_expression sum( 0*x[i,1] + y for i=1:3 for j in 1:3)
-    end
+    err = ErrorException("`MathOptInterface.SOS1` is not a " *
+                            "concrete type. Did you miss a type parameter?")
+    @test_throws err all_constraints(
+        model, Vector{GenericQuadExpr{Float64,VariableRef}},
+        MOI.SOS1)
 end
 
-@testset "Constraints for JuMP.Model" begin
-    constraints_test(Model, JuMP.VariableRef)
-    @testset "all_constraints (scalar)" begin
-        model = Model()
-        @variable(model, x >= 0)
-        @test 1 == @inferred num_constraints(model, VariableRef,
-                                             MOI.GreaterThan{Float64})
-        ref = @inferred all_constraints(
-            model, VariableRef, MOI.GreaterThan{Float64})
-        @test ref == [LowerBoundRef(x)]
-        @test 0 == @inferred num_constraints(model, AffExpr,
-                                             MOI.GreaterThan{Float64})
-        aff_constraints = all_constraints(model, AffExpr,
-                                          MOI.GreaterThan{Float64})
-        @test isempty(aff_constraints)
-        err = ErrorException("`MathOptInterface.GreaterThan` is not a " *
-                             "concrete type. Did you miss a type parameter?")
-        @test_throws err num_constraints(model, AffExpr,
-                                         MOI.GreaterThan)
-        @test_throws err all_constraints(model, AffExpr,
-                                         MOI.GreaterThan)
-        err = ErrorException("`GenericAffExpr` is not a concrete type. " *
-                             "Did you miss a type parameter?")
-        @test_throws err num_constraints(model, GenericAffExpr,
-                                         MOI.ZeroOne)
-        @test_throws err all_constraints(model, GenericAffExpr,
-                                         MOI.ZeroOne)
-    end
-    @testset "all_constraints (vector)" begin
-        model = Model()
-        @variable(model, x[1:2, 1:2], Symmetric)
-        csdp = @constraint(model, x in PSDCone())
-        csoc = @constraint(model, [x[1], 1] in SecondOrderCone())
-        csos = @constraint(model, [x[2]^2, 1] in MOI.SOS1([1.0, 2.0]))
-        @test 1 == @inferred num_constraints(
-            model, Vector{VariableRef}, MOI.PositiveSemidefiniteConeTriangle)
-        ref = all_constraints(model, Vector{VariableRef},
-                              MOI.PositiveSemidefiniteConeTriangle)
-        @test ref == [csdp]
-        @test 1 == @inferred num_constraints(
-            model, Vector{AffExpr}, MOI.SecondOrderCone)
-        ref = all_constraints(model, Vector{AffExpr}, MOI.SecondOrderCone)
-        @test ref == [csoc]
-        @test 1 == @inferred num_constraints(
-             model, Vector{QuadExpr}, MOI.SOS1{Float64})
-        ref = all_constraints(model, Vector{QuadExpr}, MOI.SOS1{Float64})
-        @test ref == [csos]
-        @test 0 == @inferred num_constraints(
-            model, Vector{AffExpr}, MOI.PositiveSemidefiniteConeTriangle)
-        aff_constraints = all_constraints(
-            model, Vector{AffExpr}, MOI.PositiveSemidefiniteConeTriangle)
-        @test isempty(aff_constraints)
-        err = ErrorException("`GenericAffExpr{Float64,VarType} where VarType`" *
-                             " is not a concrete type. Did you miss a type " *
-                             "parameter?")
-        @test_throws err num_constraints(
-            model, Vector{GenericAffExpr{Float64}},
-            MOI.PositiveSemidefiniteConeTriangle)
-        @test_throws err all_constraints(
-            model, Vector{GenericAffExpr{Float64}},
-            MOI.SecondOrderCone)
-        err = ErrorException("`MathOptInterface.SOS1` is not a " *
-                             "concrete type. Did you miss a type parameter?")
-        @test_throws err all_constraints(
-            model, Vector{GenericQuadExpr{Float64,VariableRef}},
-            MOI.SOS1)
-    end
-    @testset "list_of_constraint_types" begin
-        model = Model()
-        @variable(model, x >= 0, Bin)
-        @constraint(model, 2x <= 1)
-        @constraint(model, [x, x] in SecondOrderCone())
-        @constraint(model, [2x  1; 1 x] in PSDCone())
-        @constraint(model, [x^2, x] in RotatedSecondOrderCone())
-        constraint_types = @inferred list_of_constraint_types(model)
-        @test Set(constraint_types) == Set([(VariableRef, MOI.ZeroOne),
-            (VariableRef, MOI.GreaterThan{Float64}),
-            (AffExpr, MOI.LessThan{Float64}),
-            (Vector{VariableRef}, MOI.SecondOrderCone),
-            (Vector{AffExpr}, MOI.PositiveSemidefiniteConeSquare),
-            (Vector{QuadExpr}, MOI.RotatedSecondOrderCone)])
-    end
+function test_Model_list_of_constraint_types(::Any, ::Any)
+    model = Model()
+    @variable(model, x >= 0, Bin)
+    @constraint(model, 2x <= 1)
+    @constraint(model, [x, x] in SecondOrderCone())
+    @constraint(model, [2x  1; 1 x] in PSDCone())
+    @constraint(model, [x^2, x] in RotatedSecondOrderCone())
+    constraint_types = @inferred list_of_constraint_types(model)
+    @test Set(constraint_types) == Set([(VariableRef, MOI.ZeroOne),
+        (VariableRef, MOI.GreaterThan{Float64}),
+        (AffExpr, MOI.LessThan{Float64}),
+        (Vector{VariableRef}, MOI.SecondOrderCone),
+        (Vector{AffExpr}, MOI.PositiveSemidefiniteConeSquare),
+        (Vector{QuadExpr}, MOI.RotatedSecondOrderCone)])
 end
 
-@testset "Constraints for JuMPExtension.MyModel" begin
-    constraints_test(JuMPExtension.MyModel, JuMPExtension.MyVariableRef)
-end
-
-@testset "Modifications" begin
-    @testset "Change coefficient" begin
-        model = JuMP.Model()
-        x = @variable(model)
-        con_ref = @constraint(model, 2 * x == -1)
-        @test JuMP.normalized_coefficient(con_ref, x) == 2.0
-        JuMP.set_normalized_coefficient(con_ref, x, 1.0)
-        @test JuMP.normalized_coefficient(con_ref, x) == 1.0
-        JuMP.set_normalized_coefficient(con_ref, x, 3)  # Check type promotion.
-        @test JuMP.normalized_coefficient(con_ref, x) == 3.0
-        quad_con = @constraint(model, x^2 == 0)
-        @test JuMP.normalized_coefficient(quad_con, x) == 0.0
-        JuMP.set_normalized_coefficient(quad_con, x, 2)
-        @test JuMP.normalized_coefficient(quad_con, x) == 2.0
-        @test JuMP.isequal_canonical(
-            JuMP.constraint_object(quad_con).func, x^2 + 2x)
-    end
-
-    @testset "Change rhs" begin
-        model = JuMP.Model()
-        x = @variable(model)
-        con_ref = @constraint(model, 2 * x <= 1)
-        @test JuMP.normalized_rhs(con_ref) == 1.0
-        JuMP.set_normalized_rhs(con_ref, 2.0)
-        @test JuMP.normalized_rhs(con_ref) == 2.0
-        con_ref = @constraint(model, 2 * x - 1 == 1)
-        @test JuMP.normalized_rhs(con_ref) == 2.0
-        JuMP.set_normalized_rhs(con_ref, 3)
-        @test JuMP.normalized_rhs(con_ref) == 3.0
-        con_ref = @constraint(model, 0 <= 2 * x <= 1)
-        @test_throws MethodError JuMP.set_normalized_rhs(con_ref, 3)
-    end
-
-    @testset "Add to function constant" begin
-        model = JuMP.Model()
-        x = @variable(model)
-        @testset "Scalar" begin
-            con_ref = @constraint(model, 2 <= 2 * x <= 3)
-            con = constraint_object(con_ref)
-            @test JuMP.isequal_canonical(JuMP.jump_function(con), 2x)
-            @test JuMP.moi_set(con) == MOI.Interval(2.0, 3.0)
-            JuMP.add_to_function_constant(con_ref, 1.0)
-            con = constraint_object(con_ref)
-            @test JuMP.isequal_canonical(JuMP.jump_function(con), 2x)
-            @test JuMP.moi_set(con) == MOI.Interval(1.0, 2.0)
-        end
-        @testset "Vector" begin
-            con_ref = @constraint(model, [x + 1, x - 1] in MOI.Nonnegatives(2))
-            con = constraint_object(con_ref)
-            @test JuMP.isequal_canonical(JuMP.jump_function(con), [x + 1, x - 1])
-            @test JuMP.moi_set(con) == MOI.Nonnegatives(2)
-            JuMP.add_to_function_constant(con_ref, [2, 3])
-            con = constraint_object(con_ref)
-            @test JuMP.isequal_canonical(JuMP.jump_function(con), [x + 3, x + 2])
-            @test JuMP.moi_set(con) == MOI.Nonnegatives(2)
-        end
-    end
-
-end
-
-function test_shadow_price(model_string, constraint_dual, constraint_shadow)
+function test_Model_change_coefficient(::Any, ::Any)
     model = JuMP.Model()
-    MOIU.loadfromstring!(JuMP.backend(model), model_string)
-    set_optimizer(model, () -> MOIU.MockOptimizer(
-                                MOIU.Model{Float64}(),
-                                eval_objective_value=false,
-                                eval_variable_constraint_dual=false))
+    x = @variable(model)
+    con_ref = @constraint(model, 2 * x == -1)
+    @test JuMP.normalized_coefficient(con_ref, x) == 2.0
+    JuMP.set_normalized_coefficient(con_ref, x, 1.0)
+    @test JuMP.normalized_coefficient(con_ref, x) == 1.0
+    JuMP.set_normalized_coefficient(con_ref, x, 3)  # Check type promotion.
+    @test JuMP.normalized_coefficient(con_ref, x) == 3.0
+    quad_con = @constraint(model, x^2 == 0)
+    @test JuMP.normalized_coefficient(quad_con, x) == 0.0
+    JuMP.set_normalized_coefficient(quad_con, x, 2)
+    @test JuMP.normalized_coefficient(quad_con, x) == 2.0
+    @test JuMP.isequal_canonical(
+        JuMP.constraint_object(quad_con).func, x^2 + 2x)
+end
+
+function test_Model_change_rhs(::Any, ::Any)
+    model = JuMP.Model()
+    x = @variable(model)
+    con_ref = @constraint(model, 2 * x <= 1)
+    @test JuMP.normalized_rhs(con_ref) == 1.0
+    JuMP.set_normalized_rhs(con_ref, 2.0)
+    @test JuMP.normalized_rhs(con_ref) == 2.0
+    con_ref = @constraint(model, 2 * x - 1 == 1)
+    @test JuMP.normalized_rhs(con_ref) == 2.0
+    JuMP.set_normalized_rhs(con_ref, 3)
+    @test JuMP.normalized_rhs(con_ref) == 3.0
+    con_ref = @constraint(model, 0 <= 2 * x <= 1)
+    @test_throws MethodError JuMP.set_normalized_rhs(con_ref, 3)
+end
+
+function test_Model_add_to_function_constant_scalar(::Any, ::Any)
+    model = JuMP.Model()
+    x = @variable(model)
+    con_ref = @constraint(model, 2 <= 2 * x <= 3)
+    con = constraint_object(con_ref)
+    @test JuMP.isequal_canonical(JuMP.jump_function(con), 2x)
+    @test JuMP.moi_set(con) == MOI.Interval(2.0, 3.0)
+    JuMP.add_to_function_constant(con_ref, 1.0)
+    con = constraint_object(con_ref)
+    @test JuMP.isequal_canonical(JuMP.jump_function(con), 2x)
+    @test JuMP.moi_set(con) == MOI.Interval(1.0, 2.0)
+end
+
+function test_Model_add_to_function_constant_vector(::Any, ::Any)
+    model = JuMP.Model()
+    x = @variable(model)
+    con_ref = @constraint(model, [x + 1, x - 1] in MOI.Nonnegatives(2))
+    con = constraint_object(con_ref)
+    @test JuMP.isequal_canonical(JuMP.jump_function(con), [x + 1, x - 1])
+    @test JuMP.moi_set(con) == MOI.Nonnegatives(2)
+    JuMP.add_to_function_constant(con_ref, [2, 3])
+    con = constraint_object(con_ref)
+    @test JuMP.isequal_canonical(JuMP.jump_function(con), [x + 3, x + 2])
+    @test JuMP.moi_set(con) == MOI.Nonnegatives(2)
+end
+
+function _test_shadow_price_util(model_string, constraint_dual, constraint_shadow)
+    model = Model()
+    MOIU.loadfromstring!(backend(model), model_string)
+    set_optimizer(
+        model,
+        () -> MOIU.MockOptimizer(
+            MOIU.Model{Float64}();
+            eval_objective_value = false,
+            eval_variable_constraint_dual = false
+        )
+    )
     JuMP.optimize!(model)
     mock_optimizer = JuMP.backend(model).optimizer.model
     MOI.set(mock_optimizer, MOI.TerminationStatus(), MOI.OPTIMAL)
     MOI.set(mock_optimizer, MOI.DualStatus(), MOI.FEASIBLE_POINT)
     JuMP.optimize!(model)
-
-    @testset "shadow price of $constraint_name" for constraint_name in keys(constraint_dual)
-        ci = MOI.get(JuMP.backend(model), MOI.ConstraintIndex,
-                     constraint_name)
+    for constraint_name in keys(constraint_dual)
+        ci = MOI.get(backend(model), MOI.ConstraintIndex, constraint_name)
         constraint_ref = JuMP.ConstraintRef(model, ci, JuMP.ScalarShape())
-        MOI.set(mock_optimizer, MOI.ConstraintDual(),
-                JuMP.optimizer_index(constraint_ref),
-                constraint_dual[constraint_name])
-        @test JuMP.dual(constraint_ref) ==
-              constraint_dual[constraint_name]
-        @test JuMP.shadow_price(constraint_ref) ==
-              constraint_shadow[constraint_name]
+        MOI.set(
+            mock_optimizer,
+            MOI.ConstraintDual(),
+            JuMP.optimizer_index(constraint_ref),
+            constraint_dual[constraint_name]
+        )
+        @test dual(constraint_ref) == constraint_dual[constraint_name]
+        @test shadow_price(constraint_ref) == constraint_shadow[constraint_name]
     end
 end
 
-@testset "shadow_price" begin
-    test_shadow_price("""
-    variables: x, y
-    minobjective: -1.0*x
-    xub: x <= 2.0
-    ylb: y >= 0.0
-    c: x + y <= 1.0
-    """,
-    # Optimal duals
-    Dict("xub" => 0.0, "ylb" => 1.0, "c" => -1.0),
-    # Expected shadow prices
-    Dict("xub" => 0.0, "ylb" => -1.0, "c" => -1.0))
+function test_Model_shadow_price(::Any, ::Any)
+    _test_shadow_price_util(
+        """
+        variables: x, y
+        minobjective: -1.0*x
+        xub: x <= 2.0
+        ylb: y >= 0.0
+        c: x + y <= 1.0
+        """,
+        Dict("xub" => 0.0, "ylb" => 1.0, "c" => -1.0),
+        Dict("xub" => 0.0, "ylb" => -1.0, "c" => -1.0)
+    )
 
-    test_shadow_price("""
-    variables: x, y
-    maxobjective: 1.0*x
-    xub: x <= 2.0
-    ylb: y >= 0.0
-    c: x + y <= 1.0
-    """,
-    # Optimal duals
-    Dict("xub" => 0.0, "ylb" => 1.0, "c" => -1.0),
-    # Expected shadow prices
-    Dict("xub" => 0.0, "ylb" => 1.0, "c" => 1.0))
+    _test_shadow_price_util(
+        """
+        variables: x, y
+        maxobjective: 1.0*x
+        xub: x <= 2.0
+        ylb: y >= 0.0
+        c: x + y <= 1.0
+        """,
+        Dict("xub" => 0.0, "ylb" => 1.0, "c" => -1.0),
+        Dict("xub" => 0.0, "ylb" => 1.0, "c" => 1.0)
+    )
 
-    test_shadow_price("""
-    variables: x, y
-    maxobjective: 1.0*x
-    xub: x <= 2.0
-    ylb: y >= 0.0
-    """,
-    # Optimal duals
-    Dict("xub" => -1.0, "ylb" => 0.0),
-    # Expected shadow prices
-    Dict("xub" => 1.0, "ylb" => 0.0))
+    _test_shadow_price_util(
+        """
+        variables: x, y
+        maxobjective: 1.0*x
+        xub: x <= 2.0
+        ylb: y >= 0.0
+        """,
+        Dict("xub" => -1.0, "ylb" => 0.0),
+        Dict("xub" => 1.0, "ylb" => 0.0)
+    )
 
-    test_shadow_price("""
-    variables: x
-    maxobjective: 1.0*x
-    xeq: x == 2.0
-    """,
-    # Optimal duals
-    Dict("xeq" => -1.0),
-    # Expected shadow prices
-    Dict("xeq" => 1.0))
+    _test_shadow_price_util(
+        """
+        variables: x
+        maxobjective: 1.0*x
+        xeq: x == 2.0
+        """,
+        Dict("xeq" => -1.0),
+        Dict("xeq" => 1.0)
+    )
 
-    test_shadow_price("""
-    variables: x
-    minobjective: 1.0*x
-    xeq: x == 2.0
-    """,
-    # Optimal duals
-    Dict("xeq" => 1.0),
-    # Expected shadow prices
-    Dict("xeq" => -1.0))
+    _test_shadow_price_util(
+        """
+        variables: x
+        minobjective: 1.0*x
+        xeq: x == 2.0
+        """,
+        Dict("xeq" => 1.0),
+        Dict("xeq" => -1.0)
+    )
 end
+
+function runtests()
+    @testset "constraint.jl" begin
+        for name in names(@__MODULE__; all = true)
+            if !startswith("$(name)", "test_")
+                continue
+            end
+            f = getfield(@__MODULE__, name)
+            @testset "$(name)" begin
+                f(Model, VariableRef)
+            end
+            if !startswith("$(name)", "test_Model_")
+                @testset "$(name)-JuMPExtension" begin
+                    f(JuMPExtension.MyModel, JuMPExtension.MyVariableRef)
+                end
+            end
+        end
+    end
+end
+
+end
+
+TestConstraint.runtests()

--- a/test/derivatives_coloring.jl
+++ b/test/derivatives_coloring.jl
@@ -1,10 +1,13 @@
 using Test
 
-import JuMP._Derivatives.Coloring: acyclic_coloring, recovery_preprocess,
-                                   reverse_topological_sort_by_dfs,
-                                   gen_adjlist, hessian_color_preprocess,
-                                   prepare_seed_matrix!, recover_from_matmat!,
-                                   seed_matrix
+import JuMP._Derivatives.Coloring:
+    acyclic_coloring, recovery_preprocess,
+    reverse_topological_sort_by_dfs,
+    gen_adjlist,
+    hessian_color_preprocess,
+    prepare_seed_matrix!,
+    recover_from_matmat!,
+    seed_matrix
 
 struct Graph
     num_vertices::Int

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -1,5 +1,13 @@
-import MutableArithmetics
-const MA = MutableArithmetics
+using JuMP
+using Test
+
+const MA = JuMP._MA
+
+include(joinpath(@__DIR__, "utilities.jl"))
+
+@static if !(:JuMPExtension in names(Main))
+    include(joinpath(@__DIR__, "JuMPExtension.jl"))
+end
 
 # For "expression^3 and unary*"
 struct PowVariable <: JuMP.AbstractVariableRef

--- a/test/file_formats.jl
+++ b/test/file_formats.jl
@@ -6,87 +6,54 @@
 using JuMP
 using Test
 
+function test_mof_file()
+    model = Model()
+    @variable(model, x)
+    @constraint(model, my_c, 3 * x >= 1)
+    @objective(model, Min, 2 * x^2 + x + 1)
+    write_to_file(model, "my_model.mof.json")
+    model_2 = read_from_file("my_model.mof.json")
+    @test sprint(print, model) == sprint(print, model_2)
+    rm("my_model.mof.json")
+end
+
+function test_mof_io()
+    model = Model()
+    @variable(model, x)
+    @constraint(model, my_c, 3 * x >= 1)
+    @objective(model, Min, 2 * x^2 + x + 1)
+    io = IOBuffer()
+    @test_throws(
+        ErrorException("Unable to infer the file format from an IO stream."),
+        write(io, model; format = MOI.FileFormats.FORMAT_AUTOMATIC)
+    )
+    write(io, model; format = MOI.FileFormats.FORMAT_MOF)
+    seekstart(io)
+    @test_throws(
+        ErrorException("Unable to infer the file format from an IO stream."),
+        read(io, Model; format = MOI.FileFormats.FORMAT_AUTOMATIC)
+    )
+    seekstart(io)
+    model_2 = read(io, Model; format = MOI.FileFormats.FORMAT_MOF)
+    @test sprint(print, model) == sprint(print, model_2)
+end
+
+function test_mof_nlp()
+    model = Model()
+    @variable(model, x)
+    @variable(model, y)
+    @NLobjective(model, Min, (1 - x)^2 + 100 * (y - x^2)^2)
+    @NLconstraint(model, x^2 + y^2 <= 100.0)
+    @constraint(model, x + y == 10)
+    io = IOBuffer()
+    write(io, model; format = MOI.FileFormats.FORMAT_MOF)
+    seekstart(io)
+    @test read(io, String) ==
+        read(joinpath(@__DIR__, "data", "nlp_model.mof.json"), String)
+end
+
 @testset "File formats" begin
-    @testset "MOF" begin
-        model = Model()
-        @variable(model, x)
-        @constraint(model, my_c, 3 * x >= 1)
-        @objective(model, Min, 2 * x^2 + x + 1)
-        write_to_file(model, "my_model.mof.json")
-        model_2 = read_from_file("my_model.mof.json")
-        @test sprint(print, model) == sprint(print, model_2)
-        rm("my_model.mof.json")
-    end
-    @testset "MPS" begin
-        model = Model()
-        @variable(model, x >= 0)
-        @constraint(model, my_c, 3 * x >= 1)
-        @objective(model, Min, 2 * x)
-        write_to_file(model, "my_model.mps")
-        model_2 = read_from_file("my_model.mps")
-        @test sprint(print, model) == sprint(print, model_2)
-        rm("my_model.mps")
-    end
-    @testset "LP" begin
-        model = Model()
-        @variable(model, x >= 0)
-        @constraint(model, my_c, 3 * x >= 1)
-        @objective(model, Min, 2 * x)
-        write_to_file(model, "my_model.lp")
-        @test read("my_model.lp", String) ==
-            "minimize\nobj: 2 x\nsubject to\nmy_c: 3 x >= 1\nBounds\nx >= 0\nEnd\n"
-        @test_throws(
-            ErrorException("read! is not implemented for LP files."),
-            read_from_file("my_model.lp")
-        )
-        rm("my_model.lp")
-    end
-    @testset "CBF" begin
-        model = Model()
-        @variable(model, X[1:2, 1:2], PSD)
-        @constraint(model, my_c, sum(X) >= 1)
-        @objective(model, Min, sum(X))
-        write_to_file(model, "my_model.cbf")
-        @test read("my_model.cbf", String) ==
-            "VER\n3\n\nOBJSENSE\nMIN\n\nVAR\n3 1\nF 3\n\nOBJACOORD\n3\n0 1.0\n1 2.0\n2 1.0\n\nCON\n1 1\nL+ 1\n\nACOORD\n3\n0 0 1.0\n0 1 2.0\n0 2 1.0\n\nBCOORD\n1\n0 -1.0\n\nPSDCON\n1\n2\n\nHCOORD\n3\n0 0 0 0 1.0\n0 1 1 0 1.0\n0 2 1 1 1.0\n\n"
-        model_2 = read_from_file("my_model.cbf")
-        # Note: we replace ' in ' => ' ∈ ' because the unicode doesn't print on
-        # Windows systems for some reason.
-        @test replace(sprint(print, model_2), " in " => " ∈ ") ==
-            "Min noname + 2 noname + noname\nSubject to\n [noname + 2 noname + noname - 1] ∈ MathOptInterface.Nonnegatives(1)\n [noname, noname, noname] ∈ MathOptInterface.PositiveSemidefiniteConeTriangle(2)\n"
-        rm("my_model.cbf")
-    end
-    @testset "Base read/write via io" begin
-        model = Model()
-        @variable(model, x)
-        @constraint(model, my_c, 3 * x >= 1)
-        @objective(model, Min, 2 * x^2 + x + 1)
-        io = IOBuffer()
-        @test_throws(
-            ErrorException("Unable to infer the file format from an IO stream."),
-            write(io, model; format = MOI.FileFormats.FORMAT_AUTOMATIC)
-        )
-        write(io, model; format = MOI.FileFormats.FORMAT_MOF)
-        seekstart(io)
-        @test_throws(
-            ErrorException("Unable to infer the file format from an IO stream."),
-            read(io, Model; format = MOI.FileFormats.FORMAT_AUTOMATIC)
-        )
-        seekstart(io)
-        model_2 = read(io, Model; format = MOI.FileFormats.FORMAT_MOF)
-        @test sprint(print, model) == sprint(print, model_2)
-    end
-    @testset "NLP MOF" begin
-        model = Model()
-        @variable(model, x)
-        @variable(model, y)
-        @NLobjective(model, Min, (1 - x)^2 + 100 * (y - x^2)^2)
-        @NLconstraint(model, x^2 + y^2 <= 100.0)
-        @constraint(model, x + y == 10)
-        io = IOBuffer()
-        write(io, model; format = MOI.FileFormats.FORMAT_MOF)
-        seekstart(io)
-        @test read(io, String) ==
-            read(joinpath(@__DIR__, "data", "nlp_model.mof.json"), String)
-    end
+    test_mof_file()
+    test_mof_io()
+    test_mof_nlp()
 end

--- a/test/lp_sensitivity.jl
+++ b/test/lp_sensitivity.jl
@@ -7,6 +7,10 @@
 # An algebraic modeling language for Julia
 # See http://github.com/jump-dev/JuMP.jl
 #############################################################################
+
+using JuMP
+using Test
+
 function test_lp_rhs_perturbation_range(model_string, primal_solution, basis_status, feasibility_ranges)
     model = JuMP.Model()
     MOIU.loadfromstring!(JuMP.backend(model), model_string)

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -11,8 +11,16 @@
 # Testing for macros
 #############################################################################
 
-import MutableArithmetics
-const MA = MutableArithmetics
+using JuMP
+using Test
+
+const MA = JuMP._MA
+
+include(joinpath(@__DIR__, "utilities.jl"))
+
+@static if !(:JuMPExtension in names(Main))
+    include(joinpath(@__DIR__, "JuMPExtension.jl"))
+end
 
 @testset "Check Julia generator expression parsing" begin
     sumexpr = :(sum(x[i,j] * y[i,j] for i = 1:N, j in 1:M if i != j))

--- a/test/model.jl
+++ b/test/model.jl
@@ -10,8 +10,9 @@
 # test/model.jl
 #############################################################################
 
-using JuMP
+module TestModel
 
+using JuMP
 using Test
 
 # Simple LP model not supporting Interval
@@ -21,36 +22,9 @@ MOIU.@model(
     (), (MOI.ScalarAffineFunction,), (), ()
 )
 
-struct Optimizer
-    a::Int
-    b::Int
-end
-function opt_build(a::Int; b::Int = 1)
-    return Optimizer(a, b)
-end
-
-# Custom set Nonnegative with bridge NonnegativeBridge
 include("nonnegative_bridge.jl")
 
-function test_result_attributes(; test_empty = false)
-    err = JuMP.OptimizeNotCalled()
-    model = Model(() -> MOIU.MockOptimizer(SimpleLPModel{Float64}()))
-    @variable(model, x)
-    c = @constraint(model, x ≤ 0)
-    @objective(model, Max, x)
-    if test_empty
-        optimize!(model)
-        empty!(model)
-    end
-    @test_throws err JuMP.objective_value(model)
-    @test_throws err JuMP.dual_objective_value(model)
-    @test_throws err JuMP.objective_bound(model)
-    @test_throws err JuMP.value(x)
-    @test_throws err JuMP.value(c)
-    @test_throws err JuMP.dual(c)
-end
-
-function fill_small_test_model!(model)
+function _fill_small_test_model!(model)
     # The model does not need to make sense, just use many different features.
     @variable(model, a[1:5] >= 0, Int)
     @variable(model, b[6:10], Bin)
@@ -64,233 +38,259 @@ function fill_small_test_model!(model)
     return model
 end
 
-function test_model()
-    @testset "NoOptimizer" begin
-        err = NoOptimizer()
-        model = Model()
-        @variable(model, x)
-        @test_throws err optimizer_index(x)
-        cref = @constraint(model, x == 1)
-        @test_throws err JuMP.optimizer_index(cref)
-        @test_throws err JuMP.optimize!(model)
-        @test_throws err JuMP.value(x)
-        @test_throws err JuMP.value(cref)
-        @test_throws err JuMP.dual(cref)
-    end
+function test_NoOptimizer()
+    err = NoOptimizer()
+    model = Model()
+    @variable(model, x)
+    @test_throws err optimizer_index(x)
+    cref = @constraint(model, x == 1)
+    @test_throws err JuMP.optimizer_index(cref)
+    @test_throws err JuMP.optimize!(model)
+    @test_throws err JuMP.value(x)
+    @test_throws err JuMP.value(cref)
+    @test_throws err JuMP.dual(cref)
+end
 
-    @testset "Result attributes" begin
-        test_result_attributes()
-    end
+function test_result_attributes()
+    err = JuMP.OptimizeNotCalled()
+    model = Model(() -> MOIU.MockOptimizer(SimpleLPModel{Float64}()))
+    @variable(model, x)
+    c = @constraint(model, x ≤ 0)
+    @objective(model, Max, x)
+    @test_throws err JuMP.objective_value(model)
+    @test_throws err JuMP.dual_objective_value(model)
+    @test_throws err JuMP.objective_bound(model)
+    @test_throws err JuMP.value(x)
+    @test_throws err JuMP.value(c)
+    @test_throws err JuMP.dual(c)
+end
 
-    @testset "Result attributes after empty!" begin
-        test_result_attributes(test_empty = true)
-    end
+function test_result_attributes_after_empty()
+    err = JuMP.OptimizeNotCalled()
+    model = Model(() -> MOIU.MockOptimizer(SimpleLPModel{Float64}()))
+    @variable(model, x)
+    c = @constraint(model, x ≤ 0)
+    @objective(model, Max, x)
+    optimize!(model)
+    empty!(model)
+    @test_throws err JuMP.objective_value(model)
+    @test_throws err JuMP.dual_objective_value(model)
+    @test_throws err JuMP.objective_bound(model)
+    @test_throws err JuMP.value(x)
+    @test_throws err JuMP.value(c)
+    @test_throws err JuMP.dual(c)
+end
 
-    @testset "empty!(model)" begin
-        model = Model()
-        backend_type = typeof(backend(model))
-        model.optimize_hook === nothing
-        hook(m) = nothing
-        JuMP.set_optimize_hook(model, hook)
-        @test model.optimize_hook === hook
-        @test fill_small_test_model!(model) === model
-        @test_throws ErrorException fill_small_test_model!(model)
-        @test empty!(model) === model
-        @test model.optimize_hook === hook # empty! does not touch the hook
-        @test isa(backend(model), backend_type)
-        @test fill_small_test_model!(model) === model
-    end
+function test_empty!()
+    model = Model()
+    backend_type = typeof(backend(model))
+    model.optimize_hook === nothing
+    hook(m) = nothing
+    JuMP.set_optimize_hook(model, hook)
+    @test model.optimize_hook === hook
+    @test _fill_small_test_model!(model) === model
+    @test_throws ErrorException _fill_small_test_model!(model)
+    @test empty!(model) === model
+    @test model.optimize_hook === hook # empty! does not touch the hook
+    @test isa(backend(model), backend_type)
+    @test _fill_small_test_model!(model) === model
+end
 
-    @testset "Test variable/model 'hygiene'" begin
-        model_x = Model()
-        @variable(model_x, x)
-        model_y = Model()
-        @variable(model_y, y)
-        err = JuMP.VariableNotOwned(y)
-        @testset "Variable" begin
-            @testset "constraint" begin
-                @test_throws err @constraint(model_x, y in MOI.EqualTo(1.0))
-                @test_throws err @constraint(model_x, [x, y] in MOI.Zeros(2))
-            end
-            @testset "objective" begin
-                @test_throws err @objective(model_x, Min, y)
-            end
+function test_variable_model_hygiene()
+    model_x = Model()
+    @variable(model_x, x)
+    model_y = Model()
+    @variable(model_y, y)
+    err = JuMP.VariableNotOwned(y)
+    @testset "Variable" begin
+        @testset "constraint" begin
+            @test_throws err @constraint(model_x, y in MOI.EqualTo(1.0))
+            @test_throws err @constraint(model_x, [x, y] in MOI.Zeros(2))
         end
-        @testset "Linear" begin
-            @testset "constraint" begin
-                @test_throws err @constraint(model_x, x + y == 1)
-                @test_throws err begin
-                    @constraint(model_x, [x, x + y] in MOI.Zeros(2))
-                end
-                @test_throws err begin
-                    @constraint(model_x, [x + y, x] in MOI.Zeros(2))
-                end
-            end
-            @testset "objective" begin
-                @test_throws err @objective(model_x, Min, x + y)
-            end
-        end
-        @testset "Quadratic" begin
-            @testset "constraint" begin
-                @test_throws err @constraint(model_x, x * y >= 1)
-                @test_throws err begin
-                    @constraint(model_x, [x, x * y] in MOI.Zeros(2))
-                end
-                @test_throws err begin
-                    @constraint(model_x, [x * y, x] in MOI.Zeros(2))
-                end
-                @test_throws err @constraint(model_x, x * x + x + y <= 1)
-                @test_throws err begin
-                    @constraint(model_x, [x, x * x + x + y] in MOI.Zeros(2))
-                end
-                @test_throws err begin
-                    @constraint(model_x, [x * x + x + y, x] in MOI.Zeros(2))
-                end
-            end
-            @testset "objective" begin
-                @test_throws err @objective(model_x, Min, x * y)
-                @test_throws err @objective(model_x, Min, x * x + x + y)
-            end
-        end
-        @testset "Attribute" begin
-            cy = @constraint(model_y, y in MOI.EqualTo(1.0))
-            cerr = JuMP.ConstraintNotOwned(cy)
-            @testset "get" begin
-                @test_throws err begin
-                    MOI.get(model_x, MOI.VariablePrimalStart(), y)
-                end
-                @test_throws cerr begin
-                    MOI.get(model_x, MOI.ConstraintPrimalStart(), cy)
-                end
-            end
-            @testset "set" begin
-                @test_throws err begin
-                    MOI.set(model_x, MOI.VariablePrimalStart(), y, 1.0)
-                end
-                @test_throws cerr begin
-                    MOI.set(model_x, MOI.ConstraintPrimalStart(), cy, 1.0)
-                end
-            end
+        @testset "objective" begin
+            @test_throws err @objective(model_x, Min, y)
         end
     end
-
-    @testset "optimize_hook" begin
-        m = Model()
-        @test m.optimize_hook === nothing
-        called = false
-        function hook(m)
-            called = true
-        end
-        JuMP.set_optimize_hook(m, hook)
-        @test !called
-        optimize!(m)
-        @test called
-
-        m = Model()
-        err = ErrorException("Unrecognized keyword arguments: unexpected_arg")
-        @test_throws err optimize!(m, unexpected_arg=1)
-        JuMP.set_optimize_hook(m, (m ; my_new_arg=nothing) -> my_new_arg)
-        @test optimize!(m) === nothing
-        @test optimize!(m, my_new_arg = 1) == 1
-    end
-
-    @testset "UniversalFallback" begin
-        m = Model()
-        MOI.set(m, MOI.Test.UnknownModelAttribute(), 1)
-        @test MOI.get(m, MOI.Test.UnknownModelAttribute()) == 1
-    end
-
-    @testset "Bridges" begin
-        @testset "Automatic bridging" begin
-            # optimizer not supporting Interval
-            model = Model(() -> MOIU.MockOptimizer(SimpleLPModel{Float64}()))
-            @test JuMP.bridge_constraints(model)
-            @test JuMP.backend(model) isa MOIU.CachingOptimizer
-            @test JuMP.backend(model).optimizer isa MOI.Bridges.LazyBridgeOptimizer
-            @test JuMP.backend(model).optimizer.model isa MOIU.MockOptimizer
-            @variable model x
-            cref = @constraint model 0 <= x + 1 <= 1
-            @test cref isa JuMP.ConstraintRef{JuMP.Model,MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.Interval{Float64}}}
-            JuMP.optimize!(model)
-        end
-        @testset "Automatic bridging with cache for bridged model" begin
-            # optimizer not supporting Interval and not supporting `default_copy_to`
-            model = Model(() -> MOIU.MockOptimizer(SimpleLPModel{Float64}(),
-                                                   needs_allocate_load=true))
-            @test JuMP.bridge_constraints(model)
-            @test JuMP.backend(model) isa MOIU.CachingOptimizer
-            @test JuMP.backend(model).optimizer isa MOI.Bridges.LazyBridgeOptimizer
-            @test JuMP.backend(model).optimizer.model isa MOIU.CachingOptimizer
-            @test JuMP.backend(model).optimizer.model.optimizer isa MOIU.MockOptimizer
-            @variable model x
-            err = ErrorException(
-                "There is no `optimizer_index` as the optimizer is not " *
-                "synchronized with the cached model. Call " *
-                "`MOIU.attach_optimizer(model)` to synchronize it.")
-            @test_throws err optimizer_index(x)
-            cref = @constraint model 0 <= x + 1 <= 1
-            @test cref isa JuMP.ConstraintRef{JuMP.Model,MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.Interval{Float64}}}
-            @test_throws err optimizer_index(cref)
-            JuMP.optimize!(model)
-            err = ErrorException(
-                "There is no `optimizer_index` for $(typeof(index(cref))) " *
-                "constraints because they are bridged.")
-            @test_throws err optimizer_index(cref)
-        end
-        @testset "Automatic bridging disabled with `bridge_constraints` keyword" begin
-            model = Model(() -> MOIU.MockOptimizer(SimpleLPModel{Float64}()),
-                          bridge_constraints=false)
-            @test !JuMP.bridge_constraints(model)
-            @test JuMP.backend(model) isa MOIU.CachingOptimizer
-            @test !(JuMP.backend(model).optimizer isa MOI.Bridges.LazyBridgeOptimizer)
-            @variable model x
-            err = ErrorException("Constraints of type MathOptInterface.ScalarAffineFunction{Float64}-in-MathOptInterface.Interval{Float64} are not supported by the solver, try using `bridge_constraints=true` in the `JuMP.Model` constructor if you believe the constraint can be reformulated to constraints supported by the solver.")
-            @test_throws err @constraint model 0 <= x + 1 <= 1
-        end
-        @testset "No bridge automatically added in Direct mode" begin
-            optimizer = MOIU.MockOptimizer(SimpleLPModel{Float64}())
-            model = JuMP.direct_model(optimizer)
-            @test !JuMP.bridge_constraints(model)
-            @variable model x
-            err = ErrorException("Constraints of type MathOptInterface.ScalarAffineFunction{Float64}-in-MathOptInterface.Interval{Float64} are not supported by the solver.")
-            @test_throws err @constraint model 0 <= x + 1 <= 1
-        end
-
-        @testset "Add bridge" begin
-            function mock_factory()
-                mock = MOIU.MockOptimizer(MOIU.Model{Float64}(),
-                                          eval_variable_constraint_dual=false)
-                optimize!(mock) = MOIU.mock_optimize!(mock, [1.0],
-                        (MOI.SingleVariable, MOI.GreaterThan{Float64}) => [2.0])
-                MOIU.set_mock_optimize!(mock, optimize!)
-                return mock
+    @testset "Linear" begin
+        @testset "constraint" begin
+            @test_throws err @constraint(model_x, x + y == 1)
+            @test_throws err begin
+                @constraint(model_x, [x, x + y] in MOI.Zeros(2))
             end
-            @testset "before loading the constraint to the optimizer" begin
-                @testset "optimizer set at Model" begin
-                    model = Model(mock_factory)
-                    @variable(model, x)
-                    JuMP.add_bridge(model, NonnegativeBridge)
-                    c = @constraint(model, x in Nonnegative())
-                    JuMP.optimize!(model)
-                    @test 1.0 == @inferred JuMP.value(x)
-                    @test 1.0 == @inferred JuMP.value(c)
-                    @test 2.0 == @inferred JuMP.dual(c)
-                end
-                @testset "optimizer set with set_optimizer" begin
-                    model = Model()
-                    @variable(model, x)
-                    c = @constraint(model, x in Nonnegative())
-                    JuMP.add_bridge(model, NonnegativeBridge)
-                    set_optimizer(model, mock_factory)
-                    JuMP.optimize!(model)
-                    @test 1.0 == @inferred JuMP.value(x)
-                    @test 1.0 == @inferred JuMP.value(c)
-                    @test 2.0 == @inferred JuMP.dual(c)
-                end
+            @test_throws err begin
+                @constraint(model_x, [x + y, x] in MOI.Zeros(2))
             end
-            @testset "after loading the constraint to the optimizer" begin
-                @testset "optimizer set at Model" begin
-                    error_string = """
+        end
+        @testset "objective" begin
+            @test_throws err @objective(model_x, Min, x + y)
+        end
+    end
+    @testset "Quadratic" begin
+        @testset "constraint" begin
+            @test_throws err @constraint(model_x, x * y >= 1)
+            @test_throws err begin
+                @constraint(model_x, [x, x * y] in MOI.Zeros(2))
+            end
+            @test_throws err begin
+                @constraint(model_x, [x * y, x] in MOI.Zeros(2))
+            end
+            @test_throws err @constraint(model_x, x * x + x + y <= 1)
+            @test_throws err begin
+                @constraint(model_x, [x, x * x + x + y] in MOI.Zeros(2))
+            end
+            @test_throws err begin
+                @constraint(model_x, [x * x + x + y, x] in MOI.Zeros(2))
+            end
+        end
+        @testset "objective" begin
+            @test_throws err @objective(model_x, Min, x * y)
+            @test_throws err @objective(model_x, Min, x * x + x + y)
+        end
+    end
+    @testset "Attribute" begin
+        cy = @constraint(model_y, y in MOI.EqualTo(1.0))
+        cerr = JuMP.ConstraintNotOwned(cy)
+        @testset "get" begin
+            @test_throws err begin
+                MOI.get(model_x, MOI.VariablePrimalStart(), y)
+            end
+            @test_throws cerr begin
+                MOI.get(model_x, MOI.ConstraintPrimalStart(), cy)
+            end
+        end
+        @testset "set" begin
+            @test_throws err begin
+                MOI.set(model_x, MOI.VariablePrimalStart(), y, 1.0)
+            end
+            @test_throws cerr begin
+                MOI.set(model_x, MOI.ConstraintPrimalStart(), cy, 1.0)
+            end
+        end
+    end
+end
+
+function test_optimize_hook()
+    m = Model()
+    @test m.optimize_hook === nothing
+    called = false
+    function hook(m)
+        called = true
+    end
+    JuMP.set_optimize_hook(m, hook)
+    @test !called
+    optimize!(m)
+    @test called
+
+    m = Model()
+    err = ErrorException("Unrecognized keyword arguments: unexpected_arg")
+    @test_throws err optimize!(m, unexpected_arg=1)
+    JuMP.set_optimize_hook(m, (m ; my_new_arg=nothing) -> my_new_arg)
+    @test optimize!(m) === nothing
+    @test optimize!(m, my_new_arg = 1) == 1
+end
+
+function test_universal_fallback()
+    m = Model()
+    MOI.set(m, MOI.Test.UnknownModelAttribute(), 1)
+    @test MOI.get(m, MOI.Test.UnknownModelAttribute()) == 1
+end
+
+function test_automatic_bridging()
+    # optimizer not supporting Interval
+    model = Model(() -> MOIU.MockOptimizer(SimpleLPModel{Float64}()))
+    @test JuMP.bridge_constraints(model)
+    @test JuMP.backend(model) isa MOIU.CachingOptimizer
+    @test JuMP.backend(model).optimizer isa MOI.Bridges.LazyBridgeOptimizer
+    @test JuMP.backend(model).optimizer.model isa MOIU.MockOptimizer
+    @variable model x
+    cref = @constraint model 0 <= x + 1 <= 1
+    @test cref isa JuMP.ConstraintRef{JuMP.Model,MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.Interval{Float64}}}
+    JuMP.optimize!(model)
+end
+
+function test_automatic_bridging_with_cache()
+    # optimizer not supporting Interval and not supporting `default_copy_to`
+    model = Model(() -> MOIU.MockOptimizer(SimpleLPModel{Float64}(),
+                                            needs_allocate_load=true))
+    @test JuMP.bridge_constraints(model)
+    @test JuMP.backend(model) isa MOIU.CachingOptimizer
+    @test JuMP.backend(model).optimizer isa MOI.Bridges.LazyBridgeOptimizer
+    @test JuMP.backend(model).optimizer.model isa MOIU.CachingOptimizer
+    @test JuMP.backend(model).optimizer.model.optimizer isa MOIU.MockOptimizer
+    @variable(model, x)
+    err = ErrorException(
+        "There is no `optimizer_index` as the optimizer is not " *
+        "synchronized with the cached model. Call " *
+        "`MOIU.attach_optimizer(model)` to synchronize it.")
+    @test_throws err optimizer_index(x)
+    cref = @constraint model 0 <= x + 1 <= 1
+    @test cref isa JuMP.ConstraintRef{JuMP.Model,MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.Interval{Float64}}}
+    @test_throws err optimizer_index(cref)
+    JuMP.optimize!(model)
+    err = ErrorException(
+        "There is no `optimizer_index` for $(typeof(index(cref))) " *
+        "constraints because they are bridged.")
+    @test_throws err optimizer_index(cref)
+end
+
+function test_automatic_bridging_with_bridge_constraints_false()
+    model = Model(
+        () -> MOIU.MockOptimizer(SimpleLPModel{Float64}()),
+        bridge_constraints = false
+    )
+    @test !JuMP.bridge_constraints(model)
+    @test JuMP.backend(model) isa MOIU.CachingOptimizer
+    @test !(JuMP.backend(model).optimizer isa MOI.Bridges.LazyBridgeOptimizer)
+    @variable model x
+    err = ErrorException("Constraints of type MathOptInterface.ScalarAffineFunction{Float64}-in-MathOptInterface.Interval{Float64} are not supported by the solver, try using `bridge_constraints=true` in the `JuMP.Model` constructor if you believe the constraint can be reformulated to constraints supported by the solver.")
+    @test_throws err @constraint model 0 <= x + 1 <= 1
+end
+
+function test_no_bridge_direct_model()
+    optimizer = MOIU.MockOptimizer(SimpleLPModel{Float64}())
+    model = JuMP.direct_model(optimizer)
+    @test !JuMP.bridge_constraints(model)
+    @variable model x
+    err = ErrorException("Constraints of type MathOptInterface.ScalarAffineFunction{Float64}-in-MathOptInterface.Interval{Float64} are not supported by the solver.")
+    @test_throws err @constraint model 0 <= x + 1 <= 1
+end
+
+function _mock_factory()
+    mock = MOIU.MockOptimizer(
+        MOIU.Model{Float64}(), eval_variable_constraint_dual = false
+    )
+    optimize!(mock) = MOIU.mock_optimize!(
+        mock, [1.0], (MOI.SingleVariable, MOI.GreaterThan{Float64}) => [2.0]
+    )
+    MOIU.set_mock_optimize!(mock, optimize!)
+    return mock
+end
+
+function test_addbridge_at_model()
+    model = Model(_mock_factory)
+    @variable(model, x)
+    JuMP.add_bridge(model, NonnegativeBridge)
+    c = @constraint(model, x in Nonnegative())
+    JuMP.optimize!(model)
+    @test 1.0 == @inferred JuMP.value(x)
+    @test 1.0 == @inferred JuMP.value(c)
+    @test 2.0 == @inferred JuMP.dual(c)
+end
+
+function test_addbridge_at_set_optimizer()
+    model = Model()
+    @variable(model, x)
+    c = @constraint(model, x in Nonnegative())
+    JuMP.add_bridge(model, NonnegativeBridge)
+    set_optimizer(model, _mock_factory)
+    JuMP.optimize!(model)
+    @test 1.0 == @inferred JuMP.value(x)
+    @test 1.0 == @inferred JuMP.value(c)
+    @test 2.0 == @inferred JuMP.dual(c)
+end
+
+function test_bridging_at_model()
+    err = ErrorException("""
 Constrained variables in `Nonnegative` are not supported and cannot be bridged into supported constrained variables and constraints. See details below:
 [1] constrained variables in `Nonnegative` are not supported because no added bridge supports bridging it.
   Cannot add free variables and then constrain them because:
@@ -301,209 +301,211 @@ Constrained variables in `Nonnegative` are not supported and cannot be bridged i
 (2) `MOI.ScalarAffineFunction{Float64}`-in-`Nonnegative` constraints are not supported because:
   Cannot use `MOIB.Constraint.ScalarSlackBridge{Float64,MOI.ScalarAffineFunction{Float64},Nonnegative}` because:
   [1] constrained variables in `Nonnegative` are not supported
-"""
-                    err = ErrorException(error_string)
+""")
 
-                    model = Model(mock_factory)
-                    @variable(model, x)
-                    @test_throws err @constraint(model, x in Nonnegative())
-                    JuMP.add_bridge(model, NonnegativeBridge)
-                    c = @constraint(model, x in Nonnegative())
-                    JuMP.optimize!(model)
-                    @test 1.0 == @inferred JuMP.value(x)
-                    @test 1.0 == @inferred JuMP.value(c)
-                    @test 2.0 == @inferred JuMP.dual(c)
-                end
-                @testset "optimizer set with set_optimizer" begin
-                    err = MOI.UnsupportedConstraint{MOI.SingleVariable,
-                                                    Nonnegative}()
-                    model = Model()
-                    @variable(model, x)
-                    c = @constraint(model, x in Nonnegative())
-                    set_optimizer(model, mock_factory)
-                    @test_throws err JuMP.optimize!(model)
-                    JuMP.add_bridge(model, NonnegativeBridge)
-                    JuMP.optimize!(model)
-                    @test 1.0 == @inferred JuMP.value(x)
-                    @test 1.0 == @inferred JuMP.value(c)
-                    @test 2.0 == @inferred JuMP.dual(c)
-                end
-            end
-            @testset "automatically with BridgeableConstraint" begin
-                @testset "optimizer set at Model" begin
-                    model = Model(mock_factory)
-                    @variable(model, x)
-                    constraint = ScalarConstraint(x, Nonnegative())
-                    bc = BridgeableConstraint(constraint, NonnegativeBridge)
-                    c = add_constraint(model, bc)
-                    JuMP.optimize!(model)
-                    @test 1.0 == @inferred JuMP.value(x)
-                    @test 1.0 == @inferred JuMP.value(c)
-                    @test 2.0 == @inferred JuMP.dual(c)
-                end
-                @testset "optimizer set with set_optimizer" begin
-                    model = Model()
-                    @variable(model, x)
-                    constraint = ScalarConstraint(x, Nonnegative())
-                    bc = BridgeableConstraint(constraint, NonnegativeBridge)
-                    c = add_constraint(model, bc)
-                    set_optimizer(model, mock_factory)
-                    JuMP.optimize!(model)
-                    @test 1.0 == @inferred JuMP.value(x)
-                    @test 1.0 == @inferred JuMP.value(c)
-                    @test 2.0 == @inferred JuMP.dual(c)
-                end
-            end
-        end
+    model = Model(_mock_factory)
+    @variable(model, x)
+    @test_throws err try
+        @constraint(model, x in Nonnegative())
+    catch e
+        error(replace(e.msg, "Main.TestModel." => ""))
     end
-
-    @testset "solve_time" begin
-        @testset "NoOptimizer()" begin
-            err = NoOptimizer()
-            model = Model()
-            @test_throws err solve_time(model)
-        end
-
-        @testset "OptimizeNotCalled()" begin
-            err = OptimizeNotCalled()
-            model = Model(() -> MOIU.MockOptimizer(SimpleLPModel{Float64}()))
-            @test_throws err solve_time(model)
-        end
-
-        @testset "Solved model" begin
-            # TODO
-        end
-    end
-
-    @testset "solver_name" begin
-        @testset "Not attached" begin
-            model = Model()
-            @test "No optimizer attached." == @inferred JuMP.solver_name(model)
-        end
-
-        @testset "Mock" begin
-            model = Model(() -> MOIU.MockOptimizer(SimpleLPModel{Float64}()))
-            @test "Mock" == @inferred JuMP.solver_name(model)
-        end
-    end
-    @testset "set_silent and unset_silent" begin
-        mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
-        model = Model(() -> MOIU.MockOptimizer(mock))
-        @test JuMP.set_silent(model)
-        @test MOI.get(backend(model), MOI.Silent())
-        @test MOI.get(model, MOI.Silent())
-        @test !JuMP.unset_silent(model)
-        @test !MOI.get(backend(model), MOI.Silent())
-        @test !MOI.get(model, MOI.Silent())
-    end
-
-    @testset "set_optimizer_attribute" begin
-        mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
-        model = Model(() -> MOIU.MockOptimizer(mock))
-        @test JuMP.set_optimizer_attribute(model, "aaa", "bbb") == "bbb"
-        @test MOI.get(backend(model), MOI.RawParameter("aaa")) == "bbb"
-        @test MOI.get(model, MOI.RawParameter("aaa")) == "bbb"
-    end
-
-    @testset "set_optimizer_attributes" begin
-        mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
-        model = Model(() -> MOIU.MockOptimizer(mock))
-        JuMP.set_optimizer_attributes(model, "aaa" => "bbb", "abc" => 10)
-        @test MOI.get(model, MOI.RawParameter("aaa")) == "bbb"
-        @test MOI.get(model, MOI.RawParameter("abc")) == 10
-    end
-
-    @testset "get_optimizer_attribute" begin
-        mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
-        model = Model(() -> MOIU.MockOptimizer(mock))
-        @test JuMP.set_optimizer_attribute(model, "aaa", "bbb") == "bbb"
-        @test JuMP.get_optimizer_attribute(model, "aaa") == "bbb"
-    end
-
-    @testset "set and retrieve time limit" begin
-        mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
-        model = Model(() -> MOIU.MockOptimizer(mock))
-        JuMP.set_time_limit_sec(model, 12.0)
-        @test JuMP.time_limit_sec(model) == 12.0
-        JuMP.set_time_limit_sec(model, nothing)
-        @test JuMP.time_limit_sec(model) === nothing
-        JuMP.set_time_limit_sec(model, 12.0)
-        JuMP.unset_time_limit_sec(model)
-        @test JuMP.time_limit_sec(model) === nothing
-    end
+    JuMP.add_bridge(model, NonnegativeBridge)
+    c = @constraint(model, x in Nonnegative())
+    JuMP.optimize!(model)
+    @test 1.0 == @inferred JuMP.value(x)
+    @test 1.0 == @inferred JuMP.value(c)
+    @test 2.0 == @inferred JuMP.dual(c)
 end
 
-@testset "Model" begin
-    test_model()
+function test_bridging_at_set_optimizer()
+    err = MOI.UnsupportedConstraint{MOI.SingleVariable, Nonnegative}()
+    model = Model()
+    @variable(model, x)
+    c = @constraint(model, x in Nonnegative())
+    set_optimizer(model, _mock_factory)
+    @test_throws err JuMP.optimize!(model)
+    JuMP.add_bridge(model, NonnegativeBridge)
+    JuMP.optimize!(model)
+    @test 1.0 == @inferred JuMP.value(x)
+    @test 1.0 == @inferred JuMP.value(c)
+    @test 2.0 == @inferred JuMP.dual(c)
+end
+
+function test_bridgeableconstraint_at_model()
+    model = Model(_mock_factory)
+    @variable(model, x)
+    constraint = ScalarConstraint(x, Nonnegative())
+    bc = BridgeableConstraint(constraint, NonnegativeBridge)
+    c = add_constraint(model, bc)
+    JuMP.optimize!(model)
+    @test 1.0 == @inferred JuMP.value(x)
+    @test 1.0 == @inferred JuMP.value(c)
+    @test 2.0 == @inferred JuMP.dual(c)
+end
+
+function test_bridgeableconstraint_at_set_optimizer()
+    model = Model()
+    @variable(model, x)
+    constraint = ScalarConstraint(x, Nonnegative())
+    bc = BridgeableConstraint(constraint, NonnegativeBridge)
+    c = add_constraint(model, bc)
+    set_optimizer(model, _mock_factory)
+    JuMP.optimize!(model)
+    @test 1.0 == @inferred JuMP.value(x)
+    @test 1.0 == @inferred JuMP.value(c)
+    @test 2.0 == @inferred JuMP.dual(c)
+end
+
+function test_solve_time_no_optimizer()
+    err = NoOptimizer()
+    model = Model()
+    @test_throws err solve_time(model)
+end
+
+function test_solve_time_OptimizeNotCalled()
+    err = OptimizeNotCalled()
+    model = Model(() -> MOIU.MockOptimizer(SimpleLPModel{Float64}()))
+    @test_throws err solve_time(model)
+end
+
+function test_solve_time()
+    # TODO(odow): Add a test for getting the solve time of a solved model.
+    @test_broken true == false
+end
+
+function test_solver_name_not_attached()
+    model = Model()
+    @test "No optimizer attached." == @inferred JuMP.solver_name(model)
+end
+
+function test_solver_name_mock()
+    model = Model(() -> MOIU.MockOptimizer(SimpleLPModel{Float64}()))
+    @test "Mock" == @inferred JuMP.solver_name(model)
+end
+
+function test_set_silent()
+    mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
+    model = Model(() -> MOIU.MockOptimizer(mock))
+    @test JuMP.set_silent(model)
+    @test MOI.get(backend(model), MOI.Silent())
+    @test MOI.get(model, MOI.Silent())
+    @test !JuMP.unset_silent(model)
+    @test !MOI.get(backend(model), MOI.Silent())
+    @test !MOI.get(model, MOI.Silent())
+end
+
+function test_set_optimizer_attribute()
+    mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
+    model = Model(() -> MOIU.MockOptimizer(mock))
+    @test JuMP.set_optimizer_attribute(model, "aaa", "bbb") == "bbb"
+    @test MOI.get(backend(model), MOI.RawParameter("aaa")) == "bbb"
+    @test MOI.get(model, MOI.RawParameter("aaa")) == "bbb"
+end
+
+function test_set_optimizer_attributes()
+    mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
+    model = Model(() -> MOIU.MockOptimizer(mock))
+    JuMP.set_optimizer_attributes(model, "aaa" => "bbb", "abc" => 10)
+    @test MOI.get(model, MOI.RawParameter("aaa")) == "bbb"
+    @test MOI.get(model, MOI.RawParameter("abc")) == 10
+end
+
+function test_get_optimizer_attribute()
+    mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
+    model = Model(() -> MOIU.MockOptimizer(mock))
+    @test JuMP.set_optimizer_attribute(model, "aaa", "bbb") == "bbb"
+    @test JuMP.get_optimizer_attribute(model, "aaa") == "bbb"
+end
+
+function test_time_limit_sec()
+    mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
+    model = Model(() -> MOIU.MockOptimizer(mock))
+    JuMP.set_time_limit_sec(model, 12.0)
+    @test JuMP.time_limit_sec(model) == 12.0
+    JuMP.set_time_limit_sec(model, nothing)
+    @test JuMP.time_limit_sec(model) === nothing
+    JuMP.set_time_limit_sec(model, 12.0)
+    JuMP.unset_time_limit_sec(model)
+    @test JuMP.time_limit_sec(model) === nothing
 end
 
 struct DummyExtensionData
     model::JuMP.Model
 end
-function JuMP.copy_extension_data(data::DummyExtensionData,
-                                  new_model::JuMP.AbstractModel,
-                                  model::JuMP.AbstractModel)
+
+function JuMP.copy_extension_data(
+    data::DummyExtensionData,
+    new_model::JuMP.AbstractModel,
+    model::JuMP.AbstractModel
+)
     @test data.model === model
     return DummyExtensionData(new_model)
 end
+
 function dummy_optimizer_hook(::JuMP.AbstractModel) end
 
-@testset "Model copy" begin
-    for copy_model in (true, false)
-        @testset "Using $(copy_model ? "JuMP.copy_model" : "Base.copy")" begin
-            for caching_mode in (MOIU.AUTOMATIC, MOIU.MANUAL)
-                @testset "In $caching_mode mode" begin
-                    model = Model(caching_mode = caching_mode)
-                    model.optimize_hook = dummy_optimizer_hook
-                    data = DummyExtensionData(model)
-                    model.ext[:dummy] = data
-                    @variable(model, x ≥ 0, Bin)
-                    @variable(model, y ≤ 1, Int)
-                    @variable(model, z == 0)
-                    @constraint(model, cref, x + y == 1)
-
-                    if copy_model
-                        new_model, reference_map = JuMP.copy_model(model)
-                    else
-                        new_model = copy(model)
-                        reference_map = Dict{Union{JuMP.VariableRef,
-                                                   JuMP.ConstraintRef},
-                                             Union{JuMP.VariableRef,
-                                                   JuMP.ConstraintRef}}()
-                        reference_map[x] = new_model[:x]
-                        reference_map[y] = new_model[:y]
-                        reference_map[z] = new_model[:z]
-                        reference_map[cref] = new_model[:cref]
-                    end
-                    @test caching_mode == @inferred MOIU.mode(JuMP.backend(new_model))
-                    @test new_model.optimize_hook === dummy_optimizer_hook
-                    @test new_model.ext[:dummy].model === new_model
-                    x_new = reference_map[x]
-                    @test JuMP.owner_model(x_new) === new_model
-                    @test "x" == @inferred JuMP.name(x_new)
-                    y_new = reference_map[y]
-                    @test JuMP.owner_model(y_new) === new_model
-                    @test "y" == @inferred JuMP.name(y_new)
-                    z_new = reference_map[z]
-                    @test JuMP.owner_model(z_new) === new_model
-                    @test "z" == @inferred JuMP.name(z_new)
-                    if copy_model
-                        @test reference_map[JuMP.LowerBoundRef(x)] == @inferred JuMP.LowerBoundRef(x_new)
-                        @test reference_map[JuMP.BinaryRef(x)] == @inferred JuMP.BinaryRef(x_new)
-                        @test reference_map[JuMP.UpperBoundRef(y)] == @inferred JuMP.UpperBoundRef(y_new)
-                        @test reference_map[JuMP.IntegerRef(y)] == @inferred JuMP.IntegerRef(y_new)
-                        @test reference_map[JuMP.FixRef(z)] == @inferred JuMP.FixRef(z_new)
-                    end
-                    cref_new = reference_map[cref]
-                    @test cref_new.model === new_model
-                    @test "cref" == @inferred JuMP.name(cref_new)
-                end
-            end
-        end
-    end
-    @testset "In Direct mode" begin
-        mock = MOIU.MockOptimizer(MOIU.Model{Float64}())
-        model = JuMP.direct_model(mock)
-        @test_throws ErrorException JuMP.copy(model)
+function test_copy_model()
+    for caching_mode in (MOIU.AUTOMATIC, MOIU.MANUAL)
+        model = Model(caching_mode = caching_mode)
+        model.optimize_hook = dummy_optimizer_hook
+        model.ext[:dummy] = DummyExtensionData(model)
+        @variable(model, x ≥ 0, Bin)
+        @variable(model, y ≤ 1, Int)
+        @variable(model, z == 0)
+        @constraint(model, cref, x + y == 1)
+        new_model, reference_map = JuMP.copy_model(model)
+        @test caching_mode == @inferred MOIU.mode(JuMP.backend(new_model))
+        @test new_model.optimize_hook === dummy_optimizer_hook
+        @test new_model.ext[:dummy].model === new_model
+        x_new = reference_map[x]
+        @test JuMP.owner_model(x_new) === new_model
+        @test "x" == @inferred JuMP.name(x_new)
+        y_new = reference_map[y]
+        @test JuMP.owner_model(y_new) === new_model
+        @test "y" == @inferred JuMP.name(y_new)
+        z_new = reference_map[z]
+        @test JuMP.owner_model(z_new) === new_model
+        @test "z" == @inferred JuMP.name(z_new)
+        @test reference_map[JuMP.LowerBoundRef(x)] == @inferred JuMP.LowerBoundRef(x_new)
+        @test reference_map[JuMP.BinaryRef(x)] == @inferred JuMP.BinaryRef(x_new)
+        @test reference_map[JuMP.UpperBoundRef(y)] == @inferred JuMP.UpperBoundRef(y_new)
+        @test reference_map[JuMP.IntegerRef(y)] == @inferred JuMP.IntegerRef(y_new)
+        @test reference_map[JuMP.FixRef(z)] == @inferred JuMP.FixRef(z_new)
+        cref_new = reference_map[cref]
+        @test cref_new.model === new_model
+        @test "cref" == @inferred JuMP.name(cref_new)
     end
 end
+
+function test_base_copy()
+    caching_mode = MOIU.MANUAL
+    model = Model(caching_mode = caching_mode)
+    @variable(model, x)
+    new_model = Base.copy(model)
+    @test caching_mode == @inferred MOIU.mode(JuMP.backend(new_model))
+    @test JuMP.owner_model(new_model[:x]) === new_model
+    @test JuMP.owner_model(new_model[:x]) != model
+    @test "x" == @inferred JuMP.name(new_model[:x])
+end
+
+function test_copy_in_direct_mode()
+    mock = MOIU.MockOptimizer(MOIU.Model{Float64}())
+    model = JuMP.direct_model(mock)
+    @test_throws ErrorException JuMP.copy(model)
+end
+
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if !startswith("$(name)", "test_")
+            continue
+        end
+        @testset "$(name)" begin
+            getfield(@__MODULE__, name)()
+        end
+    end
+end
+
+end
+
+TestModel.runtests()

--- a/test/mutable_arithmetics.jl
+++ b/test/mutable_arithmetics.jl
@@ -1,12 +1,14 @@
+module TestMutableArithmetics
+
 using LinearAlgebra
 using JuMP
 using Test
 
 const MA = JuMP._MA
 
-@static if !(:JuMPExtension in names(Main))
-    include(joinpath(@__DIR__, "JuMPExtension.jl"))
-end
+# @static if !(:JuMPExtension in names(Main))
+#     include(joinpath(@__DIR__, "JuMPExtension.jl"))
+# end
 
 struct DummyVariableRef <: JuMP.AbstractVariableRef end
 JuMP.name(::DummyVariableRef) = "dummy"
@@ -22,109 +24,125 @@ function promote_operation_test(op::Function, x::Type, y::Type)
     @test 0 == @allocated f()
 end
 
-function mutable_arithmetics_test(ModelType::Type{<:JuMP.AbstractModel},
-                                  VariableRefType::Type{<:JuMP.AbstractVariableRef})
+function test_promote_operation(ModelType, VariableRefType)
     AffExprType = JuMP.GenericAffExpr{Float64, VariableRefType}
     QuadExprType = JuMP.GenericQuadExpr{Float64, VariableRefType}
+    for op in [+, -, *]
+        for T in [Int, Float64]
+            promote_operation_test(op, T, VariableRefType)
+            promote_operation_test(op, VariableRefType, T)
+            promote_operation_test(op, T, AffExprType)
+            promote_operation_test(op, AffExprType, T)
+            promote_operation_test(op, T, QuadExprType)
+            promote_operation_test(op, QuadExprType, T)
+        end
+        promote_operation_test(op, VariableRefType, VariableRefType)
+        promote_operation_test(op, VariableRefType, AffExprType)
+        promote_operation_test(op, AffExprType, VariableRefType)
+        if op != *
+            promote_operation_test(op, VariableRefType, QuadExprType)
+            promote_operation_test(op, QuadExprType, VariableRefType)
+            promote_operation_test(op, AffExprType, QuadExprType)
+            promote_operation_test(op, QuadExprType, AffExprType)
+        end
+    end
+end
 
-    @testset "promote_operation" begin
-        for op in [+, -, *]
-            for T in [Int, Float64]
-                promote_operation_test(op, T, VariableRefType)
-                promote_operation_test(op, VariableRefType, T)
-                promote_operation_test(op, T, AffExprType)
-                promote_operation_test(op, AffExprType, T)
-                promote_operation_test(op, T, QuadExprType)
-                promote_operation_test(op, QuadExprType, T)
+function test_int(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, x)
+    MA.Test.int_test(typeof(1x), exclude = ["int_mul", "int_add", "int_add_mul"])
+    MA.Test.int_test(typeof(1x^2), exclude = ["int_mul", "int_add", "int_add_mul"])
+end
+
+function test_scalar(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, x)
+    exclude = ["cube"]
+    MA.Test.scalar_test(x, exclude = exclude)
+    MA.Test.scalar_test(2x + 3, exclude = exclude)
+    MA.Test.scalar_test(2x^2 + 4x + 1, exclude = exclude)
+end
+
+function test_quadratic(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, w)
+    @variable(model, x)
+    @variable(model, y)
+    @variable(model, z)
+    MA.Test.quadratic_test(w, x, y, z)
+end
+
+function test_sparse(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, X11)
+    @variable(model, X23)
+    @variable(model, Xd[1:3, 1:3])
+    MA.Test.sparse_test(X11, X23, Xd)
+end
+
+function test_vector(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, x[1:3])
+    MA.Test.array_test(x)
+end
+
+function test_symmetric_matrix(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, y[1:2, 1:2], Symmetric)
+    MA.Test.array_test(y)
+end
+
+function test_nonsquare_matrix(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, z[1:2, 1:3])
+    MA.Test.array_test(z)
+end
+
+function test_DenseAxisVector(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, y[2:5])
+    MA.Test.array_test(y, exclude = ["matrix_vector", "non_array"])
+end
+
+function test_different_variables(ModelType, ::Any)
+    model = ModelType()
+    x = @variable(model)
+    y = DummyVariableRef()
+    aff = x + 1
+    function _promote_test(a, b)
+        A = typeof(a)
+        B = typeof(b)
+        @test MA.promote_operation(+, A, B) == DummyExpr
+        @test MA.promote_operation(-, A, B) == DummyExpr
+        @test MA.promote_operation(+, B, A) == DummyExpr
+        @test MA.promote_operation(-, B, A) == DummyExpr
+    end
+    _promote_test(x, y)
+    _promote_test(aff, y)
+end
+
+function runtests()
+    @testset "mutable_arithmetics.jl" begin
+        for name in names(@__MODULE__; all = true)
+            if !startswith("$(name)", "test_")
+                continue
             end
-            promote_operation_test(op, VariableRefType, VariableRefType)
-            promote_operation_test(op, VariableRefType, AffExprType)
-            promote_operation_test(op, AffExprType, VariableRefType)
-            if op != *
-                promote_operation_test(op, VariableRefType, QuadExprType)
-                promote_operation_test(op, QuadExprType, VariableRefType)
-                promote_operation_test(op, AffExprType, QuadExprType)
-                promote_operation_test(op, QuadExprType, AffExprType)
+            f = getfield(@__MODULE__, name)
+            @testset "$(name)" begin
+                f(Model, VariableRef)
             end
+            # Note(odow): We disable JuMPExtension tests for MutableArithmetics
+            # because they take far to looooooong. MutableArithmetics is a
+            # tested package. We're also testing that it works with JuMP. We
+            # don't need to double up on our tests.
+            # @testset "$(name)-JuMPExtension" begin
+            #     f(JuMPExtension.MyModel, JuMPExtension.MyVariableRef)
+            # end
         end
     end
-
-    @testset "Int" begin
-        model = ModelType()
-        @variable(model, x)
-        @testset "Affine" begin
-            MA.Test.int_test(typeof(1x), exclude = ["int_mul", "int_add", "int_add_mul"])
-        end
-        @testset "Quadratic" begin
-            MA.Test.int_test(typeof(1x^2), exclude = ["int_mul", "int_add", "int_add_mul"])
-        end
-    end
-
-    @testset "Scalar" begin
-        model = ModelType()
-        @variable(model, x)
-        exclude = ["cube"]
-        MA.Test.scalar_test(x, exclude = exclude)
-        MA.Test.scalar_test(2x + 3, exclude = exclude)
-        MA.Test.scalar_test(2x^2 + 4x + 1, exclude = exclude)
-    end
-    @testset "Quadratic" begin
-        model = ModelType()
-        @variable(model, w)
-        @variable(model, x)
-        @variable(model, y)
-        @variable(model, z)
-        MA.Test.quadratic_test(w, x, y, z)
-    end
-    @testset "Sparse" begin
-        model = ModelType()
-        @variable(model, X11)
-        @variable(model, X23)
-        @variable(model, Xd[1:3, 1:3])
-        MA.Test.sparse_test(X11, X23, Xd)
-    end
-    @testset "Vector" begin
-        model = ModelType()
-        @variable(model, x[1:3])
-        MA.Test.array_test(x)
-    end
-    @testset "Matrix" begin
-        model = ModelType()
-        @variable(model, x[1:2, 1:2])
-        MA.Test.array_test(x)
-        @variable(model, y[1:2, 1:2], Symmetric)
-        MA.Test.array_test(y)
-        @variable(model, z[1:2, 1:3])
-        MA.Test.array_test(z)
-    end
-    @testset "DenseAxisVector" begin
-        model = ModelType()
-        @variable(model, y[2:5])
-        MA.Test.array_test(y, exclude = ["matrix_vector", "non_array"])
-    end
-    @testset "Mix different variables" begin
-        model = ModelType()
-        x = @variable(model)
-        y = DummyVariableRef()
-        aff = x + 1
-        function _promote_test(a, b)
-            A = typeof(a)
-            B = typeof(b)
-            @test MA.promote_operation(+, A, B) == DummyExpr
-            @test MA.promote_operation(-, A, B) == DummyExpr
-            @test MA.promote_operation(+, B, A) == DummyExpr
-            @test MA.promote_operation(-, B, A) == DummyExpr
-        end
-        _promote_test(x, y)
-        _promote_test(aff, y)
-    end
+end
 
 end
 
-@testset "Operators for JuMP.Model" begin
-    mutable_arithmetics_test(Model, VariableRef)
-end
-
-@testset "Operators for JuMPExtension.MyModel" begin
-    mutable_arithmetics_test(JuMPExtension.MyModel, JuMPExtension.MyVariableRef)
-end
+TestMutableArithmetics.runtests()

--- a/test/mutable_arithmetics.jl
+++ b/test/mutable_arithmetics.jl
@@ -1,9 +1,12 @@
-using LinearAlgebra, Test
-
-import MutableArithmetics
-const MA = MutableArithmetics
-
+using LinearAlgebra
 using JuMP
+using Test
+
+const MA = JuMP._MA
+
+@static if !(:JuMPExtension in names(Main))
+    include(joinpath(@__DIR__, "JuMPExtension.jl"))
+end
 
 struct DummyVariableRef <: JuMP.AbstractVariableRef end
 JuMP.name(::DummyVariableRef) = "dummy"

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -1,4 +1,12 @@
 # TODO: Replace isapprox with ≈ everywhere.
+
+using JuMP
+using LinearAlgebra
+using SparseArrays
+using Test
+
+include(joinpath(@__DIR__, "utilities.jl"))
+
 @testset "Nonlinear" begin
 
     import JuMP: _NonlinearExprData

--- a/test/nonnegative_bridge.jl
+++ b/test/nonnegative_bridge.jl
@@ -11,6 +11,7 @@
 # This file contains an example bridge used for tests.
 
 using JuMP
+
 const MOIB = MOI.Bridges
 const MOIBC = MOI.Bridges.Constraint
 

--- a/test/nonnegative_bridge.jl
+++ b/test/nonnegative_bridge.jl
@@ -8,7 +8,7 @@
 # See http://github.com/jump-dev/JuMP.jl
 #############################################################################
 
-# This file contains an example bridge used for tests.
+# This file contains an example bridge used in test/model.jl.
 
 using JuMP
 

--- a/test/objective.jl
+++ b/test/objective.jl
@@ -1,5 +1,9 @@
-using Test
 using JuMP
+using Test
+
+@static if !(:JuMPExtension in names(Main))
+    include(joinpath(@__DIR__, "JuMPExtension.jl"))
+end
 
 struct DummyOptimizer <: MOI.AbstractOptimizer end
 MOI.is_empty(::DummyOptimizer) = true

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -1,9 +1,15 @@
-using LinearAlgebra, Test
-
-import MutableArithmetics
-const MA = MutableArithmetics
-
 using JuMP
+using LinearAlgebra
+using SparseArrays
+using Test
+
+const MA = JuMP._MA
+
+include(joinpath(@__DIR__, "utilities.jl"))
+
+@static if !(:JuMPExtension in names(Main))
+    include(joinpath(@__DIR__, "JuMPExtension.jl"))
+end
 
 # For "DimensionMismatch when performing vector-matrix multiplication with custom types #988"
 import Base: +, *

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -1,3 +1,5 @@
+module TestOperators
+
 using JuMP
 using LinearAlgebra
 using SparseArrays
@@ -6,10 +8,7 @@ using Test
 const MA = JuMP._MA
 
 include(joinpath(@__DIR__, "utilities.jl"))
-
-@static if !(:JuMPExtension in names(Main))
-    include(joinpath(@__DIR__, "JuMPExtension.jl"))
-end
+include(joinpath(@__DIR__, "JuMPExtension.jl"))
 
 # For "DimensionMismatch when performing vector-matrix multiplication with custom types #988"
 import Base: +, *
@@ -35,461 +34,493 @@ LinearAlgebra.adjoint(t::Union{MyType, MySumType}) = t
 function JuMP.isequal_canonical(t::MySumType, s::MySumType)
     return JuMP.isequal_canonical(t.a, s.a)
 end
-function JuMP.isequal_canonical(x::AbstractArray{<:MySumType},
-                           y::AbstractArray{<:MySumType})
+function JuMP.isequal_canonical(
+    x::AbstractArray{<:MySumType}, y::AbstractArray{<:MySumType}
+)
     return size(x) == size(y) && all(JuMP.isequal_canonical.(x, y))
 end
 
-function operators_test(ModelType::Type{<:JuMP.AbstractModel}, VariableRefType::Type{<:JuMP.AbstractVariableRef})
-    AffExprType = JuMP.GenericAffExpr{Float64, VariableRefType}
-    QuadExprType = JuMP.GenericQuadExpr{Float64, VariableRefType}
+function test_promotion(ModelType, VariableRefType)
+    m = ModelType()
+    I = Int
+    V = VariableRefType
+    A = JuMP.GenericAffExpr{Float64, VariableRefType}
+    Q = JuMP.GenericQuadExpr{Float64, VariableRefType}
+    @test promote_type(V, I) == A
+    @test promote_type(I, V) == A
+    @test promote_type(A, I) == A
+    @test promote_type(I, A) == A
+    @test promote_type(A, V) == A
+    @test promote_type(V, A) == A
+    @test promote_type(Q, I) == Q
+    @test promote_type(I, Q) == Q
+    @test promote_type(Q, A) == Q
+    @test promote_type(A, Q) == Q
+    @test promote_type(Q, V) == Q
+    @test promote_type(V, Q) == Q
+    @test promote_type(Q, A) == Q
+    @test promote_type(A, Q) == Q
+end
 
-    @testset "Promotion" begin
-        m = ModelType()
-        I = Int
-        V = VariableRefType
-        A = AffExprType
-        Q = QuadExprType
-        @test promote_type(V, I) == A
-        @test promote_type(I, V) == A
-        @test promote_type(A, I) == A
-        @test promote_type(I, A) == A
-        @test promote_type(A, V) == A
-        @test promote_type(V, A) == A
-        @test promote_type(Q, I) == Q
-        @test promote_type(I, Q) == Q
-        @test promote_type(Q, A) == Q
-        @test promote_type(A, Q) == Q
-        @test promote_type(Q, V) == Q
-        @test promote_type(V, Q) == Q
-        @test promote_type(Q, A) == Q
-        @test promote_type(A, Q) == Q
+function test_broadcast_division_error(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, x[1:2, 1:2])
+    A = [1 2;
+            3 4]
+    B = sparse(A)
+    y = SparseMatrixCSC(2, 2, copy(B.colptr), copy(B.rowval), vec(x))
+    @test_throws ErrorException A ./ x
+    @test_throws ErrorException B ./ x
+    @test_throws ErrorException A ./ y
+    @test_throws ErrorException B ./ y
+
+    # TODO: Refactor to avoid calling the internal JuMP function
+    # `_densify_with_jump_eltype`.
+    #z = JuMP._densify_with_jump_eltype((2 .* y) ./ 3)
+    #@test JuMP.isequal_canonical((2 .* x) ./ 3, z)
+    #z = JuMP._densify_with_jump_eltype(2 * (y ./ 3))
+    #@test JuMP.isequal_canonical(2 .* (x ./ 3), z)
+    #z = JuMP._densify_with_jump_eltype((x[1,1],) .* B)
+    #@test JuMP.isequal_canonical((x[1,1],) .* A, z)
+end
+
+function test_vectorized_comparisons(ModelType, ::Any)
+    m = ModelType()
+    @variable(m, x[1:3])
+    A = [1 2 3
+         0 4 5
+         6 0 7]
+    B = sparse(A)
+    # force vector output
+    cref1 = @constraint(m, reshape(x, (1, 3)) * A * x .>= 1)
+    c1 = JuMP.constraint_object.(cref1)
+    f1 = map(c -> c.func, c1)
+    @test JuMP.isequal_canonical(f1, [x[1]*x[1] + 2x[1]*x[2] + 4x[2]*x[2] + 9x[1]*x[3] + 5x[2]*x[3] + 7x[3]*x[3]])
+    @test all(c -> c.set.lower == 1, c1)
+
+    cref2 = @constraint(m, x'*A*x >= 1)
+    c2 = JuMP.constraint_object.(cref2)
+    @test JuMP.isequal_canonical(f1[1], c2.func)
+
+    mat = [ 3x[1] + 12x[3] +  4x[2]
+            2x[1] + 12x[2] + 10x[3]
+           15x[1] +  5x[2] + 21x[3]]
+
+    cref3 = @constraint(m, (x'A)' + 2A*x .<= 1)
+    c3 = JuMP.constraint_object.(cref3)
+    f3 = map(c->c.func, c3)
+    @test JuMP.isequal_canonical(f3, mat)
+    @test all(c -> c.set.upper == 1, c3)
+    @test JuMP.isequal_canonical((x'A)' + 2A*x, (x'A)' + 2B*x)
+    @test JuMP.isequal_canonical((x'A)' + 2A*x, (x'B)' + 2A*x)
+    @test JuMP.isequal_canonical((x'A)' + 2A*x, (x'B)' + 2B*x)
+    @test JuMP.isequal_canonical((x'A)' + 2A*x, MA.@rewrite((x'A)' + 2A*x))
+    @test JuMP.isequal_canonical((x'A)' + 2A*x, MA.@rewrite((x'B)' + 2A*x))
+    @test JuMP.isequal_canonical((x'A)' + 2A*x, MA.@rewrite((x'A)' + 2B*x))
+    @test JuMP.isequal_canonical((x'A)' + 2A*x, MA.@rewrite((x'B)' + 2B*x))
+
+    cref4 = @constraint(m, -1 .<= (x'A)' + 2A*x .<= 1)
+    c4 = JuMP.constraint_object.(cref4)
+    f4 = map(c->c.func, c4)
+    @test JuMP.isequal_canonical(f4, mat)
+    @test all(c -> c.set.lower == -1, c4)
+    @test all(c -> c.set.upper == 1, c4)
+
+    cref5 = @constraint(m, -[1:3;] .<= (x'A)' + 2A*x .<= 1)
+    c5 = JuMP.constraint_object.(cref5)
+    f5 = map(c->c.func, c5)
+    @test JuMP.isequal_canonical(f5, mat)
+    @test map(c -> c.set.lower, c5) == -[1:3;]
+    @test all(c -> c.set.upper == 1, c4)
+
+    cref6 = @constraint(m, -[1:3;] .<= (x'A)' + 2A*x .<= [3:-1:1;])
+    c6 = JuMP.constraint_object.(cref6)
+    f6 = map(c->c.func, c6)
+    @test JuMP.isequal_canonical(f6, mat)
+    @test map(c -> c.set.lower, c6) == -[1:3;]
+    @test map(c -> c.set.upper, c6) == [3:-1:1;]
+
+    cref7 = @constraint(m, -[1:3;] .<= (x'A)' + 2A*x .<= 3)
+    c7 = JuMP.constraint_object.(cref7)
+    f7 = map(c->c.func, c7)
+    @test JuMP.isequal_canonical(f7, mat)
+    @test map(c -> c.set.lower, c7) == -[1:3;]
+    @test all(c -> c.set.upper == 3, c7)
+end
+
+function test_custom_dimension_mismatch(ModelType, VariableRefType)
+    ElemT = MySumType{JuMP.GenericAffExpr{Float64, VariableRefType}}
+    model = ModelType()
+    @variable(model, Q[1:3, 1:3], PSD)
+    x = [MyType(1), MyType(2), MyType(3)]
+    y = Q * x
+    z = x' * Q
+    @test y isa Vector{ElemT}
+    @test size(y) == (3,)
+    @test z isa Adjoint{ElemT, <:Any}
+    @test size(z) == (1, 3)
+    for i in 1:3
+        # Q is symmetric
+        a = zero(JuMP.GenericAffExpr{Float64, VariableRefType})
+        a += Q[1,i]
+        a += 2Q[2,i]
+        a += 3Q[3,i]
+        # Q[1,i] + 2Q[2,i] + 3Q[3,i] is rearranged as 2 Q[2,3] + Q[1,3] + 3 Q[3,3]
+        @test z[i].a == y[i].a == a
     end
+end
 
-    @testset "Basic operator overloads" begin
-        model = ModelType()
-        @variable(model, w)
-        @variable(model, x)
-        @variable(model, y)
-        @variable(model, z)
+function test_matrix_multiplication(ModelType, VariableRefType)
+    ElemT = MySumType{JuMP.GenericAffExpr{Float64, VariableRefType}}
+    model = ModelType()
+    @variable(model, Q[1:3, 1:3], PSD)
+    X = MyType.((1:3)' .+ (1:3))
+    @test_expression Q * X
+    Y = Q * X
+    @test_expression X' * Q
+    Z = X' * Q
+    @test Y isa Matrix{ElemT}
+    @test size(Y) == (3, 3)
+    @test Z isa Matrix{ElemT}
+    @test size(Z) == (3, 3)
+    @test JuMP.isequal_canonical(Z', Y)
+    @test_expression Q * X'
+    Y = Q * X'
+    @test_expression X * Q
+    Z = X * Q
+    @test Y isa Matrix{ElemT}
+    @test size(Y) == (3, 3)
+    @test Z isa Matrix{ElemT}
+    @test size(Z) == (3, 3)
+    @test JuMP.isequal_canonical(Z', Y)
+end
 
-        aff = @inferred 7.1 * x + 2.5
-        @test_expression_with_string 7.1 * x + 2.5 "7.1 x + 2.5"
-        aff2 = @inferred 1.2 * y + 1.2
-        @test_expression_with_string 1.2 * y + 1.2 "1.2 y + 1.2"
-        q = @inferred 2.5 * y * z + aff
-        @test_expression_with_string 2.5 * y * z + aff "2.5 y*z + 7.1 x + 2.5"
-        q2 = @inferred 8 * x * z + aff2
-        @test_expression_with_string 8 * x * z + aff2 "8 x*z + 1.2 y + 1.2"
-        @test_expression_with_string 2 * x * x + 1 * y * y + z + 3 "2 x² + y² + z + 3"
-
-        # 1. Number tests
-        @testset "Number--???" begin
-            # 1-1 Number--Number - nope!
-            # 1-2 Number--Variable
-            @test_expression_with_string 4.13 + w "w + 4.13"
-            @test_expression_with_string 3.16 - w "-w + 3.16"
-            @test_expression_with_string 5.23 * w "5.23 w"
-            @test_throws ErrorException 2.94 / w
-            # 1-3 Number--AffExpr
-            @test_expression_with_string 1.5 + aff "7.1 x + 4"
-            @test_expression_with_string 1.5 - aff "-7.1 x - 1"
-            @test_expression_with_string 2 * aff "14.2 x + 5"
-            @test_throws ErrorException 2 / aff
-            # 1-4 Number--QuadExpr
-            @test_expression_with_string 1.5 + q "2.5 y*z + 7.1 x + 4"
-            @test_expression_with_string 1.5 - q "-2.5 y*z - 7.1 x - 1"
-            @test_expression_with_string 2 * q "5 y*z + 14.2 x + 5"
-            @test_throws ErrorException 2 / q
-        end
-
-        # 2. Variable tests
-        @testset "Variable--???" begin
-            # 2-0 Variable unary
-            @test (+x) === x
-            @test_expression_with_string -x "-x"
-            # 2-1 Variable--Number
-            @test_expression_with_string w + 4.13 "w + 4.13"
-            @test_expression_with_string w - 4.13 "w - 4.13"
-            @test_expression_with_string w * 4.13 "4.13 w"
-            @test_expression_with_string w / 2.00 "0.5 w"
-            @test w == w
-            @test_expression_with_string x*y - 1 "x*y - 1"
-            @test_expression_with_string x^2 "x²"
-            @test_expression_with_string x^1 "x"
-            @test_expression_with_string x^0 "1"
-            @test_throws ErrorException x^3
-            @test_throws ErrorException x^1.5
-            # 2-2 Variable--Variable
-            @test_expression_with_string w + x "w + x"
-            @test_expression_with_string w - x "w - x"
-            @test_expression_with_string w * x "w*x"
-            @test_expression_with_string x - x "0"
-            @test_throws ErrorException w / x
-            @test_expression_with_string y*z - x "y*z - x"
-            # 2-3 Variable--AffExpr
-            @test_expression_with_string z + aff "z + 7.1 x + 2.5"
-            @test_expression_with_string z - aff "z - 7.1 x - 2.5"
-            @test_expression_with_string z * aff "7.1 z*x + 2.5 z"
-            @test_throws ErrorException z / aff
-            @test_throws MethodError z ≤ aff
-            @test_expression_with_string 7.1 * x - aff "0 x - 2.5"
-            # 2-4 Variable--QuadExpr
-            @test_expression_with_string w + q "2.5 y*z + w + 7.1 x + 2.5"
-            @test_expression_with_string w - q "-2.5 y*z + w - 7.1 x - 2.5"
-            @test_throws ErrorException w*q
-            @test_throws ErrorException w/q
-            @test transpose(x) === x
-            @test conj(x) === x
-        end
-
-        # 3. AffExpr tests
-        @testset "AffExpr--???" begin
-            # 3-0 AffExpr unary
-            @test_expression_with_string +aff "7.1 x + 2.5"
-            @test_expression_with_string -aff "-7.1 x - 2.5"
-            # 3-1 AffExpr--Number
-            @test_expression_with_string aff + 1.5 "7.1 x + 4"
-            @test_expression_with_string aff - 1.5 "7.1 x + 1"
-            @test_expression_with_string aff * 2 "14.2 x + 5"
-            @test_expression_with_string aff / 2 "3.55 x + 1.25"
-            @test_throws MethodError aff ≤ 1
-            @test aff == aff
-            @test_throws MethodError aff ≥ 1
-            @test_expression_with_string aff - 1 "7.1 x + 1.5"
-            @test_expression_with_string aff^2 "50.41 x² + 35.5 x + 6.25"
-            @test_expression_with_string (7.1*x + 2.5)^2 "50.41 x² + 35.5 x + 6.25"
-            @test_expression_with_string aff^1 "7.1 x + 2.5"
-            @test_expression_with_string (7.1*x + 2.5)^1 "7.1 x + 2.5"
-            @test_expression_with_string aff^0 "1"
-            @test_expression_with_string (7.1*x + 2.5)^0 "1"
-            @test_throws ErrorException aff^3
-            @test_throws ErrorException (7.1*x + 2.5)^3
-            @test_throws ErrorException aff^1.5
-            @test_throws ErrorException (7.1*x + 2.5)^1.5
-            # 3-2 AffExpr--Variable
-            @test_expression_with_string aff + z "7.1 x + z + 2.5"
-            @test_expression_with_string aff - z "7.1 x - z + 2.5"
-            @test_expression_with_string aff * z "7.1 x*z + 2.5 z"
-            @test_throws ErrorException aff/z
-            @test_expression_with_string aff - 7.1 * x "0 x + 2.5"
-            # 3-3 AffExpr--AffExpr
-            @test_expression_with_string aff + aff2 "7.1 x + 1.2 y + 3.7"
-            @test_expression_with_string aff - aff2 "7.1 x - 1.2 y + 1.3"
-            @test_expression_with_string aff * aff2 "8.52 x*y + 3 y + 8.52 x + 3"
-            @test string((x+x)*(x+3)) == string((x+3)*(x+x))  # Issue #288
-            @test_throws ErrorException aff/aff2
-            @test_expression_with_string aff-aff "0 x"
-            # 4-4 AffExpr--QuadExpr
-            @test_expression_with_string aff2 + q "2.5 y*z + 1.2 y + 7.1 x + 3.7"
-            @test_expression_with_string aff2 - q "-2.5 y*z + 1.2 y - 7.1 x - 1.3"
-            @test_throws ErrorException aff2 * q
-            @test_throws ErrorException aff2 / q
-            @test transpose(aff) === aff
-            @test conj(aff) === aff
-        end
-
-        # 4. QuadExpr
-        # TODO: This test block and others above should be rewritten to be
-        # self-contained. The definitions of q, w, and aff2 are too far to
-        # easily check correctness of the tests.
-        @testset "QuadExpr--???" begin
-            # 4-0 QuadExpr unary
-            @test_expression_with_string +q "2.5 y*z + 7.1 x + 2.5"
-            @test_expression_with_string -q "-2.5 y*z - 7.1 x - 2.5"
-            # 4-1 QuadExpr--Number
-            @test_expression_with_string q + 1.5 "2.5 y*z + 7.1 x + 4"
-            @test_expression_with_string q - 1.5 "2.5 y*z + 7.1 x + 1"
-            @test_expression_with_string q * 2 "5 y*z + 14.2 x + 5"
-            @test_expression_with_string q / 2 "1.25 y*z + 3.55 x + 1.25"
-            @test q == q
-            @test_expression_with_string aff2 - q "-2.5 y*z + 1.2 y - 7.1 x - 1.3"
-            # 4-2 QuadExpr--Variable
-            @test_expression_with_string q + w "2.5 y*z + 7.1 x + w + 2.5"
-            @test_expression_with_string q - w "2.5 y*z + 7.1 x - w + 2.5"
-            @test_throws ErrorException q*w
-            @test_throws ErrorException q/w
-            # 4-3 QuadExpr--AffExpr
-            @test_expression_with_string q + aff2 "2.5 y*z + 7.1 x + 1.2 y + 3.7"
-            @test_expression_with_string q - aff2 "2.5 y*z + 7.1 x - 1.2 y + 1.3"
-            @test_throws ErrorException q * aff2
-            @test_throws ErrorException q / aff2
-            # 4-4 QuadExpr--QuadExpr
-            @test_expression_with_string q + q2 "2.5 y*z + 8 x*z + 7.1 x + 1.2 y + 3.7"
-            @test_expression_with_string q - q2 "2.5 y*z - 8 x*z + 7.1 x - 1.2 y + 1.3"
-            @test_throws ErrorException q * q2
-            @test_throws ErrorException q / q2
-            @test transpose(q) === q
-            @test conj(q) === q
-        end
+function test_operator_warn(ModelType, ::Any)
+    model = ModelType()
+    @variable model x[1:51]
+    # JuMPExtension does not have the `operator_counter` field
+    if ModelType <: Model
+        @test model.operator_counter == 0
     end
-
-    @testset "Higher-level operators" begin
-        model = ModelType()
-        @testset "sum" begin
-            sum_m = ModelType()
-            @variable(sum_m, 0 ≤ matrix[1:3,1:3] ≤ 1, start = 1)
-            @testset "sum(j::DenseAxisArray{Variable})" begin
-                @test_expression_with_string sum(matrix) "matrix[1,1] + matrix[2,1] + matrix[3,1] + matrix[1,2] + matrix[2,2] + matrix[3,2] + matrix[1,3] + matrix[2,3] + matrix[3,3]"
-            end
-
-            @testset "sum(j::DenseAxisArray{T}) where T<:Real" begin
-                @test sum(JuMP.start_value.(matrix)) ≈ 9
-            end
-            @testset "sum(j::Array{VariableRef})" begin
-                @test string(sum(matrix[1:3,1:3])) == string(sum(matrix))
-            end
-            @testset "sum(affs::Array{AffExpr})" begin
-                @test_expression_with_string sum([2*matrix[i,j] for i in 1:3, j in 1:3]) "2 matrix[1,1] + 2 matrix[2,1] + 2 matrix[3,1] + 2 matrix[1,2] + 2 matrix[2,2] + 2 matrix[3,2] + 2 matrix[1,3] + 2 matrix[2,3] + 2 matrix[3,3]"
-            end
-            @testset "sum(quads::Array{QuadExpr})" begin
-                @test_expression_with_string sum([2*matrix[i,j]^2 for i in 1:3, j in 1:3]) "2 matrix[1,1]² + 2 matrix[2,1]² + 2 matrix[3,1]² + 2 matrix[1,2]² + 2 matrix[2,2]² + 2 matrix[3,2]² + 2 matrix[1,3]² + 2 matrix[2,3]² + 2 matrix[3,3]²"
-            end
-
-            S = [1,3]
-            @variable(sum_m, x[S], start=1)
-            @testset "sum(j::JuMPDict{VariableRef})" begin
-                @test_expression sum(x)
-                @test length(string(sum(x))) == 11 # order depends on hashing
-                @test occursin("x[1]",string(sum(x)))
-                @test occursin("x[3]",string(sum(x)))
-            end
-            @testset "sum(j::JuMPDict{T}) where T<:Real" begin
-                @test sum(JuMP.start_value.(x)) == 2
-            end
-        end
-
-        @testset "dot" begin
-            dot_m = ModelType()
-            @variable(dot_m, 0 ≤ x[1:3] ≤ 1)
-
-            @test_expression_with_string dot(x[1],x[1]) "x[1]²"
-            @test_expression_with_string dot(2,x[1]) "2 x[1]"
-            @test_expression_with_string dot(x[1],2) "2 x[1]"
-
-            c = vcat(1:3)
-            @test_expression_with_string dot(c,x) "x[1] + 2 x[2] + 3 x[3]"
-            @test_expression_with_string dot(x,c) "x[1] + 2 x[2] + 3 x[3]"
-
-            A = [1 3 ; 2 4]
-            @variable(dot_m, 1 ≤ y[1:2,1:2] ≤ 1)
-            @test_expression_with_string dot(A,y) "y[1,1] + 2 y[2,1] + 3 y[1,2] + 4 y[2,2]"
-            @test_expression_with_string dot(y,A) "y[1,1] + 2 y[2,1] + 3 y[1,2] + 4 y[2,2]"
-
-            B = ones(2,2,2)
-            @variable(dot_m, 0 ≤ z[1:2,1:2,1:2] ≤ 1)
-            @test_expression_with_string dot(B,z) "z[1,1,1] + z[2,1,1] + z[1,2,1] + z[2,2,1] + z[1,1,2] + z[2,1,2] + z[1,2,2] + z[2,2,2]"
-            @test_expression_with_string dot(z,B) "z[1,1,1] + z[2,1,1] + z[1,2,1] + z[2,2,1] + z[1,1,2] + z[2,1,2] + z[1,2,2] + z[2,2,2]"
-
-            @objective(dot_m, Max, dot(x, ones(3)) - dot(y, ones(2,2)))
-            for i in 1:3
-                JuMP.set_start_value(x[i], 1)
-            end
-            for i in 1:2, j in 1:2
-                JuMP.set_start_value(y[i,j], 1)
-            end
-            for i in 1:2, j in 1:2, k in 1:2
-                JuMP.set_start_value(z[i,j,k], 1)
-            end
-            @test dot(c, JuMP.start_value.(x)) ≈ 6
-            @test dot(A, JuMP.start_value.(y)) ≈ 10
-            @test dot(B, JuMP.start_value.(z)) ≈ 8
-
-            if ModelType <: Model
-                # Only `Model` is guaranteed to have `operator_counter`, so
-                # only test for that case.
-                @testset "dot doesn't trigger operator_counter" begin
-                    # Check that dot is not falling back to default, inefficient
-                    # addition (JuMP PR #943).
-                    model = ModelType()
-                    @test model.operator_counter == 0
-                    @variable(model, x[1:100])
-                    JuMP.set_start_value.(x, 1:100)
-                    @expression(model, test_sum, sum(x[i] * i for i in 1:100))
-                    @expression(model, test_dot1, dot(x, 1:100))
-                    @expression(model, test_dot2, dot(1:100, x))
-                    @test model.operator_counter == 0
-                    test_add = test_dot1 + test_dot2
-                    @test model.operator_counter == 1  # Check triggerable.
-                    test_sum_value = JuMP.value(test_sum, JuMP.start_value)
-                    @test test_sum_value ≈ JuMP.value(test_dot1, JuMP.start_value)
-                    @test test_sum_value ≈ JuMP.value(test_dot2, JuMP.start_value)
-                end
-            end
-        end
+    # Triggers the increment of operator_counter since sum(x) has more than 50 terms
+    @test_expression(sum(x) + 2x[1])
+    if ModelType <: Model
+        # The following check verifies that this test covers the code incrementing `operator_counter`
+        @test model.operator_counter == 1
     end
+end
 
-    @testset "Broadcase divisio error" begin
-        model = ModelType()
-        @variable(model, x[1:2, 1:2])
-        A = [1 2;
-             3 4]
-        B = sparse(A)
-        y = SparseMatrixCSC(2, 2, copy(B.colptr), copy(B.rowval), vec(x))
-        @test_throws ErrorException A ./ x
-        @test_throws ErrorException B ./ x
-        @test_throws ErrorException A ./ y
-        @test_throws ErrorException B ./ y
+function test_uniform_scaling(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, x)
+    @test_expression_with_string x + 2I "x + 2"
+    @test_expression_with_string (x + 1) + I "x + 2"
+    @test_expression_with_string x - 2I "x - 2"
+    @test_expression_with_string (x - 1) - I "x - 2"
+    @test_expression_with_string 2I + x "x + 2"
+    @test_expression_with_string I + (x + 1) "x + 2"
+    @test_expression_with_string 2I - x "-x + 2"
+    @test_expression_with_string I - (x - 1) "-x + 2"
+    @test_expression_with_string I * x "x"
+    @test_expression_with_string I * (x + 1) "x + 1"
+    @test_expression_with_string (x + 1) * I "x + 1"
+end
 
-        # TODO: Refactor to avoid calling the internal JuMP function
-        # `_densify_with_jump_eltype`.
-        #z = JuMP._densify_with_jump_eltype((2 .* y) ./ 3)
-        #@test JuMP.isequal_canonical((2 .* x) ./ 3, z)
-        #z = JuMP._densify_with_jump_eltype(2 * (y ./ 3))
-        #@test JuMP.isequal_canonical(2 .* (x ./ 3), z)
-        #z = JuMP._densify_with_jump_eltype((x[1,1],) .* B)
-        #@test JuMP.isequal_canonical((x[1,1],) .* A, z)
+function test_basic_operators(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, w)
+    @variable(model, x)
+    @variable(model, y)
+    @variable(model, z)
+
+    aff = @inferred 7.1 * x + 2.5
+    @test_expression_with_string 7.1 * x + 2.5 "7.1 x + 2.5"
+    aff2 = @inferred 1.2 * y + 1.2
+    @test_expression_with_string 1.2 * y + 1.2 "1.2 y + 1.2"
+    q = @inferred 2.5 * y * z + aff
+    @test_expression_with_string 2.5 * y * z + aff "2.5 y*z + 7.1 x + 2.5"
+    q2 = @inferred 8 * x * z + aff2
+    @test_expression_with_string 8 * x * z + aff2 "8 x*z + 1.2 y + 1.2"
+    @test_expression_with_string 2 * x * x + 1 * y * y + z + 3 "2 x² + y² + z + 3"
+end
+
+function test_basic_operators_number(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, w)
+    @variable(model, x)
+    @variable(model, y)
+    @variable(model, z)
+
+    aff = @inferred 7.1 * x + 2.5
+    q = @inferred 2.5 * y * z + aff
+
+    # 1-1 Number--Number
+    # ???
+    # 1-2 Number--Variable
+    @test_expression_with_string 4.13 + w "w + 4.13"
+    @test_expression_with_string 3.16 - w "-w + 3.16"
+    @test_expression_with_string 5.23 * w "5.23 w"
+    @test_throws ErrorException 2.94 / w
+    # 1-3 Number--AffExpr
+    @test_expression_with_string 1.5 + aff "7.1 x + 4"
+    @test_expression_with_string 1.5 - aff "-7.1 x - 1"
+    @test_expression_with_string 2 * aff "14.2 x + 5"
+    @test_throws ErrorException 2 / aff
+    # 1-4 Number--QuadExpr
+    @test_expression_with_string 1.5 + q "2.5 y*z + 7.1 x + 4"
+    @test_expression_with_string 1.5 - q "-2.5 y*z - 7.1 x - 1"
+    @test_expression_with_string 2 * q "5 y*z + 14.2 x + 5"
+    @test_throws ErrorException 2 / q
+end
+
+function test_basic_operators_variable(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, w)
+    @variable(model, x)
+    @variable(model, y)
+    @variable(model, z)
+
+    aff = @inferred 7.1 * x + 2.5
+    q = @inferred 2.5 * y * z + aff
+
+    # 2-0 Variable unary
+    @test (+x) === x
+    @test_expression_with_string -x "-x"
+    # 2-1 Variable--Number
+    @test_expression_with_string w + 4.13 "w + 4.13"
+    @test_expression_with_string w - 4.13 "w - 4.13"
+    @test_expression_with_string w * 4.13 "4.13 w"
+    @test_expression_with_string w / 2.00 "0.5 w"
+    @test w == w
+    @test_expression_with_string x*y - 1 "x*y - 1"
+    @test_expression_with_string x^2 "x²"
+    @test_expression_with_string x^1 "x"
+    @test_expression_with_string x^0 "1"
+    @test_throws ErrorException x^3
+    @test_throws ErrorException x^1.5
+    # 2-2 Variable--Variable
+    @test_expression_with_string w + x "w + x"
+    @test_expression_with_string w - x "w - x"
+    @test_expression_with_string w * x "w*x"
+    @test_expression_with_string x - x "0"
+    @test_throws ErrorException w / x
+    @test_expression_with_string y*z - x "y*z - x"
+    # 2-3 Variable--AffExpr
+    @test_expression_with_string z + aff "z + 7.1 x + 2.5"
+    @test_expression_with_string z - aff "z - 7.1 x - 2.5"
+    @test_expression_with_string z * aff "7.1 z*x + 2.5 z"
+    @test_throws ErrorException z / aff
+    @test_throws MethodError z ≤ aff
+    @test_expression_with_string 7.1 * x - aff "0 x - 2.5"
+    # 2-4 Variable--QuadExpr
+    @test_expression_with_string w + q "2.5 y*z + w + 7.1 x + 2.5"
+    @test_expression_with_string w - q "-2.5 y*z + w - 7.1 x - 2.5"
+    @test_throws ErrorException w*q
+    @test_throws ErrorException w/q
+    @test transpose(x) === x
+    @test conj(x) === x
+end
+
+function test_basic_operators_affexpr(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, w)
+    @variable(model, x)
+    @variable(model, y)
+    @variable(model, z)
+
+    aff = @inferred 7.1 * x + 2.5
+    aff2 = @inferred 1.2 * y + 1.2
+    q = @inferred 2.5 * y * z + aff
+    # 3-0 AffExpr unary
+    @test_expression_with_string +aff "7.1 x + 2.5"
+    @test_expression_with_string -aff "-7.1 x - 2.5"
+    # 3-1 AffExpr--Number
+    @test_expression_with_string aff + 1.5 "7.1 x + 4"
+    @test_expression_with_string aff - 1.5 "7.1 x + 1"
+    @test_expression_with_string aff * 2 "14.2 x + 5"
+    @test_expression_with_string aff / 2 "3.55 x + 1.25"
+    @test_throws MethodError aff ≤ 1
+    @test aff == aff
+    @test_throws MethodError aff ≥ 1
+    @test_expression_with_string aff - 1 "7.1 x + 1.5"
+    @test_expression_with_string aff^2 "50.41 x² + 35.5 x + 6.25"
+    @test_expression_with_string (7.1*x + 2.5)^2 "50.41 x² + 35.5 x + 6.25"
+    @test_expression_with_string aff^1 "7.1 x + 2.5"
+    @test_expression_with_string (7.1*x + 2.5)^1 "7.1 x + 2.5"
+    @test_expression_with_string aff^0 "1"
+    @test_expression_with_string (7.1*x + 2.5)^0 "1"
+    @test_throws ErrorException aff^3
+    @test_throws ErrorException (7.1*x + 2.5)^3
+    @test_throws ErrorException aff^1.5
+    @test_throws ErrorException (7.1*x + 2.5)^1.5
+    # 3-2 AffExpr--Variable
+    @test_expression_with_string aff + z "7.1 x + z + 2.5"
+    @test_expression_with_string aff - z "7.1 x - z + 2.5"
+    @test_expression_with_string aff * z "7.1 x*z + 2.5 z"
+    @test_throws ErrorException aff/z
+    @test_expression_with_string aff - 7.1 * x "0 x + 2.5"
+    # 3-3 AffExpr--AffExpr
+    @test_expression_with_string aff + aff2 "7.1 x + 1.2 y + 3.7"
+    @test_expression_with_string aff - aff2 "7.1 x - 1.2 y + 1.3"
+    @test_expression_with_string aff * aff2 "8.52 x*y + 3 y + 8.52 x + 3"
+    @test string((x+x)*(x+3)) == string((x+3)*(x+x))  # Issue #288
+    @test_throws ErrorException aff/aff2
+    @test_expression_with_string aff-aff "0 x"
+    # 4-4 AffExpr--QuadExpr
+    @test_expression_with_string aff2 + q "2.5 y*z + 1.2 y + 7.1 x + 3.7"
+    @test_expression_with_string aff2 - q "-2.5 y*z + 1.2 y - 7.1 x - 1.3"
+    @test_throws ErrorException aff2 * q
+    @test_throws ErrorException aff2 / q
+    @test transpose(aff) === aff
+    @test conj(aff) === aff
+end
+
+function test_basic_operators_quadexpr(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, w)
+    @variable(model, x)
+    @variable(model, y)
+    @variable(model, z)
+
+    aff = @inferred 7.1 * x + 2.5
+    aff2 = @inferred 1.2 * y + 1.2
+    q = @inferred 2.5 * y * z + aff
+    q2 = @inferred 8 * x * z + aff2
+    # 4-0 QuadExpr unary
+    @test_expression_with_string +q "2.5 y*z + 7.1 x + 2.5"
+    @test_expression_with_string -q "-2.5 y*z - 7.1 x - 2.5"
+    # 4-1 QuadExpr--Number
+    @test_expression_with_string q + 1.5 "2.5 y*z + 7.1 x + 4"
+    @test_expression_with_string q - 1.5 "2.5 y*z + 7.1 x + 1"
+    @test_expression_with_string q * 2 "5 y*z + 14.2 x + 5"
+    @test_expression_with_string q / 2 "1.25 y*z + 3.55 x + 1.25"
+    @test q == q
+    @test_expression_with_string aff2 - q "-2.5 y*z + 1.2 y - 7.1 x - 1.3"
+    # 4-2 QuadExpr--Variable
+    @test_expression_with_string q + w "2.5 y*z + 7.1 x + w + 2.5"
+    @test_expression_with_string q - w "2.5 y*z + 7.1 x - w + 2.5"
+    @test_throws ErrorException q*w
+    @test_throws ErrorException q/w
+    # 4-3 QuadExpr--AffExpr
+    @test_expression_with_string q + aff2 "2.5 y*z + 7.1 x + 1.2 y + 3.7"
+    @test_expression_with_string q - aff2 "2.5 y*z + 7.1 x - 1.2 y + 1.3"
+    @test_throws ErrorException q * aff2
+    @test_throws ErrorException q / aff2
+    # 4-4 QuadExpr--QuadExpr
+    @test_expression_with_string q + q2 "2.5 y*z + 8 x*z + 7.1 x + 1.2 y + 3.7"
+    @test_expression_with_string q - q2 "2.5 y*z - 8 x*z + 7.1 x - 1.2 y + 1.3"
+    @test_throws ErrorException q * q2
+    @test_throws ErrorException q / q2
+    @test transpose(q) === q
+    @test conj(q) === q
+end
+
+function test_dot(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, 0 ≤ x[1:3] ≤ 1)
+
+    @test_expression_with_string dot(x[1],x[1]) "x[1]²"
+    @test_expression_with_string dot(2,x[1]) "2 x[1]"
+    @test_expression_with_string dot(x[1],2) "2 x[1]"
+
+    c = vcat(1:3)
+    @test_expression_with_string dot(c,x) "x[1] + 2 x[2] + 3 x[3]"
+    @test_expression_with_string dot(x,c) "x[1] + 2 x[2] + 3 x[3]"
+
+    A = [1 3 ; 2 4]
+    @variable(model, 1 ≤ y[1:2,1:2] ≤ 1)
+    @test_expression_with_string dot(A,y) "y[1,1] + 2 y[2,1] + 3 y[1,2] + 4 y[2,2]"
+    @test_expression_with_string dot(y,A) "y[1,1] + 2 y[2,1] + 3 y[1,2] + 4 y[2,2]"
+
+    B = ones(2,2,2)
+    @variable(model, 0 ≤ z[1:2,1:2,1:2] ≤ 1)
+    @test_expression_with_string dot(B,z) "z[1,1,1] + z[2,1,1] + z[1,2,1] + z[2,2,1] + z[1,1,2] + z[2,1,2] + z[1,2,2] + z[2,2,2]"
+    @test_expression_with_string dot(z,B) "z[1,1,1] + z[2,1,1] + z[1,2,1] + z[2,2,1] + z[1,1,2] + z[2,1,2] + z[1,2,2] + z[2,2,2]"
+
+    @objective(model, Max, dot(x, ones(3)) - dot(y, ones(2,2)))
+    for i in 1:3
+        JuMP.set_start_value(x[i], 1)
     end
-
-    @testset "Vectorized comparisons" begin
-        m = ModelType()
-        @variable(m, x[1:3])
-        A = [1 2 3
-             0 4 5
-             6 0 7]
-        B = sparse(A)
-        # force vector output
-        cref1 = @constraint(m, reshape(x, (1, 3)) * A * x .>= 1)
-        c1 = JuMP.constraint_object.(cref1)
-        f1 = map(c -> c.func, c1)
-        @test JuMP.isequal_canonical(f1, [x[1]*x[1] + 2x[1]*x[2] + 4x[2]*x[2] + 9x[1]*x[3] + 5x[2]*x[3] + 7x[3]*x[3]])
-        @test all(c -> c.set.lower == 1, c1)
-
-        cref2 = @constraint(m, x'*A*x >= 1)
-        c2 = JuMP.constraint_object.(cref2)
-        @test JuMP.isequal_canonical(f1[1], c2.func)
-
-        mat = [ 3x[1] + 12x[3] +  4x[2]
-                2x[1] + 12x[2] + 10x[3]
-               15x[1] +  5x[2] + 21x[3]]
-
-        cref3 = @constraint(m, (x'A)' + 2A*x .<= 1)
-        c3 = JuMP.constraint_object.(cref3)
-        f3 = map(c->c.func, c3)
-        @test JuMP.isequal_canonical(f3, mat)
-        @test all(c -> c.set.upper == 1, c3)
-        @test JuMP.isequal_canonical((x'A)' + 2A*x, (x'A)' + 2B*x)
-        @test JuMP.isequal_canonical((x'A)' + 2A*x, (x'B)' + 2A*x)
-        @test JuMP.isequal_canonical((x'A)' + 2A*x, (x'B)' + 2B*x)
-        @test JuMP.isequal_canonical((x'A)' + 2A*x, MA.@rewrite((x'A)' + 2A*x))
-        @test JuMP.isequal_canonical((x'A)' + 2A*x, MA.@rewrite((x'B)' + 2A*x))
-        @test JuMP.isequal_canonical((x'A)' + 2A*x, MA.@rewrite((x'A)' + 2B*x))
-        @test JuMP.isequal_canonical((x'A)' + 2A*x, MA.@rewrite((x'B)' + 2B*x))
-
-        cref4 = @constraint(m, -1 .<= (x'A)' + 2A*x .<= 1)
-        c4 = JuMP.constraint_object.(cref4)
-        f4 = map(c->c.func, c4)
-        @test JuMP.isequal_canonical(f4, mat)
-        @test all(c -> c.set.lower == -1, c4)
-        @test all(c -> c.set.upper == 1, c4)
-
-        cref5 = @constraint(m, -[1:3;] .<= (x'A)' + 2A*x .<= 1)
-        c5 = JuMP.constraint_object.(cref5)
-        f5 = map(c->c.func, c5)
-        @test JuMP.isequal_canonical(f5, mat)
-        @test map(c -> c.set.lower, c5) == -[1:3;]
-        @test all(c -> c.set.upper == 1, c4)
-
-        cref6 = @constraint(m, -[1:3;] .<= (x'A)' + 2A*x .<= [3:-1:1;])
-        c6 = JuMP.constraint_object.(cref6)
-        f6 = map(c->c.func, c6)
-        @test JuMP.isequal_canonical(f6, mat)
-        @test map(c -> c.set.lower, c6) == -[1:3;]
-        @test map(c -> c.set.upper, c6) == [3:-1:1;]
-
-        cref7 = @constraint(m, -[1:3;] .<= (x'A)' + 2A*x .<= 3)
-        c7 = JuMP.constraint_object.(cref7)
-        f7 = map(c->c.func, c7)
-        @test JuMP.isequal_canonical(f7, mat)
-        @test map(c -> c.set.lower, c7) == -[1:3;]
-        @test all(c -> c.set.upper == 3, c7)
+    for i in 1:2, j in 1:2
+        JuMP.set_start_value(y[i,j], 1)
     end
-
-    @testset "Custom types" begin
-        ElemT = MySumType{AffExprType}
-        model = ModelType()
-        @variable model Q[1:3, 1:3] PSD
-
-        @testset "DimensionMismatch when performing vector-matrix multiplication #988" begin
-            x = [MyType(1), MyType(2), MyType(3)]
-            y = Q * x
-            z = x' * Q
-            @test y isa Vector{ElemT}
-            @test size(y) == (3,)
-            @test z isa Adjoint{ElemT, <:Any}
-            @test size(z) == (1, 3)
-            for i in 1:3
-                # Q is symmetric
-                a = zero(AffExprType)
-                a += Q[1,i]
-                a += 2Q[2,i]
-                a += 3Q[3,i]
-                # Q[1,i] + 2Q[2,i] + 3Q[3,i] is rearranged as 2 Q[2,3] + Q[1,3] + 3 Q[3,3]
-                @test z[i].a == y[i].a == a
-            end
-        end
-
-        @testset "Matrix multiplication #1990" begin
-            X = MyType.((1:3)' .+ (1:3))
-            @test_expression Q * X
-            Y = Q * X
-            @test_expression X' * Q
-            Z = X' * Q
-            @test Y isa Matrix{ElemT}
-            @test size(Y) == (3, 3)
-            @test Z isa Matrix{ElemT}
-            @test size(Z) == (3, 3)
-            @test JuMP.isequal_canonical(Z', Y)
-            @test_expression Q * X'
-            Y = Q * X'
-            @test_expression X * Q
-            Z = X * Q
-            @test Y isa Matrix{ElemT}
-            @test size(Y) == (3, 3)
-            @test Z isa Matrix{ElemT}
-            @test size(Z) == (3, 3)
-            @test JuMP.isequal_canonical(Z', Y)
-        end
+    for i in 1:2, j in 1:2, k in 1:2
+        JuMP.set_start_value(z[i,j,k], 1)
     end
+    @test dot(c, JuMP.start_value.(x)) ≈ 6
+    @test dot(A, JuMP.start_value.(y)) ≈ 10
+    @test dot(B, JuMP.start_value.(z)) ≈ 8
 
-    @testset "operator_warn" begin
-        model = ModelType()
-        @variable model x[1:51]
-        # JuMPExtension does not have the `operator_counter` field
-        if ModelType <: Model
+    if ModelType <: Model
+        # Only `Model` is guaranteed to have `operator_counter`, so
+        # only test for that case.
+        @testset "dot doesn't trigger operator_counter" begin
+            # Check that dot is not falling back to default, inefficient
+            # addition (JuMP PR #943).
+            model = ModelType()
             @test model.operator_counter == 0
-        end
-        # Triggers the increment of operator_counter since sum(x) has more than 50 terms
-        @test_expression(sum(x) + 2x[1])
-        if ModelType <: Model
-            # The following check verifies that this test covers the code incrementing `operator_counter`
-            @test model.operator_counter == 1
-        end
-    end
-
-    @testset "UniformScaling" begin
-        model = ModelType()
-        @testset "Scalar" begin
-            @variable(model, x)
-            @test_expression_with_string x + 2I "x + 2"
-            @test_expression_with_string (x + 1) + I "x + 2"
-            @test_expression_with_string x - 2I "x - 2"
-            @test_expression_with_string (x - 1) - I "x - 2"
-            @test_expression_with_string 2I + x "x + 2"
-            @test_expression_with_string I + (x + 1) "x + 2"
-            @test_expression_with_string 2I - x "-x + 2"
-            @test_expression_with_string I - (x - 1) "-x + 2"
-            @test_expression_with_string I * x "x"
-            @test_expression_with_string I * (x + 1) "x + 1"
-            @test_expression_with_string (x + 1) * I "x + 1"
+            @variable(model, x[1:100])
+            JuMP.set_start_value.(x, 1:100)
+            @expression(model, test_sum, sum(x[i] * i for i in 1:100))
+            @expression(model, test_dot1, dot(x, 1:100))
+            @expression(model, test_dot2, dot(1:100, x))
+            @test model.operator_counter == 0
+            test_add = test_dot1 + test_dot2
+            @test model.operator_counter == 1  # Check triggerable.
+            test_sum_value = JuMP.value(test_sum, JuMP.start_value)
+            @test test_sum_value ≈ JuMP.value(test_dot1, JuMP.start_value)
+            @test test_sum_value ≈ JuMP.value(test_dot2, JuMP.start_value)
         end
     end
 end
 
-@testset "Operators for JuMP.Model" begin
-    operators_test(Model, VariableRef)
+function test_higher_level(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, 0 ≤ matrix[1:3,1:3] ≤ 1, start = 1)
+    @testset "sum(j::DenseAxisArray{Variable})" begin
+        @test_expression_with_string sum(matrix) "matrix[1,1] + matrix[2,1] + matrix[3,1] + matrix[1,2] + matrix[2,2] + matrix[3,2] + matrix[1,3] + matrix[2,3] + matrix[3,3]"
+    end
+
+    @testset "sum(j::DenseAxisArray{T}) where T<:Real" begin
+        @test sum(JuMP.start_value.(matrix)) ≈ 9
+    end
+    @testset "sum(j::Array{VariableRef})" begin
+        @test string(sum(matrix[1:3,1:3])) == string(sum(matrix))
+    end
+    @testset "sum(affs::Array{AffExpr})" begin
+        @test_expression_with_string sum([2*matrix[i,j] for i in 1:3, j in 1:3]) "2 matrix[1,1] + 2 matrix[2,1] + 2 matrix[3,1] + 2 matrix[1,2] + 2 matrix[2,2] + 2 matrix[3,2] + 2 matrix[1,3] + 2 matrix[2,3] + 2 matrix[3,3]"
+    end
+    @testset "sum(quads::Array{QuadExpr})" begin
+        @test_expression_with_string sum([2*matrix[i,j]^2 for i in 1:3, j in 1:3]) "2 matrix[1,1]² + 2 matrix[2,1]² + 2 matrix[3,1]² + 2 matrix[1,2]² + 2 matrix[2,2]² + 2 matrix[3,2]² + 2 matrix[1,3]² + 2 matrix[2,3]² + 2 matrix[3,3]²"
+    end
+    S = [1,3]
+    @variable(model, x[S], start=1)
+    @testset "sum(j::JuMPDict{VariableRef})" begin
+        @test_expression sum(x)
+        @test length(string(sum(x))) == 11 # order depends on hashing
+        @test occursin("x[1]",string(sum(x)))
+        @test occursin("x[3]",string(sum(x)))
+    end
+    @testset "sum(j::JuMPDict{T}) where T<:Real" begin
+        @test sum(JuMP.start_value.(x)) == 2
+    end
 end
 
-@testset "Operators for JuMPExtension.MyModel" begin
-    operators_test(JuMPExtension.MyModel, JuMPExtension.MyVariableRef)
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if !startswith("$(name)", "test_")
+            continue
+        end
+        f = getfield(@__MODULE__, name)
+        @testset "$(name)" begin
+            f(Model, VariableRef)
+        end
+        @testset "$(name)-JuMPExtension" begin
+            f(JuMPExtension.MyModel, JuMPExtension.MyVariableRef)
+        end
+    end
 end
+
+end
+
+TestOperators.runtests()

--- a/test/print.jl
+++ b/test/print.jl
@@ -12,8 +12,15 @@
 #############################################################################
 
 using JuMP
-using LinearAlgebra, Test
-import JuMP.REPLMode, JuMP.IJuliaMode
+using LinearAlgebra
+using Test
+
+import JuMP.IJuliaMode
+import JuMP.REPLMode
+
+@static if !(:JuMPExtension in names(Main))
+    include(joinpath(@__DIR__, "JuMPExtension.jl"))
+end
 
 # Helper function to test IO methods work correctly
 function io_test(mode, obj, exp_str; repl=:both)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,16 +10,9 @@
 # test/runtests.jl
 #############################################################################
 
-using JuMP
-
-using LinearAlgebra  # for dot and tr
-using SparseArrays # for sparse
 using Test
 
 include("Containers/Containers.jl")
-
-include("utilities.jl")
-include("JuMPExtension.jl")
 
 @testset "$(file)" for file in filter(f -> endswith(f, ".jl"), readdir(@__DIR__))
     if file in [
@@ -31,7 +24,9 @@ include("JuMPExtension.jl")
     ]
         continue
     end
+    t = time()
     include(file)
+    println("$(file) took $(round(time() - t; digits = 1)) seconds.")
 end
 
 # TODO: The hygiene test should run in a separate Julia instance where JuMP

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -19,8 +19,9 @@ end
 
 macro test_expression_with_string(expr, str)
     esc(quote
-            @test string(@inferred $expr) == $str
-            @test_expression $expr
+            realized_expr = @inferred $expr
+            @test string(realized_expr) == $str
+            @test JuMP.isequal_canonical(@expression(model, $expr), realized_expr)
     end)
 end
 

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -12,13 +12,13 @@
 #############################################################################
 
 using JuMP
-
 import LinearAlgebra: Symmetric
 using Test
 
-include("utilities.jl")
+include(joinpath(@__DIR__, "utilities.jl"))
+
 @static if !(:JuMPExtension in names(Main))
-    include("JuMPExtension.jl")
+    include(joinpath(@__DIR__, "JuMPExtension.jl"))
 end
 
 function test_variable_name(variable, name)


### PR DESCRIPTION
This PR is an attempt to make the JuMP tests run faster.

The first commit is a general tidying commit:
- Removes unneeded imports
- Remove `DualNumbers` in favor of `ForwardDiff`
- Adds imports each test file so that it can be run independently of `runtests.jl`, or in an arbitrary order

The next commits refactor the worst-performing files to speed them up.

In every case, the overwhelming majority of the time is spent compiling methods instead of doing work.

For example, running `test/operator.jl` (slightly modified to call `TestOperator.runtests()` twice) on my machine yields:
```Julia
oscar@Oscars-MBP JuMP % ~/julia1.3 --project=. --color=yes test/operator.jl 
 31.475031 seconds (89.82 M allocations: 4.505 GiB, 5.54% gc time)
  0.025482 seconds (64.32 k allocations: 5.131 MiB)
```
Yes, that is a 1200 fold difference in run time the second time round 😢.
Running it with `-O0` drops the time further.
```julia
oscar@Oscars-MBP JuMP % ~/julia1.3 --project=. --color=yes -O0 test/operator.jl
 23.202877 seconds (89.82 M allocations: 4.505 GiB, 7.17% gc time)
  0.023707 seconds (64.97 k allocations: 5.151 MiB)
```

Current top-5 run times in seconds
| commit | ma | operator | file_formats | constraint | variable | TOTAL(5) |
| --: | --: | --: | --: | --: | --: | --: |
| start (s) | 200 |  76 | 64 | 59 | 33 | 432 |
| latest (s) | 101 | 40 | 35 | 51 |  34 | 261 |
|change | -50% | -47% | -45% | -13% |  +0% | -40% |


Latest `master` build of Travis:
![image](https://user-images.githubusercontent.com/8177701/87257943-f1292280-c464-11ea-9a58-18520e121cc4.png)

Latest Travis build for this branch:
![image](https://user-images.githubusercontent.com/8177701/87262970-64d92880-c481-11ea-9f71-51243bd53dbe.png)

TODO before merging:
- [ ] Consider whether to cherry pick commits 2 to N into separate PRs
- [ ] Can we run travis with `-O0`?