### PR TITLE
Define haskey for JuMP AbstractModel

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -955,8 +955,9 @@ function Base.setindex!(m::JuMP.Model, value, name::Symbol)
 end
 
 """
+    Base.haskey(m::JuMP.AbstractModel, name::Symbol)
 
-
+To allow easy verification if a key is present in a JuMP model.
 """
 function Base.haskey(m::JuMP.AbstractModel, name::Symbol)
     haskey(object_dictionary(m), name)

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -955,12 +955,12 @@ function Base.setindex!(m::JuMP.Model, value, name::Symbol)
 end
 
 """
-    Base.haskey(m::JuMP.AbstractModel, name::Symbol)
+    haskey(model::JuMP.AbstractModel, name::Symbol)
 
-To allow easy verification if a key is present in a JuMP model.
+Determine whether the model has a mapping for a given name..
 """
-function Base.haskey(m::JuMP.AbstractModel, name::Symbol)
-    haskey(object_dictionary(m), name)
+function Base.haskey(model::JuMP.AbstractModel, name::Symbol)
+    haskey(object_dictionary(model), name)
 end
 
 """

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -955,6 +955,14 @@ function Base.setindex!(m::JuMP.Model, value, name::Symbol)
 end
 
 """
+
+
+"""
+function Base.haskey(m::JuMP.AbstractModel, name::Symbol)
+    haskey(object_dictionary(m), name)
+end
+
+"""
     operator_warn(model::AbstractModel)
     operator_warn(model::Model)
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -955,11 +955,11 @@ function Base.setindex!(m::JuMP.Model, value, name::Symbol)
 end
 
 """
-    haskey(model::JuMP.AbstractModel, name::Symbol)
+    haskey(model::AbstractModel, name::Symbol)
 
 Determine whether the model has a mapping for a given name.
 """
-function Base.haskey(model::JuMP.AbstractModel, name::Symbol)
+function Base.haskey(model::AbstractModel, name::Symbol)
     return haskey(object_dictionary(model), name)
 end
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -957,7 +957,7 @@ end
 """
     haskey(model::JuMP.AbstractModel, name::Symbol)
 
-Determine whether the model has a mapping for a given name..
+Determine whether the model has a mapping for a given name.
 """
 function Base.haskey(model::JuMP.AbstractModel, name::Symbol)
     haskey(object_dictionary(model), name)

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -960,7 +960,7 @@ end
 Determine whether the model has a mapping for a given name.
 """
 function Base.haskey(model::JuMP.AbstractModel, name::Symbol)
-    haskey(object_dictionary(model), name)
+    return haskey(object_dictionary(model), name)
 end
 
 """

--- a/test/model.jl
+++ b/test/model.jl
@@ -492,6 +492,13 @@ function test_copy_direct_mode()
     @test_throws ErrorException JuMP.copy(model)
 end
 
+function test_haskey()
+    m = Model()
+    @variable(m, p[i=1:10] >=  0)
+    @test haskey(m, :p)
+    @test !haskey(m, :i)
+end
+
 function runtests()
     for name in names(@__MODULE__; all = true)
         if !startswith("$(name)", "test_")

--- a/test/model.jl
+++ b/test/model.jl
@@ -493,10 +493,10 @@ function test_copy_direct_mode()
 end
 
 function test_haskey()
-    m = Model()
-    @variable(m, p[i=1:10] >=  0)
-    @test haskey(m, :p)
-    @test !haskey(m, :i)
+    model = Model()
+    @variable(model, p[i=1:10] >=  0)
+    @test haskey(model, :p)
+    @test !haskey(model, :i)
 end
 
 function runtests()


### PR DESCRIPTION
Overloads `Base.haskey` for `JuMP.AbstractModel`.

Relates to https://github.com/jump-dev/JuMP.jl/issues/1887