### PR TITLE
[ci] Fix release branch wildcard for GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - /^release-.*$/
+      - release-*
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:


### PR DESCRIPTION
I pushed 0.21.6 to the `release-0.21` branch, but CI didn't run. It appears GH actions doesn't use regex: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet