### PR TITLE
Add `value` for constraints with a custom `var_value` function

### DIFF
--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -161,6 +161,10 @@ function value(ex::GenericAffExpr{T, V}, var_value::Function) where {T, V}
     ret
 end
 
+function value(ex::Vector{GenericAffExpr{T, V}}, var_value::Function) where {T, V}
+    return value.(ex, var_value)
+end
+
 """
     constant(aff::GenericAffExpr{C, V})::C
 

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -161,10 +161,6 @@ function value(ex::GenericAffExpr{T, V}, var_value::Function) where {T, V}
     ret
 end
 
-function value(ex::Vector{GenericAffExpr{T, V}}, var_value::Function) where {T, V}
-    return value.(ex, var_value)
-end
-
 """
     constant(aff::GenericAffExpr{C, V})::C
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -588,6 +588,12 @@ function value(con_ref::ConstraintRef{Model, <:_MOICON}; result::Int = 1)
     return reshape_vector(_constraint_primal(con_ref, result), con_ref.shape)
 end
 
+"""
+    value(con_ref::ConstraintRef, var_value::Function)
+
+Evaluate the primal value of the constraint `con_ref` using `var_value(v)` 
+as the value for each variable `v`.
+"""
 function value(con_ref::ConstraintRef{Model, <:_MOICON}, var_value::Function)
     f = jump_function(constraint_object(con_ref))
     return reshape_vector(value.(f, Ref(var_value)), con_ref.shape)

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -589,7 +589,8 @@ function value(con_ref::ConstraintRef{Model, <:_MOICON}; result::Int = 1)
 end
 
 function value(con_ref::ConstraintRef{Model, <:_MOICON}, var_value::Function)
-    return value(jump_function(constraint_object(con_ref)), var_value)
+    f = jump_function(constraint_object(con_ref))
+    return reshape_vector(value.(f, Ref(var_value)), con_ref.shape)
 end
 
 # Returns the value of MOI.ConstraintPrimal in a type-stable way

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -589,7 +589,7 @@ function value(con_ref::ConstraintRef{Model, <:_MOICON}; result::Int = 1)
 end
 
 function value(con_ref::ConstraintRef{Model, <:_MOICON}, var_value::Function)
-  return value(jump_function(constraint_object(con_ref)), var_value)
+    return value(jump_function(constraint_object(con_ref)), var_value)
 end
 
 # Returns the value of MOI.ConstraintPrimal in a type-stable way

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -588,6 +588,10 @@ function value(con_ref::ConstraintRef{Model, <:_MOICON}; result::Int = 1)
     return reshape_vector(_constraint_primal(con_ref, result), con_ref.shape)
 end
 
+function value(con_ref::ConstraintRef{Model, <:_MOICON}, var_value::Function)
+  return value(jump_function(constraint_object(con_ref)), var_value)
+end
+
 # Returns the value of MOI.ConstraintPrimal in a type-stable way
 function _constraint_primal(
     con_ref::ConstraintRef{

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -596,7 +596,7 @@ as the value for each variable `v`.
 """
 function value(con_ref::ConstraintRef{Model, <:_MOICON}, var_value::Function)
     f = jump_function(constraint_object(con_ref))
-    return reshape_vector(value.(f, Ref(var_value)), con_ref.shape)
+    return reshape_vector(value.(f, var_value), con_ref.shape)
 end
 
 # Returns the value of MOI.ConstraintPrimal in a type-stable way

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -767,6 +767,11 @@ function value(v::VariableRef; result::Int = 1)::Float64
     return MOI.get(owner_model(v), MOI.VariablePrimal(result), v)
 end
 
+"""
+    value(v::VariableRef, var_value::Function)
+
+Evaluate the value of the variable `v` as `var_value(v)`.
+"""
 function value(v::VariableRef, var_value::Function)
     return var_value(v)
 end

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -767,7 +767,7 @@ function value(v::VariableRef; result::Int = 1)::Float64
     return MOI.get(owner_model(v), MOI.VariablePrimal(result), v)
 end
 
-function JuMP.value(v::VariableRef, var_value::Function)
+function value(v::VariableRef, var_value::Function)
     return var_value(v)
 end
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -767,6 +767,10 @@ function value(v::VariableRef; result::Int = 1)::Float64
     return MOI.get(owner_model(v), MOI.VariablePrimal(result), v)
 end
 
+function JuMP.value(v::VariableRef, var_value::Function)
+  return var_value(v)
+end
+
 """
     has_values(model::Model; result::Int = 1)
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -768,7 +768,7 @@ function value(v::VariableRef; result::Int = 1)::Float64
 end
 
 function JuMP.value(v::VariableRef, var_value::Function)
-  return var_value(v)
+    return var_value(v)
 end
 
 """

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -663,6 +663,21 @@ function test_Model_add_to_function_constant_vector(::Any, ::Any)
     @test JuMP.moi_set(con) == MOI.Nonnegatives(2)
 end
 
+function test_Model_value_constraint_var(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, x[1:2])
+    @constraint(model, c1, x[1] + x[2] <= 3.0)
+    @constraint(model, c2, x[1]^2 + x[2]^2 <= 3.0)
+    @constraint(model, c3, [1.0, x[1], x[2]] in SecondOrderCone())
+
+    vals = Dict(x[1] => 1.0, x[2] => 2.0)
+    f = vidx -> vals[vidx]
+
+    @test value(c1, f) === 3.0 # Affine expression
+    @test value(c2, f) === 5.0 # Quadratic expression
+    @test value(c3, f) == [1.0, 1.0, 2.0] # Vector expression
+end
+
 function _test_shadow_price_util(model_string, constraint_dual, constraint_shadow)
     model = Model()
     MOIU.loadfromstring!(backend(model), model_string)

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -716,6 +716,7 @@ end
 function test_Model_value_var(ModelType, ::Any)
     model = ModelType()
     @variable(model, x[1:2])
+
     vals = Dict(x[1] => 1.0, x[2] => 2.0)
     f = vidx -> vals[vidx]
 

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -713,6 +713,16 @@ function test_Model_value(::Any, ::Any)
     @test value(JuMP._MA.Zero()) === 0.0
 end
 
+function test_Model_value_var(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, x[1:2])
+    vals = Dict(x[1] => 1.0, x[2] => 2.0)
+    f = vidx -> vals[vidx]
+
+    @test value(x[1], f) === 1.0
+    @test value(x[2], f) === 2.0
+end
+
 function test_Model_relax_integrality(::Any, ::Any)
     model = Model()
     @variable(model, x, Bin)


### PR DESCRIPTION
This proposes a link between constraints and the `value` method that takes a `var_value` argument (https://github.com/jump-dev/JuMP.jl/blob/e2fd3ebd9e3f5e6913ba461c0bc54e5cc92f061e/src/aff_expr.jl#L149-L162). 

I was surprised that this was not supported; maybe there was a reason why? (It's the reason why I did not bother adding documentation or tests for now.) 