### PR TITLE
Restructure README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,123 +3,56 @@
 
 [![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
 
-JuMP is a domain-specific modeling language for **[mathematical optimization]**
-embedded in **[Julia]**. It currently supports a number of open-source and
-commercial solvers ([Artelys Knitro], [BARON], [Bonmin], [Cbc], [CDCS], [CDD],
-[Clp], [COSMO], [Couenne], [CPLEX], [CSDP], [ECOS], [FICO Xpress], [GLPK],
-[Gurobi], [Ipopt], [Juniper], [MOSEK], [NLopt], [OSQP], [ProxSDP], [SCIP],
-[SCS], [SDPA], [SDPT3], [SeDuMi], [Tulip]) for a variety of problem classes, including
-**[linear programming]**, **[(mixed) integer programming]**,
-**[second-order conic programming]**, **[semidefinite programming]**, and **[nonlinear programming]**.
+JuMP is a domain-specific modeling language for [mathematical optimization](https://en.wikipedia.org/wiki/Mathematical_optimization)
+embedded in [Julia](https://julialang.org/). You can find out more about us by 
+visiting [jump.dev](https://jump.dev).
 
-[mathematical optimization]: https://en.wikipedia.org/wiki/Mathematical_optimization
-[Julia]: https://julialang.org/
-[Artelys Knitro]: https://artelys.com/en/optimization-tools/knitro
-[BARON]: http://archimedes.cheme.cmu.edu/?q=baron
-[Bonmin]: https://projects.coin-or.org/Bonmin
-[Cbc]: https://github.com/coin-or/Cbc
-[CDCS]: https://github.com/oxfordcontrol/CDCS
-[CDD]: https://github.com/cddlib/cddlib
-[Clp]: https://github.com/coin-or/Clp
-[COSMO]: https://github.com/oxfordcontrol/COSMO.jl
-[Couenne]: https://projects.coin-or.org/Couenne
-[CPLEX]: https://www.ibm.com/analytics/cplex-optimizer
-[CSDP]: https://projects.coin-or.org/Csdp/
-[ECOS]: https://github.com/ifa-ethz/ecos
-[FICO Xpress]: https://www.fico.com/en/products/fico-xpress-optimization-suite
-[GLPK]: http://www.gnu.org/software/glpk/
-[Gurobi]: https://www.gurobi.com/
-[Ipopt]: https://github.com/coin-or/Ipopt
-[Juniper]: https://github.com/lanl-ansi/Juniper.jl
-[MOSEK]: https://mosek.com/
-[NLopt]: https://nlopt.readthedocs.io/en/latest/
-[OSQP]: https://osqp.org/
-[ProxSDP]: https://github.com/mariohsouto/ProxSDP.jl
-[SCIP]: https://scip.zib.de/
-[SCS]: https://github.com/cvxgrp/scs
-[SDPA]: http://sdpa.sourceforge.net/
-[SDPT3]: https://blog.nus.edu.sg/mattohkc/softwares/sdpt3/
-[SeDuMi]: http://sedumi.ie.lehigh.edu/
-[Tulip]: https://github.com/ds4dm/Tulip.jl
-[linear programming]: https://en.wikipedia.org/wiki/Linear_programming
-[(mixed) integer programming]: https://en.wikipedia.org/wiki/Integer_programming
-[second-order conic programming]: https://en.wikipedia.org/wiki/Second-order_cone_programming
-[semidefinite programming]: https://en.wikipedia.org/wiki/Semidefinite_programming
-[nonlinear programming]: https://en.wikipedia.org/wiki/Nonlinear_programming
-
-JuMP makes it easy to specify and **solve optimization problems without expert knowledge**, yet at the same time allows experts to implement advanced algorithmic techniques such as exploiting efficient hot-starts in linear programming or using callbacks to interact with branch-and-bound solvers. JuMP is also **fast** - benchmarking has shown that it can create problems at similar speeds to special-purpose commercial tools such as AMPL while maintaining the expressiveness of a generic high-level programming language. JuMP can be easily embedded in complex work flows including simulations and web servers.
-
-Our documentation includes an installation guide, quick-start guide, and reference manual. The **[JuMPTutorials.jl]** repository contains a small but growing collection of contributed examples. Submissions are welcome!
-
-[JuMPTutorials.jl]: https://github.com/jump-dev/JuMPTutorials.jl
-
-**See [NEWS](https://github.com/jump-dev/JuMP.jl/tree/master/NEWS.md) for
-a list of the significant breaking changes in the JuMP 0.19 release.**
-
-**Latest Release**: 0.21.5 (`release-0.21` branch)
-  * [Documentation](https://jump.dev/JuMP.jl/v0.21.5/)
+**Latest Release**: 0.21.5 (`release-0.21` branch):
+  * Use this version if you are using JuMP to solve problems.
+  * Installation via the Julia package manager:
+    * `import Pkg; Pkg.add("JuMP")`
+  * Get help:
+    * Read the [Documentation](https://jump.dev/JuMP.jl/v0.21.5/)
+    * Ask a question on the [Community forum]
+    * Explore the [JuMPTutorials](https://github.com/jump-dev/JuMPTutorials.jl)
   * Testing status:
     * Github Actions: [![Build Status](https://github.com/jump-dev/JuMP.jl/workflows/CI/badge.svg?branch=release-0.21)](https://github.com/jump-dev/JuMP.jl/actions?query=workflow%3ACI)
 
-
 **Development version** (`master` branch):
-  * [Documentation](https://jump.dev/JuMP.jl/dev/)
+  * Use this version if you are hacking on JuMP or related projects.
+  * Installation via the Julia package manager:
+    * `import Pkg; Pkg.add(Pkg.PackageSpec(name="JuMP", rev="master"))`
+  * Get help:
+    * Read the [Documentation](https://jump.dev/JuMP.jl/dev/)
+    * Join the [Developer chatroom](https://gitter.im/JuliaOpt/JuMP-dev)
+    * Read the [NEWS](https://github.com/jump-dev/JuMP.jl/tree/master/NEWS.md)
   * Testing status:
     * Github Actions: [![Build Status](https://github.com/jump-dev/JuMP.jl/workflows/CI/badge.svg?branch=master)](https://github.com/jump-dev/JuMP.jl/actions?query=workflow%3ACI)
     * Test coverage: [![codecov](https://codecov.io/gh/jump-dev/JuMP.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/jump-dev/JuMP.jl)
-  * Changes: see [NEWS](https://github.com/jump-dev/JuMP.jl/tree/master/NEWS.md)
-  * [Developer chatroom](https://gitter.im/JuliaOpt/JuMP-dev)
 
+## Need help?
 
-## Installation
+Use the [Community forum] to search for answers to previously asked questions, 
+or ask a new question. 
 
-JuMP can be installed through the Julia package manager:
+Before asking a question, you can help us by reading [PSA: make it easier to help you](https://discourse.julialang.org/t/psa-make-it-easier-to-help-you/14757),
+and following the suggestions. In particular, _simplify_ your problem and make
+it reproducible. 
 
-```julia
-julia> Pkg.add("JuMP")
-```
+[Community forum]: https://discourse.julialang.org/c/domain/opt
 
-For full installation instructions, including how to install solvers, see the documentation linked above.
+## Bug reports
 
-
-## Supported problem classes
-
-Mathematical optimization encompasses a large variety of problem classes.
-We list below what is currently supported. See the documentation for more information.
-
-**Objective types**
-
-* Linear
-* Convex Quadratic
-* Nonlinear (convex and nonconvex)
-
-**Constraint types**
-
-* Linear
-* Convex Quadratic
-* Second-order Conic
-* Semidefinite
-* Nonlinear (convex and nonconvex)
-
-**Variable types**
-
-* Continuous
-* Integer-valued
-* Semicontinuous
-* Semi-integer
-
-
-## Bug reports and support
-
-Please report any issues via the Github **[issue tracker]**. All types of issues are welcome and encouraged; this includes bug reports, documentation typos, feature requests, etc. The **[Optimization (Mathematical)]** category on Discourse is appropriate for general discussion, including "how do I do this?" questions.
+Please report any issues via the Github **[issue tracker]**. All types of issues 
+are welcome and encouraged; this includes bug reports, documentation typos, 
+feature requests, etc.
 
 [issue tracker]: https://github.com/jump-dev/JuMP.jl/issues
-[Optimization (Mathematical)]: https://discourse.julialang.org/c/domain/opt
-
 
 ## Citing JuMP
 
-If you find JuMP useful in your work, we kindly request that you cite the following paper ([pdf](https://mlubin.github.io/pdf/jump-sirev.pdf)):
+If you find JuMP useful in your work, we kindly request that you cite the 
+following paper ([pdf](https://mlubin.github.io/pdf/jump-sirev.pdf)):
 
 ```bibtex
 @article{DunningHuchetteLubin2017,
@@ -134,7 +67,8 @@ If you find JuMP useful in your work, we kindly request that you cite the follow
 }
 ```
 
-For an earlier work where we presented a prototype implementation of JuMP, see [here](https://dx.doi.org/10.1287/ijoc.2014.0623):
+For an earlier work where we presented a prototype implementation of JuMP, see 
+[here](https://dx.doi.org/10.1287/ijoc.2014.0623):
 
 ```bibtex
 @article{LubinDunningIJOC,

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ embedded in [Julia](https://julialang.org/). You can find out more about us by
 visiting [jump.dev](https://jump.dev).
 
 **Latest Release**: 0.21.5 (`release-0.21` branch):
-  * Use this version if you are using JuMP to solve problems.
   * Installation via the Julia package manager:
     * `import Pkg; Pkg.add("JuMP")`
   * Get help:
@@ -19,7 +18,6 @@ visiting [jump.dev](https://jump.dev).
     * Github Actions: [![Build Status](https://github.com/jump-dev/JuMP.jl/workflows/CI/badge.svg?branch=release-0.21)](https://github.com/jump-dev/JuMP.jl/actions?query=workflow%3ACI)
 
 **Development version** (`master` branch):
-  * Use this version if you are hacking on JuMP or related projects.
   * Installation via the Julia package manager:
     * `import Pkg; Pkg.add(Pkg.PackageSpec(name="JuMP", rev="master"))`
   * Get help:
@@ -35,15 +33,14 @@ visiting [jump.dev](https://jump.dev).
 Use the [Community forum] to search for answers to previously asked questions, 
 or ask a new question. 
 
-Before asking a question, you can help us by reading [PSA: make it easier to help you](https://discourse.julialang.org/t/psa-make-it-easier-to-help-you/14757),
-and following the suggestions. In particular, _simplify_ your problem and make
-it reproducible. 
+The post [PSA: make it easier to help you](https://discourse.julialang.org/t/psa-make-it-easier-to-help-you/14757),
+describes the best practices for asking a question.
 
 [Community forum]: https://discourse.julialang.org/c/domain/opt
 
 ## Bug reports
 
-Please report any issues via the Github **[issue tracker]**. All types of issues 
+Please report any issues via the Github [issue tracker]. All types of issues 
 are welcome and encouraged; this includes bug reports, documentation typos, 
 feature requests, etc.
 


### PR DESCRIPTION
I've always found the README quite dense. We should be off-loading information to the documentation or the `jump.dev` website.

This PR reduces the amount of text, makes it more explicit that users should use the community forum to get help, and explains who should be using the latest release and development versions.