### PR TITLE
Fix DataStructues deprecation warnings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Calculus = "0.5"
-DataStructures = "0.17, 0.18"
+DataStructures = "0.18"
 ForwardDiff = "~0.5.0, ~0.6, ~0.7, ~0.8, ~0.9, ~0.10"
 JSON = "0.21"
 MathOptInterface = "~0.9.14"

--- a/src/_Derivatives/coloring.jl
+++ b/src/_Derivatives/coloring.jl
@@ -133,7 +133,7 @@ macro colored(i)
 end
 
 function prevent_cycle(v,w,x,e_idx1,e_idx2,S,firstVisitToTree,forbiddenColors,color)
-    er = DataStructures.find_root(S, e_idx2)
+    er = DataStructures.find_root!(S, e_idx2)
     @inbounds first = firstVisitToTree[er]
     p = first.source # but this depends on the order?
     q = first.target
@@ -158,8 +158,8 @@ function grow_star(v,w,e_idx,firstNeighbor,color,S)
 end
 
 function merge_trees(eg,eg1,S)
-    e1 = DataStructures.find_root(S, eg)
-    e2 = DataStructures.find_root(S, eg1)
+    e1 = DataStructures.find_root!(S, eg)
+    e2 = DataStructures.find_root!(S, eg1)
     if e1 != e2
         union!(S, eg, eg1)
     end


### PR DESCRIPTION
Should we be running CI with ``--depwarn=error``? That would have caught this.

We need a quick tag after this. NLP models are likely printing deprecation warnings on 0.21.4.