### PR TITLE
Bound StaticArrays to fix Julia 1.0 compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ MutableArithmetics = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
 NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
@@ -24,6 +25,7 @@ JSON = "0.21"
 MathOptInterface = "~0.9.14"
 MutableArithmetics = "0.2"
 NaNMath = "0.3"
+StaticArrays = "0.12"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ MutableArithmetics = "0.2"
 NaNMath = "0.3"
 # This restriction on StaticArrays is needed to avoid excessive memory 
 # usage on Julia 1.0.x. See JuMP#2390, JuliaArrays/StaticArrays#857, or 
-# JuliaLang/julia#38634. In can be removed when the minimum Julia version
+# JuliaLang/julia#38634. It can be removed when the minimum Julia version
 # is changed to the new LTS (julia = "1.6").
 StaticArrays = "0.12"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -25,6 +25,10 @@ JSON = "0.21"
 MathOptInterface = "~0.9.14"
 MutableArithmetics = "0.2"
 NaNMath = "0.3"
+# This restriction on StaticArrays is needed to avoid excessive memory 
+# usage on Julia 1.0.x. See JuMP#2390, JuliaArrays/StaticArrays#857, or 
+# JuliaLang/julia#38634. In can be removed when the minimum Julia version
+# is changed to the new LTS (julia = "1.6").
 StaticArrays = "0.12"
 julia = "1"
 


### PR DESCRIPTION
CI is broken on Julia 1.0. We were passing 5 hours ago here: https://github.com/jump-dev/JuMP.jl/commit/77a0b82bf47f35913cc8cff0c389425948cb4fea
But failing 2 hours ago here: https://github.com/jump-dev/JuMP.jl/commit/eefafb163755b37faba5e0c0d648d77ef0a6796d

This release of ForwardDiff is the only thing I can find that changed within that time-frame: https://github.com/JuliaRegistries/General/pull/25512
https://github.com/JuliaDiff/ForwardDiff.jl/compare/v0.10.12...v0.10.13

