### PR TITLE
Add a better error message when there are duplicate indices in a container

### DIFF
--- a/src/Containers/macro.jl
+++ b/src/Containers/macro.jl
@@ -129,6 +129,12 @@ function _parse_ref_sets(_error::Function, expr::Expr)
             idxvar = gensym()
             idxset = esc(s)
         end
+        if idxvar in idxvars
+            _error(
+                "The index $(idxvar) appears more than once. The index " *
+                "associated with each set must be unique."
+            )
+        end
         push!(idxvars, idxvar)
         push!(idxsets, idxset)
     end

--- a/test/Containers/macro.jl
+++ b/test/Containers/macro.jl
@@ -48,4 +48,15 @@ using Test
         )
         @test x isa SparseAxisArray{Any,2,Tuple{Int,Int}}
     end
+    @testset "duplicate_indices" begin
+        expr = :(Containers.@container(x[i = 1:2, i = 1:2], i + i))
+        @test_throws(
+            LoadError,
+            try
+                @eval $expr
+            catch err
+                throw(err)
+            end,
+        )
+    end
 end


### PR DESCRIPTION
This would have avoided this Discourse issue: https://discourse.julialang.org/t/error-syntax-function-argument-names-not-unique-around/53944/4, and seems like it might be a thing beginners hit quite frequently.
