### PR TITLE
Remove convert methods which cause method invalidations

### DIFF
--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -311,13 +311,6 @@ end
 function Base.convert(::Type{GenericAffExpr{T,V}}, v::_Constant) where {T,V}
     return GenericAffExpr{T,V}(convert(T, _constant_to_number(v)))
 end
-# Used in `JuMP._mul!`.
-function Base.convert(::Type{T}, aff::GenericAffExpr{T}) where T
-    if !isempty(aff.terms)
-        throw(InexactError(:convert, T, aff))
-    end
-    return convert(T, aff.constant)
-end
 
 # Alias for (Float64, VariableRef), the specific GenericAffExpr used by JuMP
 const AffExpr = GenericAffExpr{Float64,VariableRef}

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -324,13 +324,6 @@ function Base.convert(::Type{GenericQuadExpr{C, V}}, v::Union{_Constant,Abstract
     return GenericQuadExpr(convert(GenericAffExpr{C, V}, v))
 end
 GenericQuadExpr{C, V}() where {C, V} = zero(GenericQuadExpr{C, V})
-# Used in `JuMP._mul!`.
-function Base.convert(::Type{T}, quad::GenericQuadExpr{T}) where T
-    if !isempty(quad.terms)
-        throw(InexactError(:convert, T, quad))
-    end
-    return convert(T, quad.aff)
-end
 
 function check_belongs_to_model(q::GenericQuadExpr, model::AbstractModel)
     check_belongs_to_model(q.aff, model)


### PR DESCRIPTION
TODO: 
- [x] Wait for https://github.com/JuliaLang/julia/pull/35877 to be merged and try again

x-ref #2273 

These methods appear to be used from before we switched to MutableArithmetics.

In the future, instead of overloading Base.convert, we should use a new function
like `to_constant(::AffExpr)` which avoids the invalidation. Alternatively,
future versions of Julia may be clever enough to avoid the invalidations.

## Background

- `@snoopr` docs: https://timholy.github.io/SnoopCompile.jl/stable/snoopr/
- Method invalidation blogpost https://github.com/JuliaLang/www.julialang.org/pull/794

## `master`

```Julia
(@v1.6) pkg> st
Status `~/.julia/environments/v1.6/Project.toml`
  [4076af6c] JuMP v0.21.3 `https://github.com/jump-dev/JuMP.jl.git#master`
  [aa65fe97] SnoopCompile v1.7.1

julia> using SnoopCompile

julia> invalidations = @snoopr using JuMP
[ Info: Precompiling JuMP [4076af6c-e467-56ae-b986-b466b2749572]
6630-element Vector{Any}:
  MethodInstance for __init__()
  "insert_backedges"
  MethodInstance for __init__()
  "insert_backedges"
  MethodInstance for __init__()
  "insert_backedges"
  MethodInstance for #readline#308(::Bool, ::typeof(readline), ::IO)
 0
  Tuple{typeof(resize!),Any,Any}
  MethodInstance for _groupedunique!(::AbstractVector{var"#s71"} where var"#s71"<:Real)
 ⋮
 1
  MethodInstance for instantiate(::Base.Broadcast.Broadcasted{Style,Nothing,typeof(Base.wrap_string),Args} where Args<:Tuple where Style<:Union{Nothing, Base.Broadcast.BroadcastStyle})
  "jl_method_table_insert"
  MethodInstance for materialize(::Base.Broadcast.Broadcasted{_A,Nothing,typeof(string),_B} where _B<:Tuple where _A<:Union{Nothing, Base.Broadcast.BroadcastStyle})
 1
  MethodInstance for instantiate(::Base.Broadcast.Broadcasted{_A,Nothing,typeof(string),_B} where _B<:Tuple where _A<:Union{Nothing, Base.Broadcast.BroadcastStyle})
  "jl_method_table_insert"
  instantiate(bc::Base.Broadcast.Broadcasted{var"#s141",Axes,F,Args} where Args<:Tuple where F where Axes where var"#s141"<:JuMP.Containers.BroadcastStyle) in JuMP.Containers at /Users/oscar/.julia/packages/JuMP/bpp7v/src/Containers/SparseAxisArray.jl:175
  "jl_method_table_insert"

julia> length(invalidations)
6630

julia> trees[end]
inserting convert(::Type{T}, quad::GenericQuadExpr{T,VarType} where VarType) where T in JuMP at /Users/oscar/.julia/packages/JuMP/bpp7v/src/quad_expr.jl:328 invalidated:
   mt_backedges:   1: signature Tuple{typeof(convert),Type{Symbol},Any} triggered MethodInstance for Pair{Symbol,Base.IRShow.var"#33#35"}(::Any, ::Any) (0 children)
                   2: signature Tuple{typeof(convert),Type{Base.IRShow.var"#33#35"},Any} triggered MethodInstance for Pair{Symbol,Base.IRShow.var"#33#35"}(::Any, ::Any) (0 children)

# ... lines omitted ...

julia> trees[end].backedges[1]
MethodInstance for convert(::Type{Any}, ::Any) at depth 0 with 1050 children
```

## This PR
```Julia
(@v1.6) pkg> st
Status `~/.julia/environments/v1.6/Project.toml`
  [4076af6c] JuMP v0.21.3 `~/.julia/dev/JuMP`
  [aa65fe97] SnoopCompile v1.7.1

julia> using SnoopCompile

julia> invalidations = @snoopr using JuMP
[ Info: Precompiling JuMP [4076af6c-e467-56ae-b986-b466b2749572]
1896-element Vector{Any}:
  MethodInstance for __init__()
  "insert_backedges"
  MethodInstance for __init__()
  "insert_backedges"
  MethodInstance for __init__()
  "insert_backedges"
  MethodInstance for #readline#308(::Bool, ::typeof(readline), ::IO)
 0
  Tuple{typeof(resize!),Any,Any}
  MethodInstance for _groupedunique!(::AbstractVector{var"#s71"} where var"#s71"<:Real)
 ⋮
  "jl_method_table_insert"
  MethodInstance for broadcasted(::typeof(string), ::AbstractArray)
 1
  MethodInstance for #unpack#101(::Bool, ::typeof(Pkg.PlatformEngines.unpack), ::String, ::String)
 2
  MethodInstance for broadcasted(::Base.Broadcast.BroadcastStyle, ::typeof(string), ::AbstractArray)
  "jl_method_table_insert"
  broadcasted(::JuMP.Containers.DenseAxisArrayBroadcastStyle, f, args...) in JuMP.Containers at /Users/oscar/.julia/dev/JuMP/src/Containers/DenseAxisArray.jl:246
  "jl_method_table_insert"

julia> length(invalidations)
1896
```