### PR TITLE
Remove incorrect and un-used copy functions

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -400,24 +400,24 @@ end
 """
      print_bridge_graph([io::IO,] model::Model)
 
-Print the hyper-graph containing all variable, constraint, and objective types 
-that could be obtained by bridging the variables, constraints, and objectives 
+Print the hyper-graph containing all variable, constraint, and objective types
+that could be obtained by bridging the variables, constraints, and objectives
 that are present in the model.
 
-Each node in the hyper-graph corresponds to a variable, constraint, or objective 
+Each node in the hyper-graph corresponds to a variable, constraint, or objective
 type.
   * Variable nodes are indicated by `[ ]`
   * Constraint nodes are indicated by `( )`
   * Objective nodes are indicated by `| |`
-The number inside each pair of brackets is an index of the node in the 
+The number inside each pair of brackets is an index of the node in the
 hyper-graph.
 
-Note that this hyper-graph is the full list of possible transformations. When 
-the bridged model is created, we select the shortest hyper-path(s) from this 
+Note that this hyper-graph is the full list of possible transformations. When
+the bridged model is created, we select the shortest hyper-path(s) from this
 graph, so many nodes may be un-used.
 
-For more information, see Legat, B., Dowson, O., Garcia, J., and Lubin, M. 
-(2020).  "MathOptInterface: a data structure for mathematical optimization 
+For more information, see Legat, B., Dowson, O., Garcia, J., and Lubin, M.
+(2020).  "MathOptInterface: a data structure for mathematical optimization
 problems." URL: https://arxiv.org/abs/2002.03447
 """
 print_bridge_graph(model::Model) = print_bridge_graph(Base.stdout, model)
@@ -790,14 +790,6 @@ mutable struct VariableNotOwnedError <: Exception
 end
 function Base.showerror(io::IO, ex::VariableNotOwnedError)
     print(io, "VariableNotOwnedError: Variable not owned by model present in $(ex.context)")
-end
-
-
-Base.copy(v::VariableRef, new_model::Model) = VariableRef(new_model, v.index)
-Base.copy(x::Nothing, new_model::AbstractModel) = nothing
-# TODO: Replace with vectorized copy?
-function Base.copy(v::AbstractArray{VariableRef}, new_model::AbstractModel)
-    return (var -> VariableRef(new_model, var.index)).(v)
 end
 
 _moi_optimizer_index(model::MOI.AbstractOptimizer, index::MOI.Index) = index

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -422,17 +422,6 @@ function moi_function_type(::Type{<:Vector{<:GenericAffExpr{T}}}) where {T}
     return MOI.VectorAffineFunction{T}
 end
 
-# Copy an affine expression to a new model by converting all the
-# variables to the new model's variables
-function Base.copy(a::GenericAffExpr, new_model::AbstractModel)
-    result = zero(a)
-    for (coef, var) in linear_terms(a)
-        add_to_expression!(result, coef, copy(var, new_model))
-    end
-    result.constant = a.constant
-    return result
-end
-
 # TODO: Find somewhere to put this error message.
 #add_constraint(m::Model, c::Array{AffExprConstraint}) =
 #    error("The operators <=, >=, and == can only be used to specify scalar constraints. If you are trying to add a vectorized constraint, use the element-wise dot comparison operators (.<=, .>=, or .==) instead")

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -430,14 +430,6 @@ function moi_function_type(::Type{<:Vector{<:GenericQuadExpr{T}}}) where {T}
     return MOI.VectorQuadraticFunction{T}
 end
 
-
-# Copy a quadratic expression to a new model by converting all the
-# variables to the new model's variables
-function Base.copy(q::GenericQuadExpr, new_model::Model)
-    GenericQuadExpr(copy(q.qvars1, new_model), copy(q.qvars2, new_model),
-                    copy(q.qcoeffs), copy(q.aff, new_model))
-end
-
 # Requires that value_func(::VarType) is defined.
 function value(ex::GenericQuadExpr{CoefType, VarType},
                value_func::Function) where {CoefType, VarType}

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -49,9 +49,6 @@ struct MyVariableRef <: JuMP.AbstractVariableRef
     idx::Int       # Index in `model.variables`
 end
 Base.copy(v::MyVariableRef) = v
-function Base.copy(v::MyVariableRef, new_model::MyModel)
-    return MyVariableRef(new_model, v.idx)
-end
 
 function Base.:(==)(v::MyVariableRef, w::MyVariableRef)
     return v.model === w.model && v.idx == w.idx

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -154,15 +154,6 @@ function expressions_test(
         @test k == 0
     end
 
-    @testset "Copy AffExpr between models" begin
-        m = ModelType()
-        @variable(m, x)
-        m2 = ModelType()
-        aff = copy(2x + 1, m2)
-        aff_expected = 2 * copy(x, m2) + 1
-        @test JuMP.isequal_canonical(aff, aff_expected)
-    end
-
     @testset "MA.add_mul!(ex::Number, c::Number, x::GenericAffExpr)" begin
         aff = MA.add_mul!(1.0, 2.0, JuMP.GenericAffExpr(1.0, :a => 1.0))
         @test JuMP.isequal_canonical(aff, JuMP.GenericAffExpr(3.0, :a => 2.0))


### PR DESCRIPTION
Closes #2407

Technically, this is a breaking change, but the definitions are old and incorrect, so no one should be relying on them.