### PR TITLE
Format the src/_Derivatives submodule

### DIFF
--- a/src/_Derivatives/_Derivatives.jl
+++ b/src/_Derivatives/_Derivatives.jl
@@ -16,7 +16,21 @@ const TAG = :jump_tag
 # This is what NLP solvers expect, and
 # sometimes the results aren't needed anyway,
 # because the code may compute derivatives wrt constants.
-import NaNMath: sin, cos, tan, asin, acos, acosh, atanh, log, log2, log10, lgamma, log1p, pow, sqrt
+import NaNMath:
+    sin,
+    cos,
+    tan,
+    asin,
+    acos,
+    acosh,
+    atanh,
+    log,
+    log2,
+    log10,
+    lgamma,
+    log1p,
+    pow,
+    sqrt
 
 include("types.jl")
 include("conversion.jl")

--- a/src/_Derivatives/coloring.jl
+++ b/src/_Derivatives/coloring.jl
@@ -36,7 +36,7 @@ function Base.empty!(v::IndexedSet)
     for i in 1:v.nnz
         empty[nzidx[i]] = true
     end
-    v.nnz = 0
+    return v.nnz = 0
 end
 
 Base.length(v::IndexedSet) = length(v.nzidx)
@@ -54,9 +54,8 @@ function Base.union!(v::IndexedSet, s)
     for x in s
         push!(v, x)
     end
-    nothing
+    return nothing
 end
-
 
 # compact storage for an undirected graph
 # neighbors of vertex i start at adjlist[offsets[i]]
@@ -112,7 +111,6 @@ function gen_adjlist(I, J, nel)
     @assert edge_count == n_edges
 
     return UndirectedGraph(adjlist, edgeindex, offsets, edges)
-
 end
 
 export gen_adjlist
@@ -130,7 +128,7 @@ normalize_p(p::MyPair) =
 normalize_p(i, j) = normalize_p(MyPair(i, j))
 
 macro colored(i)
