### PR TITLE
Change isapprox(a,b) to a \approx b in tests

### DIFF
--- a/test/derivatives.jl
+++ b/test/derivatives.jl
@@ -423,7 +423,7 @@ struct ΦEvaluator <: MOI.AbstractNLPEvaluator end
     reverse_extract(grad, reverse_storage, nd, adj, [], 1.0)
     @test grad[1] == 0.0
 
-    function test_linearity(ex, testval, IJ=[], indices=[])
+    function test_linearity(ex, testval, IJ = [], indices = [])
         nd, const_values = expr_to_nodedata(ex)
         adj = adjmat(nd)
         linearity = classify_linearity(nd, adj, [])
@@ -551,7 +551,7 @@ struct ΦEvaluator <: MOI.AbstractNLPEvaluator end
     @test grad ≈ true_grad
 
     # dual forward test
-    function dualforward(ex, x; ignore_nan=false)
+    function dualforward(ex, x; ignore_nan = false)
         nd, const_values = expr_to_nodedata(ex)
         adj = adjmat(nd)
         forward_storage = zeros(length(nd))
@@ -643,18 +643,17 @@ struct ΦEvaluator <: MOI.AbstractNLPEvaluator end
             ForwardDiff.Dual(2.0, 0.0),
         )
         for k in 1:length(nd)
-            @test _epsilon(forward_dual_storage[k]) ≈
-                forward_storage_ϵ[k][1]
+            @test _epsilon(forward_dual_storage[k]) ≈ forward_storage_ϵ[k][1]
 
             if !(isnan(_epsilon(partials_dual_storage[k])) && ignore_nan)
                 @test _epsilon(partials_dual_storage[k]) ≈
-                    partials_storage_ϵ[k][1]
+                      partials_storage_ϵ[k][1]
             else
                 @test !isnan(forward_storage_ϵ[k][1])
             end
             if !(isnan(_epsilon(reverse_dual_storage[k])) && ignore_nan)
-                @test _epsilon(reverse_dual_storage[k]) ≈ 
-                    reverse_storage_ϵ[k][1] / 2
+                @test _epsilon(reverse_dual_storage[k]) ≈
+                      reverse_storage_ϵ[k][1] / 2
             else
                 @test !isnan(reverse_storage_ϵ[k][1])
             end
@@ -674,6 +673,6 @@ struct ΦEvaluator <: MOI.AbstractNLPEvaluator end
     dualforward(
         :(x[1] * x[2]),
         [3.427139283036299e-206, 1.0],
-        ignore_nan=true,
+        ignore_nan = true,
     )
 end

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -146,7 +146,7 @@ end
         model = Model()
         @variable(model, x)
         user_function = x -> x
