### PR TITLE
Don't create a testset for each potential test file.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,7 @@ t = time()
 include("Containers/Containers.jl")
 println("Containers.jl took $(round(time() - t; digits = 1)) seconds.")
 
-@testset "$(file)" for file in filter(f -> endswith(f, ".jl"), readdir(@__DIR__))
+for file in filter(f -> endswith(f, ".jl"), readdir(@__DIR__))
     if file in [
         "runtests.jl",
         "utilities.jl",
@@ -26,9 +26,12 @@ println("Containers.jl took $(round(time() - t; digits = 1)) seconds.")
     ]
         continue
     end
-    t = time()
-    include(file)
-    println("$(file) took $(round(time() - t; digits = 1)) seconds.")
+
+    @testset "$(file)" begin
+        t = time()
+        include(file)
+        println("$(file) took $(round(time() - t; digits = 1)) seconds.")
+    end
 end
 
 # TODO: The hygiene test should run in a separate Julia instance where JuMP


### PR DESCRIPTION
This cleans up the output when running the tests, as there is no output for files that are excluded.

Previously, the output was like:

```
Test Summary: | Pass  Total
Containers    |  241    241
Containers.jl took 37.4 seconds.
Test Summary:    |
JuMPExtension.jl | No tests
callbacks.jl took 15.9 seconds.
Test Summary: | Pass  Total
callbacks.jl  |   22     22
```

With this patch:

```
Test Summary: | Pass  Total
Containers    |  241    241
Containers.jl took 22.0 seconds.
callbacks.jl took 16.8 seconds.
Test Summary: | Pass  Total
callbacks.jl  |   22     22
```