### PR TITLE
[docs] Update done items on roadmap

### DIFF
--- a/docs/src/roadmap.md
+++ b/docs/src/roadmap.md
@@ -37,7 +37,7 @@ Some but not all of these tasks are summarized in the
   - Fully integrate [JuMPTutorials](https://github.com/jump-dev/JuMPTutorials.jl)
     with JuMP's documentation.
 - Developer experience
-  - Get JuMP’s unit tests running ~~in less than two minutes~~ faster. See [#1745](https://github.com/jump-dev/JuMP.jl/pull/1745). (**Done**)
+  - Get JuMP’s unit tests running faster. See [#1745](https://github.com/jump-dev/JuMP.jl/pull/1745). (**Done**)
 - All solvers should complete the transition to MOI. (**Done**)
 - Provide packages for installing Bonmin and Couenne.
 - [MathOptFormat](https://github.com/odow/MathOptFormat.jl) 1.0 (**Done**)

--- a/docs/src/roadmap.md
+++ b/docs/src/roadmap.md
@@ -33,12 +33,12 @@ Some but not all of these tasks are summarized in the
   - Expose solver-independent options from JuMP (**Done**: see [`set_silent`](@ref) etc.)
 - Improve the documentation ([#1062](https://github.com/jump-dev/JuMP.jl/issues/1062))
   - Separate how-to, concept explanation, and technical reference following the
-    [Divio recommendations](https://www.divio.com/blog/documentation/)
+    [Divio recommendations](https://www.divio.com/blog/documentation/) (**Done**)
   - Fully integrate [JuMPTutorials](https://github.com/jump-dev/JuMPTutorials.jl)
     with JuMP's documentation.
 - Developer experience
-  - Get JuMP’s unit tests running in less than two minutes. See [#1745](https://github.com/jump-dev/JuMP.jl/pull/1745).
-- All solvers should complete the transition to MOI.
+  - Get JuMP’s unit tests running <s>in less than two minutes</s> faster. See [#1745](https://github.com/jump-dev/JuMP.jl/pull/1745). (**Done**)
+- All solvers should complete the transition to MOI. (**Done**)
 - Provide packages for installing Bonmin and Couenne.
 - [MathOptFormat](https://github.com/odow/MathOptFormat.jl) 1.0 (**Done**)
 

--- a/docs/src/roadmap.md
+++ b/docs/src/roadmap.md
@@ -37,7 +37,7 @@ Some but not all of these tasks are summarized in the
   - Fully integrate [JuMPTutorials](https://github.com/jump-dev/JuMPTutorials.jl)
     with JuMP's documentation.
 - Developer experience
-  - Get JuMP’s unit tests running <s>in less than two minutes</s> faster. See [#1745](https://github.com/jump-dev/JuMP.jl/pull/1745). (**Done**)
+  - Get JuMP’s unit tests running ~~in less than two minutes~~ faster. See [#1745](https://github.com/jump-dev/JuMP.jl/pull/1745). (**Done**)
 - All solvers should complete the transition to MOI. (**Done**)
 - Provide packages for installing Bonmin and Couenne.
 - [MathOptFormat](https://github.com/odow/MathOptFormat.jl) 1.0 (**Done**)


### PR DESCRIPTION
Update the roadmap based on discussion from January's monthly developer call.

* The documentation still has a lot of room for improvement, but it is no longer blocking
* Pajarito still needs updating, but this isn't blocking
* The tests now run faster. They will probably never run in 2 minutes, but it should continue to improve over time as Julia's latency improves.