-        JuMP.register(model, :f, 1, user_function, autodiff=true)
+        JuMP.register(model, :f, 1, user_function, autodiff = true)
         @test expressions_equal(
             JuMP.@_process_NL_expr(model, f(x)),
             _NonlinearExprData(model, :(f($x))),
@@ -158,7 +158,7 @@ end
         @variable(model, x)
         @variable(model, y)
         user_function = (x, y) -> x
-        JuMP.register(model, :f, 2, user_function, autodiff=true)
+        JuMP.register(model, :f, 2, user_function, autodiff = true)
         @test expressions_equal(
             JuMP.@_process_NL_expr(model, f(x, y)),
             _NonlinearExprData(model, :(f($x, $y))),
@@ -169,7 +169,7 @@ end
         model = Model()
         @variable(model, x[1:2])
         user_function = (x, y) -> x
-        JuMP.register(model, :f, 2, user_function, autodiff=true)
+        JuMP.register(model, :f, 2, user_function, autodiff = true)
         @test expressions_equal(
             JuMP.@_process_NL_expr(model, f(x...)),
             _NonlinearExprData(model, :(f($(x[1]), $(x[2])))),
@@ -253,7 +253,7 @@ end
         values = [1.0, 2.0, 3.0] # Values for a, b, and c, respectively.
         MOI.eval_hessian_lagrangian(d, V, values, 1.0, Float64[])
         @test dense_hessian(hessian_sparsity, V, 3) ≈
-            [0.0 1.0 0.0; 1.0 0.0 0.0; 0.0 0.0 2.0]
+              [0.0 1.0 0.0; 1.0 0.0 0.0; 0.0 0.0 2.0]
 
         # make sure we don't get NaNs in this case
         @NLobjective(m, Min, a * b + 3 * c^2)
@@ -263,14 +263,14 @@ end
         V = zeros(length(hessian_sparsity))
         MOI.eval_hessian_lagrangian(d, V, values, 1.0, Float64[])
         @test dense_hessian(hessian_sparsity, V, 3) ≈
-            [0.0 1.0 0.0; 1.0 0.0 0.0; 0.0 0.0 6.0]
+              [0.0 1.0 0.0; 1.0 0.0 0.0; 0.0 0.0 6.0]
 
         # Initialize again
         MOI.initialize(d, [:Hess])
         V = zeros(length(hessian_sparsity))
         MOI.eval_hessian_lagrangian(d, V, values, 1.0, Float64[])
         @test dense_hessian(hessian_sparsity, V, 3) ≈
-            [0.0 1.0 0.0; 1.0 0.0 0.0; 0.0 0.0 6.0]
+              [0.0 1.0 0.0; 1.0 0.0 0.0; 0.0 0.0 6.0]
     end
 
     @testset "NaN corner case (Issue #695)" begin
@@ -288,7 +288,7 @@ end
         v = [2.4, 3.5]
         values = [1.0, 2.0] # For x and y.
         MOI.eval_hessian_lagrangian_product(d, h, values, v, 1.0, Float64[])
-        correct = [0.0 -1 / (2 * 2^(3 / 2)); -1 / (2 * 2^(3 / 2)) 3 / (4 * 2^(5 / 2))] * v
+        correct = [0.0 -1/(2*2^(3/2)); -1/(2*2^(3/2)) 3/(4*2^(5/2))] * v
         @test h ≈ correct
     end
 
@@ -494,12 +494,12 @@ end
 
         ψ(x) = 1
         t(x, y) = 2
-        JuMP.register(m, :ψ, 1, ψ, autodiff=true)
-        JuMP.register(m, :t, 2, t, autodiff=true)
+        JuMP.register(m, :ψ, 1, ψ, autodiff = true)
+        JuMP.register(m, :t, 2, t, autodiff = true)
 
         @NLobjective(m, Min, x^y)
         @NLconstraint(m, sin(x) * cos(y) == 5)
-        @NLconstraint(m, nlconstr[i=1:2], i * x^2 == i)
+        @NLconstraint(m, nlconstr[i = 1:2], i * x^2 == i)
         @NLconstraint(m, -0.5 <= sin(x) <= 0.5)
         @NLconstraint(m, ψ(x) + t(x, y) <= 3)
 
@@ -558,7 +558,7 @@ end
         @objective(model, Max, x)
 
         @NLconstraints(model, begin
-            ref[i=1:3], y[i] == 0
+            ref[i = 1:3], y[i] == 0
             x + y[1] * y[2] * y[3] <= 0.5
         end)
 
@@ -592,15 +592,14 @@ end
         values = ones(18)
         MOI.eval_hessian_lagrangian(d, V, values, 1.0, Float64[])
         @test dense_hessian(hessian_sparsity, V, 18) ≈
-            ones(18, 18) - diagm(0 => ones(18))
+              ones(18, 18) - diagm(0 => ones(18))
 
         values[1] = 0.5
         MOI.eval_hessian_lagrangian(d, V, values, 1.0, Float64[])
-        @test dense_hessian(hessian_sparsity, V, 18) ≈
-            [
-                0 ones(17)'
-                ones(17) (ones(17, 17) - diagm(0 => ones(17))) / 2
-            ]
+        @test dense_hessian(hessian_sparsity, V, 18) ≈ [
+            0 ones(17)'
+            ones(17) (ones(17, 17)-diagm(0 => ones(17)))/2
+        ]
     end
 
     @testset "eval_objective and eval_objective_gradient" begin
@@ -611,15 +610,15 @@ end
 
         ψ(x) = sin(x)
         t(x, y) = x + 3y
-        JuMP.register(m, :ψ, 1, ψ, autodiff=true)
-        JuMP.register(m, :t, 2, t, autodiff=true)
+        JuMP.register(m, :ψ, 1, ψ, autodiff = true)
+        JuMP.register(m, :t, 2, t, autodiff = true)
 
         @NLobjective(m, Min, ex / 2 + sin(x[2]) / ψ(x[2]) + t(x[3], x[4]))
         d = JuMP.NLPEvaluator(m)
         MOI.initialize(d, [:Grad])
         variable_values = fill(2.0, (4,))
         @test MOI.eval_objective(d, variable_values) ≈
-            variable_values[1] + 1 + variable_values[3] + 3variable_values[4]
+              variable_values[1] + 1 + variable_values[3] + 3variable_values[4]
         grad = zeros(4)
         MOI.eval_objective_gradient(d, grad, variable_values)
         @test grad ≈ [1.0, 0.0, 1.0, 3.0]
@@ -633,8 +632,8 @@ end
 
         ψ(x) = sin(x)
         t(x, y) = x + 3y
-        JuMP.register(m, :ψ, 1, ψ, autodiff=true)
-        JuMP.register(m, :t, 2, t, autodiff=true)
+        JuMP.register(m, :ψ, 1, ψ, autodiff = true)
+        JuMP.register(m, :t, 2, t, autodiff = true)
 
         @NLconstraint(
             m,
@@ -647,7 +646,7 @@ end
         constraint_value = zeros(1)
         MOI.eval_constraint(d, constraint_value, variable_values)
         @test constraint_value[1] ≈
-            variable_values[1] + 1 + variable_values[3] + 3variable_values[4]
+              variable_values[1] + 1 + variable_values[3] + 3variable_values[4]
         jacobian_sparsity = MOI.jacobian_structure(d)
         I = [i for (i, j) in jacobian_sparsity]
         J = [j for (i, j) in jacobian_sparsity]
@@ -740,7 +739,7 @@ end
         model = Model()
         @variable(model, x[1:2])
         f(x1) = x1 + x[2]
-        JuMP.register(model, :f, 1, f; autodiff=true)
+        JuMP.register(model, :f, 1, f; autodiff = true)
         @NLobjective(model, Min, f(x[1]))
         d = JuMP.NLPEvaluator(model)
         MOI.initialize(d, [:Grad])
@@ -757,7 +756,7 @@ end
         model = Model()
         @variable(model, x)
         f(x) = string(x)
-        JuMP.register(model, :f, 1, f; autodiff=true)
+        JuMP.register(model, :f, 1, f; autodiff = true)
         @NLobjective(model, Min, f(x))
         d = JuMP.NLPEvaluator(model)
         MOI.initialize(d, [:Grad])
@@ -783,7 +782,7 @@ end
     @testset "Hessians disabled with user-defined multivariate functions" begin
         model = Model()
         my_f(x, y) = (x - 1)^2 + (y - 2)^2
-        JuMP.register(model, :my_f, 2, my_f, autodiff=true)
+        JuMP.register(model, :my_f, 2, my_f, autodiff = true)
         @variable(model, x[1:2])
         @NLobjective(model, Min, my_f(x[1], x[2]))
         evaluator = JuMP.NLPEvaluator(model)
@@ -840,7 +839,7 @@ end
         err = ErrorException(
             "Encountered an error parsing nonlinear expression: we don't support " *
             "models of type $(typeof(model)). In general, JuMP's nonlinear features " *
-            "don't work with JuMP-extensions."
+            "don't work with JuMP-extensions.",
         )
         @test_throws(err, @NLexpression(model, sqrt(x)))
     end

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -1,5 +1,3 @@
-# TODO: Replace isapprox with ≈ everywhere.
-
 using JuMP
 using LinearAlgebra
 using SparseArrays
@@ -148,7 +146,7 @@ end
         model = Model()
         @variable(model, x)
         user_function = x -> x
-        JuMP.register(model, :f, 1, user_function, autodiff = true)
+        JuMP.register(model, :f, 1, user_function, autodiff=true)
         @test expressions_equal(
             JuMP.@_process_NL_expr(model, f(x)),
             _NonlinearExprData(model, :(f($x))),
@@ -160,7 +158,7 @@ end
         @variable(model, x)
         @variable(model, y)
         user_function = (x, y) -> x
-        JuMP.register(model, :f, 2, user_function, autodiff = true)
+        JuMP.register(model, :f, 2, user_function, autodiff=true)
         @test expressions_equal(
             JuMP.@_process_NL_expr(model, f(x, y)),
             _NonlinearExprData(model, :(f($x, $y))),
@@ -171,7 +169,7 @@ end
         model = Model()
         @variable(model, x[1:2])
         user_function = (x, y) -> x
-        JuMP.register(model, :f, 2, user_function, autodiff = true)
+        JuMP.register(model, :f, 2, user_function, autodiff=true)
         @test expressions_equal(
             JuMP.@_process_NL_expr(model, f(x...)),
             _NonlinearExprData(model, :(f($(x[1]), $(x[2])))),
@@ -254,10 +252,8 @@ end
         V = zeros(length(hessian_sparsity))
         values = [1.0, 2.0, 3.0] # Values for a, b, and c, respectively.
         MOI.eval_hessian_lagrangian(d, V, values, 1.0, Float64[])
-        @test isapprox(
-            dense_hessian(hessian_sparsity, V, 3),
-            [0.0 1.0 0.0; 1.0 0.0 0.0; 0.0 0.0 2.0],
-        )
+        @test dense_hessian(hessian_sparsity, V, 3) ≈
+            [0.0 1.0 0.0; 1.0 0.0 0.0; 0.0 0.0 2.0]
 
         # make sure we don't get NaNs in this case
         @NLobjective(m, Min, a * b + 3 * c^2)
@@ -266,19 +262,15 @@ end
         values = [1.0, 2.0, -1.0]
         V = zeros(length(hessian_sparsity))
         MOI.eval_hessian_lagrangian(d, V, values, 1.0, Float64[])
-        @test isapprox(
-            dense_hessian(hessian_sparsity, V, 3),
-            [0.0 1.0 0.0; 1.0 0.0 0.0; 0.0 0.0 6.0],
-        )
+        @test dense_hessian(hessian_sparsity, V, 3) ≈
+            [0.0 1.0 0.0; 1.0 0.0 0.0; 0.0 0.0 6.0]
 
         # Initialize again
         MOI.initialize(d, [:Hess])
         V = zeros(length(hessian_sparsity))
         MOI.eval_hessian_lagrangian(d, V, values, 1.0, Float64[])
-        @test isapprox(
-            dense_hessian(hessian_sparsity, V, 3),
-            [0.0 1.0 0.0; 1.0 0.0 0.0; 0.0 0.0 6.0],
-        )
+        @test dense_hessian(hessian_sparsity, V, 3) ≈
+            [0.0 1.0 0.0; 1.0 0.0 0.0; 0.0 0.0 6.0]
     end
 
     @testset "NaN corner case (Issue #695)" begin
@@ -296,8 +288,8 @@ end
         v = [2.4, 3.5]
         values = [1.0, 2.0] # For x and y.
         MOI.eval_hessian_lagrangian_product(d, h, values, v, 1.0, Float64[])
-        correct = [0.0 -1/(2*2^(3/2)); -1/(2*2^(3/2)) 3/(4*2^(5/2))] * v
-        @test isapprox(h, correct)
+        correct = [0.0 -1 / (2 * 2^(3 / 2)); -1 / (2 * 2^(3 / 2)) 3 / (4 * 2^(5 / 2))] * v
+        @test h ≈ correct
     end
 
     @testset "NaN corner case (Issue #1205)" begin
@@ -312,7 +304,7 @@ end
         V = zeros(length(hessian_sparsity))
         values = zeros(1)
         MOI.eval_hessian_lagrangian(d, V, values, 1.0, Float64[])
-        @test isapprox(dense_hessian(hessian_sparsity, V, 1), [0.0])
+        @test dense_hessian(hessian_sparsity, V, 1) ≈ [0.0]
     end
 
     @testset "NaN corner case - ifelse (Issue #1205)" begin
@@ -327,7 +319,7 @@ end
         V = zeros(length(hessian_sparsity))
         values = zeros(1)
         MOI.eval_hessian_lagrangian(d, V, values, 1.0, Float64[])
-        @test isapprox(dense_hessian(hessian_sparsity, V, 1), [0.0])
+        @test dense_hessian(hessian_sparsity, V, 1) ≈ [0.0]
     end
 
     @testset "Product corner case (issue #1181)" begin
@@ -371,12 +363,12 @@ end
         V = zeros(length(hessian_sparsity))
         MOI.eval_hessian_lagrangian(d, V, values, 1.0, [2.0, 3.0])
         correct_hessian = [3.0 1.0 0.0; 1.0 0.0 2.0; 0.0 2.0 2.0]
-        @test isapprox(dense_hessian(hessian_sparsity, V, 3), correct_hessian)
+        @test dense_hessian(hessian_sparsity, V, 3) ≈ correct_hessian
 
         h = ones(3) # The input values should be overwritten.
         v = [2.4, 3.5, 1.2]
         MOI.eval_hessian_lagrangian_product(d, h, values, v, 1.0, [2.0, 3.0])
-        @test isapprox(h, correct_hessian * v)
+        @test h ≈ correct_hessian * v
     end
 
     @testset "Hessians and Hess-vec with subexpressions" begin
@@ -502,12 +494,12 @@ end
 
         ψ(x) = 1
         t(x, y) = 2
-        JuMP.register(m, :ψ, 1, ψ, autodiff = true)
-        JuMP.register(m, :t, 2, t, autodiff = true)
+        JuMP.register(m, :ψ, 1, ψ, autodiff=true)
+        JuMP.register(m, :t, 2, t, autodiff=true)
 
         @NLobjective(m, Min, x^y)
         @NLconstraint(m, sin(x) * cos(y) == 5)
-        @NLconstraint(m, nlconstr[i = 1:2], i * x^2 == i)
+        @NLconstraint(m, nlconstr[i=1:2], i * x^2 == i)
         @NLconstraint(m, -0.5 <= sin(x) <= 0.5)
         @NLconstraint(m, ψ(x) + t(x, y) <= 3)
 
@@ -566,7 +558,7 @@ end
         @objective(model, Max, x)
 
         @NLconstraints(model, begin
-            ref[i = 1:3], y[i] == 0
+            ref[i=1:3], y[i] == 0
             x + y[1] * y[2] * y[3] <= 0.5
         end)
 
@@ -599,20 +591,16 @@ end
         V = zeros(length(hessian_sparsity))
         values = ones(18)
         MOI.eval_hessian_lagrangian(d, V, values, 1.0, Float64[])
-        @test isapprox(
-            dense_hessian(hessian_sparsity, V, 18),
-            ones(18, 18) - diagm(0 => ones(18)),
-        )
+        @test dense_hessian(hessian_sparsity, V, 18) ≈
+            ones(18, 18) - diagm(0 => ones(18))
 
         values[1] = 0.5
         MOI.eval_hessian_lagrangian(d, V, values, 1.0, Float64[])
-        @test isapprox(
-            dense_hessian(hessian_sparsity, V, 18),
+        @test dense_hessian(hessian_sparsity, V, 18) ≈
             [
                 0 ones(17)'
-                ones(17) (ones(17, 17)-diagm(0 => ones(17)))/2
-            ],
-        )
+                ones(17) (ones(17, 17) - diagm(0 => ones(17))) / 2
+            ]
     end
 
     @testset "eval_objective and eval_objective_gradient" begin
@@ -623,20 +611,18 @@ end
 
         ψ(x) = sin(x)
         t(x, y) = x + 3y
-        JuMP.register(m, :ψ, 1, ψ, autodiff = true)
-        JuMP.register(m, :t, 2, t, autodiff = true)
+        JuMP.register(m, :ψ, 1, ψ, autodiff=true)
+        JuMP.register(m, :t, 2, t, autodiff=true)
 
         @NLobjective(m, Min, ex / 2 + sin(x[2]) / ψ(x[2]) + t(x[3], x[4]))
         d = JuMP.NLPEvaluator(m)
         MOI.initialize(d, [:Grad])
         variable_values = fill(2.0, (4,))
-        @test isapprox(
-            MOI.eval_objective(d, variable_values),
-            variable_values[1] + 1 + variable_values[3] + 3variable_values[4],
-        )
+        @test MOI.eval_objective(d, variable_values) ≈
+            variable_values[1] + 1 + variable_values[3] + 3variable_values[4]
         grad = zeros(4)
         MOI.eval_objective_gradient(d, grad, variable_values)
-        @test isapprox(grad, [1.0, 0.0, 1.0, 3.0])
+        @test grad ≈ [1.0, 0.0, 1.0, 3.0]
     end
 
     @testset "eval_constraint and Jacobians" begin
@@ -647,8 +633,8 @@ end
 
         ψ(x) = sin(x)
         t(x, y) = x + 3y
-        JuMP.register(m, :ψ, 1, ψ, autodiff = true)
-        JuMP.register(m, :t, 2, t, autodiff = true)
+        JuMP.register(m, :ψ, 1, ψ, autodiff=true)
+        JuMP.register(m, :t, 2, t, autodiff=true)
 
         @NLconstraint(
             m,
@@ -660,10 +646,8 @@ end
         variable_values = fill(2.0, (4,))
         constraint_value = zeros(1)
         MOI.eval_constraint(d, constraint_value, variable_values)
-        @test isapprox(
-            constraint_value[1],
-            variable_values[1] + 1 + variable_values[3] + 3variable_values[4],
-        )
+        @test constraint_value[1] ≈
+            variable_values[1] + 1 + variable_values[3] + 3variable_values[4]
         jacobian_sparsity = MOI.jacobian_structure(d)
         I = [i for (i, j) in jacobian_sparsity]
         J = [j for (i, j) in jacobian_sparsity]
@@ -672,7 +656,7 @@ end
         MOI.eval_constraint_jacobian(d, jac_nonzeros, variable_values)
         jac_values = zeros(4)
         jac_values[J] = jac_nonzeros
-        @test isapprox(jac_values, [1.0, 0.0, 1.0, 3.0])
+        @test jac_values ≈ [1.0, 0.0, 1.0, 3.0]
     end
 
     @testset "set_NL_objective and add_NL_constraint" begin
@@ -756,7 +740,7 @@ end
         model = Model()
         @variable(model, x[1:2])
         f(x1) = x1 + x[2]
-        JuMP.register(model, :f, 1, f; autodiff = true)
+        JuMP.register(model, :f, 1, f; autodiff=true)
         @NLobjective(model, Min, f(x[1]))
         d = JuMP.NLPEvaluator(model)
         MOI.initialize(d, [:Grad])
@@ -773,7 +757,7 @@ end
         model = Model()
         @variable(model, x)
         f(x) = string(x)
-        JuMP.register(model, :f, 1, f; autodiff = true)
+        JuMP.register(model, :f, 1, f; autodiff=true)
         @NLobjective(model, Min, f(x))
         d = JuMP.NLPEvaluator(model)
         MOI.initialize(d, [:Grad])
@@ -799,7 +783,7 @@ end
     @testset "Hessians disabled with user-defined multivariate functions" begin
         model = Model()
         my_f(x, y) = (x - 1)^2 + (y - 2)^2
-        JuMP.register(model, :my_f, 2, my_f, autodiff = true)
+        JuMP.register(model, :my_f, 2, my_f, autodiff=true)
         @variable(model, x[1:2])
         @NLobjective(model, Min, my_f(x[1], x[2]))
         evaluator = JuMP.NLPEvaluator(model)


### PR DESCRIPTION
I found a TODO note in /test/nlp.jl indicating this should be done (probably because it's cleaner), so I worked on the low-hanging fruit.

 Not related to any open issues (that I'm aware of).