-    esc(:((color[$i] != 0)))
+    return esc(:((color[$i] != 0)))
 end
 
 function prevent_cycle(
@@ -153,7 +151,7 @@ function prevent_cycle(
     elseif q != w
         forbiddenColors[color[x]] = v
     end
-    nothing
+    return nothing
 end
 
 function grow_star(v, w, e_idx, firstNeighbor, color, S)
@@ -165,7 +163,7 @@ function grow_star(v, w, e_idx, firstNeighbor, color, S)
     else
         union!(S, e_idx, e.index)
     end
-    nothing
+    return nothing
 end
 
 function merge_trees(eg, eg1, S)
@@ -174,14 +172,13 @@ function merge_trees(eg, eg1, S)
     if e1 != e2
         union!(S, eg, eg1)
     end
-    nothing
+    return nothing
 end
 
 # acyclic coloring algorithm of Gebremdehin, Tarafdar, Manne, and Pothen
 # "New Acyclic and Star Coloring Algorithms with Application to Computing Hessians"
 # SIAM J. Sci. Comput. 2007
 function acyclic_coloring(g::UndirectedGraph)
-
     if num_edges(g) == 0
         return fill(1, num_vertices(g)), 1
     end
@@ -298,7 +295,6 @@ function recovery_preprocess(
     # represent two-color subgraph as:
     # list of vertices (with map to global indices)
     # adjacency list in a single vector (with list of offsets)
-
 
     # linear index of pair of colors
     twocolorindex = zeros(Int32, num_colors, num_colors)
@@ -425,7 +421,6 @@ function recovery_preprocess(
         num_edges(g),
         local_indices,
     )
-
 end
 
 function indirect_recover_structure(rinfo::RecoveryInfo)
@@ -459,7 +454,6 @@ function indirect_recover_structure(rinfo::RecoveryInfo)
             I[k] = i
             J[k] = j
         end
-
     end
 
     @assert k == nnz + N
@@ -473,7 +467,6 @@ function hessian_color_preprocess(
     num_total_var,
     seen_idx = IndexedSet(0),
 )
-
     resize!(seen_idx, num_total_var)
     I = Int[]
     J = Int[]
@@ -524,7 +517,6 @@ seed_matrix(rinfo::RecoveryInfo) =
 export seed_matrix
 
 function prepare_seed_matrix!(R, rinfo::RecoveryInfo)
-
     N = length(rinfo.color) # number of local variables
     @assert N == length(rinfo.local_indices)
     @assert size(R, 1) == N
@@ -584,7 +576,6 @@ function recover_from_matmat!(V, R, rinfo::RecoveryInfo, stored_values)
     @assert k == nnz + N
 
     return
-
 end
 
 export recover_from_matmat!

--- a/src/_Derivatives/coloring.jl
+++ b/src/_Derivatives/coloring.jl
@@ -11,7 +11,7 @@ struct MyPair{T}
 end
 
 # workaround for julia issue #10208
-Base.hash(x::MyPair{Int},h::UInt) = hash(x.first,hash(x.second,h))
+Base.hash(x::MyPair{Int}, h::UInt) = hash(x.first, hash(x.second, h))
 
 # indexed sparse set of integers
 mutable struct IndexedSet
@@ -20,11 +20,11 @@ mutable struct IndexedSet
     nnz::Int
 end
 
-IndexedSet(n::Integer) = IndexedSet(zeros(Int,n),trues(n),0)
+IndexedSet(n::Integer) = IndexedSet(zeros(Int, n), trues(n), 0)
 
-function Base.push!(v::IndexedSet,i::Integer)
+function Base.push!(v::IndexedSet, i::Integer)
     if v.empty[i]  # new index
-        v.nzidx[v.nnz += 1] = i
+        v.nzidx[v.nnz+=1] = i
         v.empty[i] = false
     end
     return nothing
@@ -45,14 +45,14 @@ function Base.resize!(v::IndexedSet, n::Integer)
         @assert v.nnz == 0 # only resize empty vector
         resize!(v.nzidx, n)
         resize!(v.empty, n)
-        fill!(v.empty,true)
+        fill!(v.empty, true)
     end
 end
 
 Base.collect(v::IndexedSet) = v.nzidx[1:v.nnz]
-function Base.union!(v::IndexedSet,s)
+function Base.union!(v::IndexedSet, s)
     for x in s
-        push!(v,x)
+        push!(v, x)
     end
     nothing
 end
@@ -66,13 +66,13 @@ struct UndirectedGraph
     offsets::Vector{Int}
     edges::Vector{MyPair{Int}}
 end
-num_vertices(g::UndirectedGraph) = length(g.offsets)-1
+num_vertices(g::UndirectedGraph) = length(g.offsets) - 1
 num_edges(g::UndirectedGraph) = length(g.edges)
-num_neighbors(i::Int,g::UndirectedGraph) = g.offsets[i+1]-g.offsets[i]
-start_neighbors(i::Int,g::UndirectedGraph) = g.offsets[i]
+num_neighbors(i::Int, g::UndirectedGraph) = g.offsets[i+1] - g.offsets[i]
+start_neighbors(i::Int, g::UndirectedGraph) = g.offsets[i]
 
-function gen_adjlist(I,J,nel)
-    adjcount = zeros(Int,nel)
+function gen_adjlist(I, J, nel)
+    adjcount = zeros(Int, nel)
     n_edges = 0
     for k in 1:length(I)
         i = I[k]
@@ -82,15 +82,15 @@ function gen_adjlist(I,J,nel)
         adjcount[i] += 1
         adjcount[j] += 1
     end
-    offsets = Array{Int}(undef, nel+1)
+    offsets = Array{Int}(undef, nel + 1)
     offsets[1] = 1
     for k in 1:nel
         offsets[k+1] = offsets[k] + adjcount[k]
     end
-    fill!(adjcount,0)
+    fill!(adjcount, 0)
 
     edges = Array{MyPair{Int}}(undef, n_edges)
-    adjlist = Array{Int}(undef, offsets[nel+1]-1)
+    adjlist = Array{Int}(undef, offsets[nel+1] - 1)
     edgeindex = Array{Int}(undef, length(adjlist))
     edge_count = 0
 
@@ -107,11 +107,11 @@ function gen_adjlist(I,J,nel)
         edgeindex[offsets[j]+adjcount[j]] = edge_count
         adjcount[j] += 1
 
-        edges[edge_count] = MyPair(i,j)
+        edges[edge_count] = MyPair(i, j)
     end
     @assert edge_count == n_edges
 
-    return UndirectedGraph(adjlist,edgeindex,offsets,edges)
+    return UndirectedGraph(adjlist, edgeindex, offsets, edges)
 
 end
 
@@ -124,40 +124,51 @@ struct Edge
 end
 
 # convert to lower triangular indices, using Pairs
-normalize(i,j) = (j > i) ? (j,i) : (i,j)
-normalize_p(p::MyPair) = (p.second > p.first) ? MyPair(p.second,p.first) : MyPair(p.first,p.second)
-normalize_p(i,j) = normalize_p(MyPair(i,j))
+normalize(i, j) = (j > i) ? (j, i) : (i, j)
+normalize_p(p::MyPair) =
+    (p.second > p.first) ? MyPair(p.second, p.first) : MyPair(p.first, p.second)
+normalize_p(i, j) = normalize_p(MyPair(i, j))
 
 macro colored(i)
     esc(:((color[$i] != 0)))
 end
 
-function prevent_cycle(v,w,x,e_idx1,e_idx2,S,firstVisitToTree,forbiddenColors,color)
+function prevent_cycle(
+    v,
+    w,
+    x,
+    e_idx1,
+    e_idx2,
+    S,
+    firstVisitToTree,
+    forbiddenColors,
+    color,
+)
     er = DataStructures.find_root!(S, e_idx2)
     @inbounds first = firstVisitToTree[er]
     p = first.source # but this depends on the order?
     q = first.target
     @inbounds if p != v
-        firstVisitToTree[er] = Edge(e_idx1,v,w)
+        firstVisitToTree[er] = Edge(e_idx1, v, w)
     elseif q != w
         forbiddenColors[color[x]] = v
     end
     nothing
 end
 
-function grow_star(v,w,e_idx,firstNeighbor,color,S)
+function grow_star(v, w, e_idx, firstNeighbor, color, S)
     @inbounds e = firstNeighbor[color[w]]
     p = e.source
     q = e.target
     @inbounds if p != v
-        firstNeighbor[color[w]] = Edge(e_idx,v,w)
+        firstNeighbor[color[w]] = Edge(e_idx, v, w)
     else
         union!(S, e_idx, e.index)
     end
     nothing
 end
 
-function merge_trees(eg,eg1,S)
+function merge_trees(eg, eg1, S)
     e1 = DataStructures.find_root!(S, eg)
     e2 = DataStructures.find_root!(S, eg1)
     if e1 != e2
@@ -172,19 +183,19 @@ end
 function acyclic_coloring(g::UndirectedGraph)
 
     if num_edges(g) == 0
-        return fill(1,num_vertices(g)), 1
+        return fill(1, num_vertices(g)), 1
     end
     num_colors = 0
     forbiddenColors = Int[]
     firstNeighbor = Edge[]
-    firstVisitToTree = fill(Edge(0,0,0),num_edges(g))
+    firstVisitToTree = fill(Edge(0, 0, 0), num_edges(g))
     color = fill(0, num_vertices(g))
     # disjoint set forest of edges in the graph
     S = DataStructures.IntDisjointSets(num_edges(g))
 
     @inbounds for v in 1:num_vertices(g)
-        n_neighbor = num_neighbors(v,g)
-        start_neighbor = start_neighbors(v,g)
+        n_neighbor = num_neighbors(v, g)
+        start_neighbor = start_neighbors(v, g)
         for k in 0:(n_neighbor-1)
             w = g.adjlist[start_neighbor+k]
             @colored(w) || continue
@@ -194,14 +205,24 @@ function acyclic_coloring(g::UndirectedGraph)
             w = g.adjlist[start_neighbor+k]
             e_idx = g.edgeindex[start_neighbor+k]
             @colored(w) || continue
-            n_neighbor_w = num_neighbors(w,g)
-            start_neighbor_w = start_neighbors(w,g)
+            n_neighbor_w = num_neighbors(w, g)
+            start_neighbor_w = start_neighbors(w, g)
             for k2 in 0:(n_neighbor_w-1)
                 x = g.adjlist[start_neighbor_w+k2]
                 e2_idx = g.edgeindex[start_neighbor_w+k2]
                 @colored(x) || continue
                 if forbiddenColors[color[x]] != v
-                    prevent_cycle(v,w,x,e_idx,e2_idx,S,firstVisitToTree,forbiddenColors,color)
+                    prevent_cycle(
+                        v,
+                        w,
+                        x,
+                        e_idx,
+                        e2_idx,
+                        S,
+                        firstVisitToTree,
+                        forbiddenColors,
+                        color,
+                    )
                 end
             end
         end
@@ -218,7 +239,7 @@ function acyclic_coloring(g::UndirectedGraph)
         if !found
             num_colors += 1
             push!(forbiddenColors, 0)
-            push!(firstNeighbor, Edge(0,0,0))
+            push!(firstNeighbor, Edge(0, 0, 0))
             color[v] = num_colors
         end
 
@@ -226,20 +247,20 @@ function acyclic_coloring(g::UndirectedGraph)
             w = g.adjlist[start_neighbor+k]
             e_idx = g.edgeindex[start_neighbor+k]
             @colored(w) || continue
-            grow_star(v,w,e_idx,firstNeighbor,color,S)
+            grow_star(v, w, e_idx, firstNeighbor, color, S)
         end
         for k in 0:(n_neighbor-1)
             w = g.adjlist[start_neighbor+k]
             e_idx = g.edgeindex[start_neighbor+k]
             @colored(w) || continue
-            n_neighbor_w = num_neighbors(w,g)
-            start_neighbor_w = start_neighbors(w,g)
+            n_neighbor_w = num_neighbors(w, g)
+            start_neighbor_w = start_neighbors(w, g)
             for k2 in 0:(n_neighbor_w-1)
                 x = g.adjlist[start_neighbor_w+k2]
                 e2_idx = g.edgeindex[start_neighbor_w+k2]
                 (@colored(x) && x != v) || continue
                 if color[x] == color[v]
-                    merge_trees(e_idx,e2_idx,S)
+                    merge_trees(e_idx, e2_idx, S)
                 end
             end
         end
@@ -258,16 +279,29 @@ struct RecoveryInfo
     local_indices::Vector{Int} # map back to global indices
 end
 
-RecoveryInfo() = RecoveryInfo(Vector{Vector{Int}}(undef, 0),Vector{Vector{Int}}(undef, 0),Vector{Vector{Int}}(undef, 0),Vector{Int}(undef,0),0,0,Vector{Int}(undef, 0))
+RecoveryInfo() = RecoveryInfo(
+    Vector{Vector{Int}}(undef, 0),
+    Vector{Vector{Int}}(undef, 0),
+    Vector{Vector{Int}}(undef, 0),
+    Vector{Int}(undef, 0),
+    0,
+    0,
+    Vector{Int}(undef, 0),
+)
 
-function recovery_preprocess(g::UndirectedGraph,color,num_colors, local_indices)
+function recovery_preprocess(
+    g::UndirectedGraph,
+    color,
+    num_colors,
+    local_indices,
+)
     # represent two-color subgraph as:
     # list of vertices (with map to global indices)
     # adjacency list in a single vector (with list of offsets)
 
 
     # linear index of pair of colors
-    twocolorindex = zeros(Int32,num_colors, num_colors)
+    twocolorindex = zeros(Int32, num_colors, num_colors)
     seen_twocolors = 0
     # count of edges in each subgraph
     edge_count = Int[]
@@ -275,31 +309,31 @@ function recovery_preprocess(g::UndirectedGraph,color,num_colors, local_indices)
         e = g.edges[k]
         u = e.first
         v = e.second
-        i = min(color[u],color[v])
-        j = max(color[u],color[v])
-        if twocolorindex[i,j] == 0
+        i = min(color[u], color[v])
+        j = max(color[u], color[v])
+        if twocolorindex[i, j] == 0
             seen_twocolors += 1
-            twocolorindex[i,j] = seen_twocolors
-            push!(edge_count,0)
+            twocolorindex[i, j] = seen_twocolors
+            push!(edge_count, 0)
         end
-        idx = twocolorindex[i,j]
+        idx = twocolorindex[i, j]
         edge_count[idx] += 1
     end
     # edges sorted by twocolor subgraph
     sorted_edges = Array{Vector{MyPair{Int}}}(undef, seen_twocolors)
     for idx in 1:seen_twocolors
         sorted_edges[idx] = MyPair{Int}[]
-        sizehint!(sorted_edges[idx],edge_count[idx])
+        sizehint!(sorted_edges[idx], edge_count[idx])
     end
 
     for i in 1:length(g.edges)
         e = g.edges[i]
         u = e.first
         v = e.second
-        i = min(color[u],color[v])
-        j = max(color[u],color[v])
-        idx = twocolorindex[i,j]
-        push!(sorted_edges[idx], MyPair(u,v))
+        i = min(color[u], color[v])
+        j = max(color[u], color[v])
+        idx = twocolorindex[i, j]
+        push!(sorted_edges[idx], MyPair(u, v))
     end
 
     # list of unique vertices in each twocolor subgraph
@@ -309,11 +343,11 @@ function recovery_preprocess(g::UndirectedGraph,color,num_colors, local_indices)
     parents = Array{Vector{Int}}(undef, seen_twocolors)
 
     # temporary lookup map from global index to subgraph index
-    revmap = zeros(Int,num_vertices(g))
+    revmap = zeros(Int, num_vertices(g))
 
-    adjcount = zeros(Int,num_vertices(g))
+    adjcount = zeros(Int, num_vertices(g))
 
-    cmap = zeros(Int,0) # shared storage for DFS
+    cmap = zeros(Int, 0) # shared storage for DFS
     vertex_stack = Int[]
     index_stack = Int[]
 
@@ -328,12 +362,12 @@ function recovery_preprocess(g::UndirectedGraph,color,num_colors, local_indices)
             v = e.second
             # seen these vertices yet?
             if revmap[u] == 0
-                push!(vlist,u)
+                push!(vlist, u)
                 revmap[u] = length(vlist)
                 adjcount[u] = 0
             end
             if revmap[v] == 0
-                push!(vlist,v)
+                push!(vlist, v)
                 revmap[v] = length(vlist)
                 adjcount[v] = 0
             end
@@ -342,7 +376,7 @@ function recovery_preprocess(g::UndirectedGraph,color,num_colors, local_indices)
         end
 
         # set up offsets for adjlist
-        offset = Array{Int}(undef, length(vlist)+1)
+        offset = Array{Int}(undef, length(vlist) + 1)
         offset[1] = 1
         for k in 1:length(vlist)
             offset[k+1] = offset[k] + adjcount[vlist[k]]
@@ -351,7 +385,7 @@ function recovery_preprocess(g::UndirectedGraph,color,num_colors, local_indices)
         # adjlist for node u in twocolor idx starts at
         # vec[offset[u]]
         # u has global index vlist[u]
-        vec = Array{Int}(undef, offset[length(vlist)+1]-1)
+        vec = Array{Int}(undef, offset[length(vlist)+1] - 1)
 
         # now fill in
         for k in 1:length(my_edges)
@@ -368,8 +402,9 @@ function recovery_preprocess(g::UndirectedGraph,color,num_colors, local_indices)
             adjcount[v] += 1
         end
 
-        resize!(cmap,length(vlist))
-        order, parent = reverse_topological_sort_by_dfs(vec,offset,length(vlist),cmap)
+        resize!(cmap, length(vlist))
+        order, parent =
+            reverse_topological_sort_by_dfs(vec, offset, length(vlist), cmap)
 
         for k in 1:length(vlist)
             # clear for reuse
@@ -381,7 +416,15 @@ function recovery_preprocess(g::UndirectedGraph,color,num_colors, local_indices)
         vertexmap[idx] = vlist
     end
 
-    return RecoveryInfo(vertexmap, postorder, parents, color, num_colors, num_edges(g), local_indices)
+    return RecoveryInfo(
+        vertexmap,
+        postorder,
+        parents,
+        color,
+        num_colors,
+        num_edges(g),
+        local_indices,
+    )
 
 end
 
@@ -389,8 +432,8 @@ function indirect_recover_structure(rinfo::RecoveryInfo)
     N = length(rinfo.color)
     nnz = rinfo.nnz
 
-    I = zeros(Int, nnz+N)
-    J = zeros(Int, nnz+N)
+    I = zeros(Int, nnz + N)
+    J = zeros(Int, nnz + N)
 
     # diagonal entries
     k = 0
@@ -411,7 +454,7 @@ function indirect_recover_structure(rinfo::RecoveryInfo)
             (p == 0) && continue
             i = vmap[v]
             j = vmap[p]
-            i,j = normalize(i,j)
+            i, j = normalize(i, j)
             k += 1
             I[k] = i
             J[k] = j
@@ -421,20 +464,24 @@ function indirect_recover_structure(rinfo::RecoveryInfo)
 
     @assert k == nnz + N
 
-    return I,J
+    return I, J
 end
 
 # edgelist is nonzeros in hessian, *including* nonzeros on the diagonal
-function hessian_color_preprocess(edgelist,num_total_var,seen_idx=IndexedSet(0))
+function hessian_color_preprocess(
+    edgelist,
+    num_total_var,
+    seen_idx = IndexedSet(0),
+)
 
-    resize!(seen_idx,num_total_var)
+    resize!(seen_idx, num_total_var)
     I = Int[]
     J = Int[]
-    for (i,j) in edgelist
-        push!(seen_idx,i)
-        push!(seen_idx,j)
-        push!(I,i)
-        push!(J,j)
+    for (i, j) in edgelist
+        push!(seen_idx, i)
+        push!(seen_idx, j)
+        push!(I, i)
+        push!(J, j)
     end
     local_indices = sort!(seen_idx.nzidx[1:seen_idx.nnz])
     empty!(seen_idx)
@@ -449,7 +496,7 @@ function hessian_color_preprocess(edgelist,num_total_var,seen_idx=IndexedSet(0))
         J[k] = global_to_local_idx[J[k]]
     end
 
-    g = gen_adjlist(I,J, length(local_indices))
+    g = gen_adjlist(I, J, length(local_indices))
 
     color, num_colors = acyclic_coloring(g)
 
@@ -457,7 +504,7 @@ function hessian_color_preprocess(edgelist,num_total_var,seen_idx=IndexedSet(0))
 
     rinfo = recovery_preprocess(g, color, num_colors, local_indices)
 
-    I,J = indirect_recover_structure(rinfo)
+    I, J = indirect_recover_structure(rinfo)
     #nnz = num_edges(g)
     # convert back to global indices
     for k in 1:length(I)
@@ -465,13 +512,14 @@ function hessian_color_preprocess(edgelist,num_total_var,seen_idx=IndexedSet(0))
         J[k] = local_indices[J[k]]
     end
 
-    return I,J, rinfo
+    return I, J, rinfo
 end
 
 export hessian_color_preprocess
 
 # allocate a seed matrix
-seed_matrix(rinfo::RecoveryInfo) = Array{Float64}(undef,length(rinfo.local_indices),rinfo.num_colors)
+seed_matrix(rinfo::RecoveryInfo) =
+    Array{Float64}(undef, length(rinfo.local_indices), rinfo.num_colors)
 
 export seed_matrix
 
@@ -479,12 +527,12 @@ function prepare_seed_matrix!(R, rinfo::RecoveryInfo)
 
     N = length(rinfo.color) # number of local variables
     @assert N == length(rinfo.local_indices)
-    @assert size(R,1) == N
-    @assert size(R,2) == rinfo.num_colors
+    @assert size(R, 1) == N
+    @assert size(R, 2) == rinfo.num_colors
 
-    fill!(R,0.0)
+    fill!(R, 0.0)
     for i in 1:N
-        R[i,rinfo.color[i]] = 1
+        R[i, rinfo.color[i]] = 1
     end
     return
 end
@@ -497,7 +545,7 @@ function recover_from_matmat!(V, R, rinfo::RecoveryInfo, stored_values)
     N = length(rinfo.color) # number of local variables
     nnz = rinfo.nnz
 
-    @assert length(V) == nnz+N
+    @assert length(V) == nnz + N
     @assert length(stored_values) >= length(rinfo.local_indices)
 
     # diagonal entries
@@ -505,7 +553,7 @@ function recover_from_matmat!(V, R, rinfo::RecoveryInfo, stored_values)
 
     for i in 1:N
         k += 1
-        V[k] = R[i,rinfo.color[i]]
+        V[k] = R[i, rinfo.color[i]]
     end
 
     for t in 1:length(rinfo.vertexmap)
@@ -525,7 +573,7 @@ function recover_from_matmat!(V, R, rinfo::RecoveryInfo, stored_values)
             i = vmap[v]
             j = vmap[p]
 
-            value = R[i,rinfo.color[j]] - stored_values[v]
+            value = R[i, rinfo.color[j]] - stored_values[v]
             stored_values[p] += value
 
             k += 1

--- a/src/_Derivatives/conversion.jl
+++ b/src/_Derivatives/conversion.jl
@@ -1,7 +1,6 @@
 
 # convert from Julia expression into NodeData form
 
-
 function expr_to_nodedata(
     ex::Expr,
     r::UserOperatorRegistry = UserOperatorRegistry(),
@@ -19,7 +18,6 @@ function expr_to_nodedata(
     parentid,
     r::UserOperatorRegistry,
 )
-
     myid = length(nd) + 1
     if isexpr(ex, :call)
         op = ex.args[1]
@@ -67,7 +65,7 @@ function expr_to_nodedata(
     else
         error("Unrecognized expression $ex: $(ex.head)")
     end
-    nothing
+    return nothing
 end
 
 function expr_to_nodedata(
@@ -80,7 +78,7 @@ function expr_to_nodedata(
     valueidx = length(values) + 1
     push!(values, ex)
     push!(nd, NodeData(VALUE, valueidx, parentid))
-    nothing
+    return nothing
 end
 
 export expr_to_nodedata

--- a/src/_Derivatives/forward.jl
+++ b/src/_Derivatives/forward.jl
@@ -42,7 +42,6 @@ function forward_eval(
     user_output_buffer,
     user_operators::UserOperatorRegistry,
 ) where {T}
-
     @assert length(storage) >= length(nd)
     @assert length(partials_storage) >= length(nd)
 
@@ -251,7 +250,6 @@ function forward_eval(
     #@show storage
 
     return storage[1]
-
 end
 
 export forward_eval
@@ -273,7 +271,6 @@ function forward_eval_ϵ(
     subexpression_values_ϵ,
     user_operators::UserOperatorRegistry,
 ) where {N,T}
-
     @assert length(storage_ϵ) >= length(nd)
     @assert length(partials_storage_ϵ) >= length(nd)
 
@@ -428,7 +425,6 @@ end
 
 export forward_eval_ϵ
 
-
 exprs = Expr[]
 for i in 1:length(univariate_operators)
     op = univariate_operators[i]
@@ -458,7 +454,7 @@ switchexpr = binaryswitch(1:length(exprs), exprs)
 
 @eval @inline function eval_univariate(operator_id, x::T) where {T}
     $switchexpr
-    error("No match for operator_id")
+    return error("No match for operator_id")
 end
 
 # TODO: optimize sin/cos/exp
@@ -496,5 +492,5 @@ switchexpr = binaryswitch(ids, exprs)
     fval::T,
 ) where {T}
     $switchexpr
-    error("No match for operator_id")
+    return error("No match for operator_id")
 end

--- a/src/_Derivatives/linearity.jl
+++ b/src/_Derivatives/linearity.jl
@@ -6,7 +6,7 @@
 
 export CONSTANT, LINEAR, PIECEWISE_LINEAR, NONLINEAR
 
-function classify_linearity(nd::Vector{NodeData},adj,subexpression_linearity)
+function classify_linearity(nd::Vector{NodeData}, adj, subexpression_linearity)
 
     linearity = Array{Linearity}(undef, length(nd))
 
@@ -24,7 +24,7 @@ function classify_linearity(nd::Vector{NodeData},adj,subexpression_linearity)
         elseif nod.nodetype == SUBEXPRESSION
             linearity[k] = subexpression_linearity[nod.index]
         else
-            children_idx = nzrange(adj,k)
+            children_idx = nzrange(adj, k)
             num_constant_children = 0
             any_nonlinear = false
             for r in children_idx
@@ -40,8 +40,11 @@ function classify_linearity(nd::Vector{NodeData},adj,subexpression_linearity)
                 linearity[k] = NONLINEAR
                 # except in the case of ifelse. If the operands are linear then
                 # we're piecewise linear.
-                if nod.nodetype == CALL && nod.index < USER_OPERATOR_ID_START && operators[nod.index] == :ifelse
-                    if linearity[children_arr[children_idx[2]]] == LINEAR && linearity[children_arr[children_idx[3]]] == LINEAR
+                if nod.nodetype == CALL &&
+                   nod.index < USER_OPERATOR_ID_START &&
+                   operators[nod.index] == :ifelse
+                    if linearity[children_arr[children_idx[2]]] == LINEAR &&
+                       linearity[children_arr[children_idx[3]]] == LINEAR
                         linearity[k] = PIECEWISE_LINEAR
                     end
                 end
@@ -55,7 +58,10 @@ function classify_linearity(nd::Vector{NodeData},adj,subexpression_linearity)
             # if operator is nonlinear, then we're nonlinear
             op = nod.index
             if nod.nodetype == CALLUNIVAR
-                if op < USER_UNIVAR_OPERATOR_ID_START && (univariate_operators[op] == :+ || univariate_operators[op] == :-)
+                if op < USER_UNIVAR_OPERATOR_ID_START && (
+                    univariate_operators[op] == :+ ||
+                    univariate_operators[op] == :-
+                )
                     linearity[k] = LINEAR
                 else
                     linearity[k] = NONLINEAR
@@ -66,7 +72,8 @@ function classify_linearity(nd::Vector{NodeData},adj,subexpression_linearity)
                     linearity[k] = NONLINEAR
                 elseif operators[op] == :+ || operators[op] == :-
                     linearity[k] = LINEAR
-                elseif operators[op] == :* && num_constant_children == length(children_idx) - 1
+                elseif operators[op] == :* &&
+                       num_constant_children == length(children_idx) - 1
                     linearity[k] = LINEAR
                 elseif operators[op] == :/
                     if linearity[children_arr[last(children_idx)]] == CONSTANT
@@ -91,4 +98,4 @@ function classify_linearity(nd::Vector{NodeData},adj,subexpression_linearity)
 
 end
 
-export Linearity,classify_linearity
+export Linearity, classify_linearity

--- a/src/_Derivatives/linearity.jl
+++ b/src/_Derivatives/linearity.jl
@@ -1,5 +1,4 @@
 
-
 # classify the nodes in a tree as constant, linear, or nonlinear with respect to the input
 
 @enum Linearity CONSTANT LINEAR PIECEWISE_LINEAR NONLINEAR
@@ -7,7 +6,6 @@
 export CONSTANT, LINEAR, PIECEWISE_LINEAR, NONLINEAR
 
 function classify_linearity(nd::Vector{NodeData}, adj, subexpression_linearity)
-
     linearity = Array{Linearity}(undef, length(nd))
 
     # do a forward pass through the graph, which is reverse order of nd
@@ -95,7 +93,6 @@ function classify_linearity(nd::Vector{NodeData}, adj, subexpression_linearity)
     end
 
     return linearity
-
 end
 
 export Linearity, classify_linearity

--- a/src/_Derivatives/reverse.jl
+++ b/src/_Derivatives/reverse.jl
@@ -5,8 +5,12 @@
 # assumes partials_storage is already updated
 # dense gradient output, assumes initialized to zero
 # if subexpressions are present, must run reverse_eval on subexpression tapes afterwards
-function reverse_eval(reverse_storage::AbstractVector{T}, partials_storage::AbstractVector{T},
-                      nd::Vector{NodeData}, adj) where T
+function reverse_eval(
+    reverse_storage::AbstractVector{T},
+    partials_storage::AbstractVector{T},
+    nd::Vector{NodeData},
+    adj,
+) where {T}
 
     @assert length(reverse_storage) >= length(nd)
     @assert length(partials_storage) >= length(nd)
@@ -20,12 +24,19 @@ function reverse_eval(reverse_storage::AbstractVector{T}, partials_storage::Abst
 
     for k in 2:length(nd)
         @inbounds nod = nd[k]
-        if nod.nodetype == VALUE || nod.nodetype == LOGIC || nod.nodetype == COMPARISON || nod.nodetype == PARAMETER
+        if nod.nodetype == VALUE ||
+           nod.nodetype == LOGIC ||
+           nod.nodetype == COMPARISON ||
+           nod.nodetype == PARAMETER
             continue
         end
         @inbounds rev_parent = reverse_storage[nod.parent]
         @inbounds partial = partials_storage[k]
-        @inbounds reverse_storage[k] = ifelse(rev_parent == 0.0 && !isfinite(partial), rev_parent, rev_parent*partial)
+        @inbounds reverse_storage[k] = ifelse(
+            rev_parent == 0.0 && !isfinite(partial),
+            rev_parent,
+            rev_parent * partial,
+        )
         #@inbounds reverse_storage[k] = reverse_storage[nod.parent]*partials_storage[k]
     end
     #@show storage
@@ -38,16 +49,24 @@ export reverse_eval
 
 # assume we've already run the reverse pass, now just extract the answer
 # given the scaling value
-function reverse_extract(output::AbstractVector{T},reverse_storage::AbstractVector{T},nd::Vector{NodeData},adj,subexpression_output,scale_value::T) where T
+function reverse_extract(
+    output::AbstractVector{T},
+    reverse_storage::AbstractVector{T},
+    nd::Vector{NodeData},
+    adj,
+    subexpression_output,
+    scale_value::T,
+) where {T}
 
     @assert length(reverse_storage) >= length(nd)
 
     for k in 1:length(nd)
         @inbounds nod = nd[k]
         if nod.nodetype == VARIABLE
-            @inbounds output[nod.index] += scale_value*reverse_storage[k]
+            @inbounds output[nod.index] += scale_value * reverse_storage[k]
         elseif nod.nodetype == SUBEXPRESSION
-            @inbounds subexpression_output[nod.index] += scale_value*reverse_storage[k]
+            @inbounds subexpression_output[nod.index] +=
+                scale_value * reverse_storage[k]
         end
     end
     #@show storage
@@ -60,12 +79,19 @@ export reverse_extract
 
 # Compute directional derivatives of the reverse pass, goes with forward_eval_ϵ
 # to compute hessian-vector products.
-function reverse_eval_ϵ(output_ϵ::AbstractVector{ForwardDiff.Partials{N, T}},
-                        reverse_storage::AbstractVector{T}, reverse_storage_ϵ,
-                        partials_storage::AbstractVector{T}, partials_storage_ϵ,
-                        nd::Vector{NodeData}, adj, subexpression_output,
-                        subexpression_output_ϵ, scale_value::T,
-                        scale_value_ϵ::ForwardDiff.Partials{N, T}) where {N, T}
+function reverse_eval_ϵ(
+    output_ϵ::AbstractVector{ForwardDiff.Partials{N,T}},
+    reverse_storage::AbstractVector{T},
+    reverse_storage_ϵ,
+    partials_storage::AbstractVector{T},
+    partials_storage_ϵ,
+    nd::Vector{NodeData},
+    adj,
+    subexpression_output,
+    subexpression_output_ϵ,
+    scale_value::T,
+    scale_value_ϵ::ForwardDiff.Partials{N,T},
+) where {N,T}
 
     @assert length(reverse_storage_ϵ) >= length(nd)
     @assert length(partials_storage_ϵ) >= length(nd)
@@ -74,7 +100,8 @@ function reverse_eval_ϵ(output_ϵ::AbstractVector{ForwardDiff.Partials{N, T}},
         @inbounds output_ϵ[nd[1].index] += scale_value_ϵ
         return
     elseif nd[1].nodetype == SUBEXPRESSION
-        @inbounds subexpression_output[nd[1].index] += scale_value*reverse_storage[1]
+        @inbounds subexpression_output[nd[1].index] +=
+            scale_value * reverse_storage[1]
         @inbounds subexpression_output_ϵ[nd[1].index] += scale_value_ϵ
         return
     end
@@ -83,11 +110,14 @@ function reverse_eval_ϵ(output_ϵ::AbstractVector{ForwardDiff.Partials{N, T}},
 
     for k in 2:length(nd)
         @inbounds nod = nd[k]
-        if nod.nodetype == VALUE || nod.nodetype == LOGIC || nod.nodetype == COMPARISON || nod.nodetype == PARAMETER
+        if nod.nodetype == VALUE ||
+           nod.nodetype == LOGIC ||
+           nod.nodetype == COMPARISON ||
+           nod.nodetype == PARAMETER
             continue
         end
         # compute the value of reverse_storage[k]
-        @inbounds parentval = scale_value*reverse_storage[nod.parent]
+        @inbounds parentval = scale_value * reverse_storage[nod.parent]
         @inbounds parentval_ϵ = reverse_storage_ϵ[nod.parent]
         @inbounds partial = partials_storage[k]
         @inbounds partial_ϵ = partials_storage_ϵ[k]
@@ -96,13 +126,19 @@ function reverse_eval_ϵ(output_ϵ::AbstractVector{ForwardDiff.Partials{N, T}},
         if !isfinite(partial) && parentval == 0.0
             reverse_storage_ϵ[k] = zero(ForwardDiff.Partials{N,T})
         else
-            reverse_storage_ϵ[k] = ForwardDiff._mul_partials(partial_ϵ,parentval_ϵ,parentval,partial)
+            reverse_storage_ϵ[k] = ForwardDiff._mul_partials(
+                partial_ϵ,
+                parentval_ϵ,
+                parentval,
+                partial,
+            )
         end
 
         if nod.nodetype == VARIABLE
             @inbounds output_ϵ[nod.index] += reverse_storage_ϵ[k]
         elseif nod.nodetype == SUBEXPRESSION
-            @inbounds subexpression_output[nod.index] += scale_value*reverse_storage[k]
+            @inbounds subexpression_output[nod.index] +=
+                scale_value * reverse_storage[k]
             @inbounds subexpression_output_ϵ[nod.index] += reverse_storage_ϵ[k]
         end
     end

--- a/src/_Derivatives/reverse.jl
+++ b/src/_Derivatives/reverse.jl
@@ -1,5 +1,4 @@
 
-
 # reverse-mode evaluation of an expression tree
 
 # assumes partials_storage is already updated
@@ -11,7 +10,6 @@ function reverse_eval(
     nd::Vector{NodeData},
     adj,
 ) where {T}
-
     @assert length(reverse_storage) >= length(nd)
     @assert length(partials_storage) >= length(nd)
 
@@ -41,8 +39,7 @@ function reverse_eval(
     end
     #@show storage
 
-    nothing
-
+    return nothing
 end
 
 export reverse_eval
@@ -57,7 +54,6 @@ function reverse_extract(
     subexpression_output,
     scale_value::T,
 ) where {T}
-
     @assert length(reverse_storage) >= length(nd)
 
     for k in 1:length(nd)
@@ -71,8 +67,7 @@ function reverse_extract(
     end
     #@show storage
 
-    nothing
-
+    return nothing
 end
 
 export reverse_extract
@@ -92,7 +87,6 @@ function reverse_eval_ϵ(
     scale_value::T,
     scale_value_ϵ::ForwardDiff.Partials{N,T},
 ) where {N,T}
-
     @assert length(reverse_storage_ϵ) >= length(nd)
     @assert length(partials_storage_ϵ) >= length(nd)
 
@@ -144,8 +138,7 @@ function reverse_eval_ϵ(
     end
     #@show storage
 
-    nothing
-
+    return nothing
 end
 
 export reverse_eval_ϵ

--- a/src/_Derivatives/sparsity.jl
+++ b/src/_Derivatives/sparsity.jl
@@ -16,7 +16,6 @@ function compute_gradient_sparsity(nd::Vector{NodeData})
     return indices
 end
 
-
 function compute_gradient_sparsity!(
     indices::Coloring.IndexedSet,
     nd::Vector{NodeData},
@@ -29,7 +28,7 @@ function compute_gradient_sparsity!(
             error("Internal error: Invalid to compute sparsity if MOIVARIABLE nodes are present.")
         end
     end
-    nothing
+    return nothing
 end
 
 export compute_gradient_sparsity, compute_gradient_sparsity!
@@ -174,7 +173,6 @@ function compute_hessian_sparsity(
                 push!(edgelist, (i, j))
             end
         end
-
     end
 
     return edgelist

--- a/src/_Derivatives/subexpressions.jl
+++ b/src/_Derivatives/subexpressions.jl
@@ -17,12 +17,14 @@ end
 
 # Order the subexpressions which main_expressions depend on such that we can
 # run forward mode in this order.
-function order_subexpressions(main_expressions::Vector{Vector{NodeData}},
-                              subexpressions::Vector{Vector{NodeData}})
+function order_subexpressions(
+    main_expressions::Vector{Vector{NodeData}},
+    subexpressions::Vector{Vector{NodeData}},
+)
     num_sub = length(subexpressions)
     computed = falses(num_sub)
     dependencies = Dict{Int,Vector{Int}}()
-    to_visit = collect(num_sub + 1 : num_sub + length(main_expressions))
+    to_visit = collect(num_sub+1:num_sub+length(main_expressions))
     # For each subexpression k, the indices of the main expressions that depend
     # on k, possibly transitively.
     depended_on_by = [Set{Int}() for i in 1:num_sub]
@@ -30,7 +32,7 @@ function order_subexpressions(main_expressions::Vector{Vector{NodeData}},
     while !isempty(to_visit)
         idx = pop!(to_visit)
         if idx > num_sub
-            subexpr = list_subexpressions(main_expressions[idx - num_sub])
+            subexpr = list_subexpressions(main_expressions[idx-num_sub])
         else
             computed[idx] && continue
             subexpr = list_subexpressions(subexpressions[idx])
@@ -57,9 +59,12 @@ function order_subexpressions(main_expressions::Vector{Vector{NodeData}},
     N = num_sub + length(main_expressions)
     sp = sparse(I, J, ones(length(I)), N, N)
     cmap = Vector{Int}(undef, N)
-    order = reverse(Coloring.reverse_topological_sort_by_dfs(sp.rowval,
-                                                             sp.colptr, N,
-                                                             cmap)[1])
+    order = reverse(Coloring.reverse_topological_sort_by_dfs(
+        sp.rowval,
+        sp.colptr,
+        N,
+        cmap,
+    )[1])
     # Remove the subexpressions which never appear anywhere and the indices of
     # the main expressions.
     condition(idx) = idx <= num_sub && computed[idx]
@@ -80,7 +85,7 @@ function order_subexpressions(main_expressions::Vector{Vector{NodeData}},
             push!(individual_order[i], o)
         end
     end
-    
+
     return order_filtered, individual_order
 end
 

--- a/src/_Derivatives/subexpressions.jl
+++ b/src/_Derivatives/subexpressions.jl
@@ -1,5 +1,4 @@
 
-
 # returns the list of subexpressions which a given tape depends on directly
 function list_subexpressions(nd::Vector{NodeData})
 

--- a/src/_Derivatives/topological_sort.jl
+++ b/src/_Derivatives/topological_sort.jl
@@ -33,7 +33,7 @@ mutable struct TopologicalSortVisitor
     function TopologicalSortVisitor(n::Int)
         vs = Int[]
         sizehint!(vs, n)
-        new(vs, zeros(Int, n))
+        return new(vs, zeros(Int, n))
     end
 end
 
@@ -44,8 +44,7 @@ function depth_first_visit_impl!(
     index_stack,                    # stack with out edge indices
     vertexcolormap::Vector{Int},    # an (initialized) color-map to indicate status of vertices
     visitor::TopologicalSortVisitor,
-)  # the visitor
-
+)
     while !isempty(vertex_stack)
         u = pop!(vertex_stack)
         out_idx = pop!(index_stack)
@@ -86,7 +85,6 @@ function traverse_graph(
     vertex_stack,
     index_stack,
 )
-
     vertexcolormap[s] = 1
 
     resize!(vertex_stack, 1)
@@ -94,7 +92,7 @@ function traverse_graph(
     resize!(index_stack, 1)
     index_stack[1] = 1
 
-    depth_first_visit_impl!(
+    return depth_first_visit_impl!(
         adjlist,
         offsets,
         vertex_stack,
@@ -104,10 +102,8 @@ function traverse_graph(
     )
 end
 
-
-
 function close_vertex!(visitor::TopologicalSortVisitor, v::Int)
-    push!(visitor.vertices, v)
+    return push!(visitor.vertices, v)
 end
 
 function reverse_topological_sort_by_dfs(
@@ -118,7 +114,6 @@ function reverse_topological_sort_by_dfs(
     vertex_stack::Vector{Int} = Int[],
     index_stack::Vector{Int} = Int[],
 )
-
     @assert length(cmap) == num_vertices
     fill!(cmap, 0)
     visitor = TopologicalSortVisitor(num_vertices)
@@ -137,5 +132,5 @@ function reverse_topological_sort_by_dfs(
         end
     end
 
-    visitor.vertices, visitor.parents
+    return visitor.vertices, visitor.parents
 end

--- a/src/_Derivatives/topological_sort.jl
+++ b/src/_Derivatives/topological_sort.jl
@@ -33,7 +33,7 @@ mutable struct TopologicalSortVisitor
     function TopologicalSortVisitor(n::Int)
         vs = Int[]
         sizehint!(vs, n)
-        new(vs, zeros(Int,n))
+        new(vs, zeros(Int, n))
     end
 end
 
@@ -43,13 +43,14 @@ function depth_first_visit_impl!(
     vertex_stack,                   # an (initialized) stack of vertex
     index_stack,                    # stack with out edge indices
     vertexcolormap::Vector{Int},    # an (initialized) color-map to indicate status of vertices
-    visitor::TopologicalSortVisitor)  # the visitor
+    visitor::TopologicalSortVisitor,
+)  # the visitor
 
     while !isempty(vertex_stack)
         u = pop!(vertex_stack)
         out_idx = pop!(index_stack)
         #uegs = out_edges(u,graph)
-        len_uegs = offsets[u+1]-offsets[u]
+        len_uegs = offsets[u+1] - offsets[u]
         found_new_vertex = false
 
         while out_idx <= len_uegs && !found_new_vertex
@@ -83,16 +84,24 @@ function traverse_graph(
     visitor::TopologicalSortVisitor,
     vertexcolormap,
     vertex_stack,
-    index_stack)
+    index_stack,
+)
 
     vertexcolormap[s] = 1
 
-    resize!(vertex_stack,1)
+    resize!(vertex_stack, 1)
     vertex_stack[1] = s
-    resize!(index_stack,1)
+    resize!(index_stack, 1)
     index_stack[1] = 1
 
-    depth_first_visit_impl!(adjlist, offsets, vertex_stack, index_stack, vertexcolormap, visitor)
+    depth_first_visit_impl!(
+        adjlist,
+        offsets,
+        vertex_stack,
+        index_stack,
+        vertexcolormap,
+        visitor,
+    )
 end
 
 
@@ -101,17 +110,32 @@ function close_vertex!(visitor::TopologicalSortVisitor, v::Int)
     push!(visitor.vertices, v)
 end
 
-function reverse_topological_sort_by_dfs(adjlist,offsets,num_vertices, cmap::Vector{Int}, vertex_stack::Vector{Int}=Int[], index_stack::Vector{Int}=Int[])
+function reverse_topological_sort_by_dfs(
+    adjlist,
+    offsets,
+    num_vertices,
+    cmap::Vector{Int},
+    vertex_stack::Vector{Int} = Int[],
+    index_stack::Vector{Int} = Int[],
+)
 
     @assert length(cmap) == num_vertices
-    fill!(cmap,0)
+    fill!(cmap, 0)
     visitor = TopologicalSortVisitor(num_vertices)
 
     for s in 1:num_vertices
         if cmap[s] == 0
-            traverse_graph(adjlist, offsets, s, visitor, cmap, vertex_stack, index_stack)
+            traverse_graph(
+                adjlist,
+                offsets,
+                s,
+                visitor,
+                cmap,
+                vertex_stack,
+                index_stack,
+            )
         end
     end
 
-    visitor.vertices,visitor.parents
+    visitor.vertices, visitor.parents
 end

--- a/src/_Derivatives/types.jl
+++ b/src/_Derivatives/types.jl
@@ -68,7 +68,6 @@ for i in 1:length(comparison_operators)
 end
 export comparison_operator_to_id, comparison_operators
 
-
 # user-provided operators
 struct UserOperatorRegistry
     multivariate_operator_to_id::Dict{Symbol,Int}
@@ -127,7 +126,6 @@ function register_univariate_operator!(
 end
 
 export register_univariate_operator!
-
 
 function has_user_multivariate_operators(nd::Vector{NodeData})
     for k in 1:length(nd)

--- a/src/_Derivatives/types.jl
+++ b/src/_Derivatives/types.jl
@@ -1,7 +1,15 @@
 
 @enum NodeType CALL CALLUNIVAR MOIVARIABLE VARIABLE VALUE PARAMETER SUBEXPRESSION LOGIC COMPARISON EXTRA
 
-export CALL, CALLUNIVAR, MOIVARIABLE, VARIABLE, VALUE, PARAMETER, SUBEXPRESSION, LOGIC, COMPARISON
+export CALL,
+    CALLUNIVAR,
+    MOIVARIABLE,
+    VARIABLE,
+    VALUE,
+    PARAMETER,
+    SUBEXPRESSION,
+    LOGIC,
+    COMPARISON
 
 struct NodeData
     nodetype::NodeType
@@ -24,7 +32,7 @@ export NodeData
 # for COMPARISON, index is into lost of comparison operators
 # for EXTRA, index is extension specific
 
-const operators = [:+,:-,:*,:^,:/,:ifelse,:max,:min]
+const operators = [:+, :-, :*, :^, :/, :ifelse, :max, :min]
 const USER_OPERATOR_ID_START = length(operators) + 1
 
 const operator_to_id = Dict{Symbol,Int}()
@@ -33,26 +41,27 @@ for i in 1:length(operators)
 end
 export operator_to_id, operators
 
-const univariate_operators = Symbol[:+,:-,:abs]
+const univariate_operators = Symbol[:+, :-, :abs]
 const univariate_operator_to_id = Dict{Symbol,Int}(:+ => 1, :- => 2, :abs => 3)
-const univariate_operator_deriv = Any[:(one(x)),:(-one(x)),:(ifelse(x >= 0, one(x),-one(x)))]
+const univariate_operator_deriv =
+    Any[:(one(x)), :(-one(x)), :(ifelse(x >= 0, one(x), -one(x)))]
 export univariate_operator_to_id, univariate_operators
 
 for (op, deriv) in Calculus.symbolic_derivatives_1arg()
     push!(univariate_operators, op)
-    push!(univariate_operator_deriv,deriv)
+    push!(univariate_operator_deriv, deriv)
     univariate_operator_to_id[op] = length(univariate_operators)
 end
 const USER_UNIVAR_OPERATOR_ID_START = length(univariate_operators) + 1
 
-const logic_operators = [:&&,:||]
+const logic_operators = [:&&, :||]
 const logic_operator_to_id = Dict{Symbol,Int}()
 for i in 1:length(logic_operators)
     logic_operator_to_id[logic_operators[i]] = i
 end
 export logic_operator_to_id, logic_operators
 
-const comparison_operators = [:<=,:(==),:>=,:<,:>]
+const comparison_operators = [:<=, :(==), :>=, :<, :>]
 const comparison_operator_to_id = Dict{Symbol,Int}()
 for i in 1:length(comparison_operators)
     comparison_operator_to_id[comparison_operators[i]] = i
@@ -70,17 +79,29 @@ struct UserOperatorRegistry
     univariate_operator_fprimeprime::Vector{Any}
 end
 
-UserOperatorRegistry() = UserOperatorRegistry(Dict{Symbol,Int}(),MOI.AbstractNLPEvaluator[],Dict{Symbol,Int}(),[],[],[])
+UserOperatorRegistry() = UserOperatorRegistry(
+    Dict{Symbol,Int}(),
+    MOI.AbstractNLPEvaluator[],
+    Dict{Symbol,Int}(),
+    [],
+    [],
+    [],
+)
 
 # we use the MathOptInterface NLPEvaluator interface, where the
 # operator takes the place of the objective function.
 # users should implement eval_f and eval_grad_f for now.
 # we will eventually support hessians too
-function register_multivariate_operator!(r::UserOperatorRegistry,s::Symbol,f::MOI.AbstractNLPEvaluator)
-    haskey(r.multivariate_operator_to_id, s) && error("Operator $s has already been defined")
-    id = length(r.multivariate_operator_evaluator)+1
+function register_multivariate_operator!(
+    r::UserOperatorRegistry,
+    s::Symbol,
+    f::MOI.AbstractNLPEvaluator,
+)
+    haskey(r.multivariate_operator_to_id, s) &&
+        error("Operator $s has already been defined")
+    id = length(r.multivariate_operator_evaluator) + 1
     r.multivariate_operator_to_id[s] = id
-    push!(r.multivariate_operator_evaluator,f)
+    push!(r.multivariate_operator_evaluator, f)
     return
 end
 
@@ -88,13 +109,20 @@ export register_multivariate_operator!
 
 # for univariate operators, just take in functions to evaluate
 # zeroth, first, and second order derivatives
-function register_univariate_operator!(r::UserOperatorRegistry,s::Symbol,f,fprime,fprimeprime)
-    haskey(r.univariate_operator_to_id, s) && error("Operator $s has already been defined")
-    id = length(r.univariate_operator_f)+1
+function register_univariate_operator!(
+    r::UserOperatorRegistry,
+    s::Symbol,
+    f,
+    fprime,
+    fprimeprime,
+)
+    haskey(r.univariate_operator_to_id, s) &&
+        error("Operator $s has already been defined")
+    id = length(r.univariate_operator_f) + 1
     r.univariate_operator_to_id[s] = id
-    push!(r.univariate_operator_f,f)
-    push!(r.univariate_operator_fprime,fprime)
-    push!(r.univariate_operator_fprimeprime,fprimeprime)
+    push!(r.univariate_operator_f, f)
+    push!(r.univariate_operator_fprime, fprime)
+    push!(r.univariate_operator_fprimeprime, fprimeprime)
     return
 end
 


### PR DESCRIPTION
Following #2292, run the formatter over `src/_Derivatives`. 

```
format("src/_Derivatives";
    margin = 80,
    always_for_in = true,
    remove_extra_newlines = true,
    always_use_return = true,
)
```

There are some `return nothing's that JuliaFormatter doesn't get rid of.