### PR TITLE
Implemented coefficient for expressions

### DIFF
--- a/docs/src/expressions.md
+++ b/docs/src/expressions.md
@@ -267,7 +267,7 @@ julia> @variable(model, y)
 y
 
 julia> @expression(model, ex, 2*x*y + 3*x)
-2 x + 1
+2 x*y + 3 x
 
 julia> coefficient(ex, x, y)
 2.0

--- a/docs/src/expressions.md
+++ b/docs/src/expressions.md
@@ -132,6 +132,30 @@ julia> ex
 1
 ```
 
+### Coefficients
+
+Use [`coefficient`](@ref) to return the coefficient associated with a variable
+in an affine expression.
+
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x)
+x
+
+julia> @variable(model, y)
+y
+
+julia> @expression(model, ex, 2x + 1)
+2 x + 1
+
+julia> coefficient(ex, x)
+2.0
+
+julia> coefficient(ex, y)
+0.0
+```
+
 ## Quadratic expressions
 
 Like affine expressions, there are four ways of constructing a quadratic
@@ -226,6 +250,33 @@ julia> drop_zeros!(ex)
 
 julia> ex
 x + 1
+```
+
+### Coefficients
+
+Use [`coefficient`](@ref) to return the coefficient associated with a pair of variables
+in a quadratic expression.
+
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x)
+x
+
+julia> @variable(model, y)
+y
+
+julia> @expression(model, ex, 2*x*y + 3*x)
+2 x + 1
+
+julia> coefficient(ex, x, y)
+2.0
+
+julia> coefficient(ex, x, x)
+0.0
+
+julia> coefficient(ex, x)
+3.0
 ```
 
 ## Nonlinear expressions

--- a/docs/src/expressions.md
+++ b/docs/src/expressions.md
@@ -275,6 +275,9 @@ julia> coefficient(ex, x, y)
 julia> coefficient(ex, x, x)
 0.0
 
+julia> coefficient(ex, y, x)
+2.0
+
 julia> coefficient(ex, x)
 3.0
 ```

--- a/docs/src/reference/expressions.md
+++ b/docs/src/reference/expressions.md
@@ -14,6 +14,7 @@ UnorderedPair
 
 add_to_expression!
 constant
+coefficient
 drop_zeros!
 isequal_canonical
 linear_terms

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -150,9 +150,11 @@ end
 Base.zero(::Type{GenericAffExpr{C,V}}) where {C,V} = GenericAffExpr{C,V}(zero(C), OrderedDict{V,C}())
 Base.one(::Type{GenericAffExpr{C,V}}) where {C,V}  = GenericAffExpr{C,V}(one(C), OrderedDict{V,C}())
 Base.zero(a::GenericAffExpr) = zero(typeof(a))
-Base.one( a::GenericAffExpr) =  one(typeof(a))
+Base.one(a::GenericAffExpr) = one(typeof(a))
 Base.copy(a::GenericAffExpr) = GenericAffExpr(copy(a.constant), copy(a.terms))
 Base.broadcastable(a::GenericAffExpr) = Ref(a)
+Base.getindex(a::GenericAffExpr{C,V}, v::V) where {C,V} = get(a.terms, v, zero(V))
+Base.getindex(a::GenericAffExpr{C,V}, v1::V, v2::V) where {C,V} = zero(V)
 
 """
     drop_zeros!(expr::GenericAffExpr)

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -153,8 +153,8 @@ Base.zero(a::GenericAffExpr) = zero(typeof(a))
 Base.one(a::GenericAffExpr) = one(typeof(a))
 Base.copy(a::GenericAffExpr) = GenericAffExpr(copy(a.constant), copy(a.terms))
 Base.broadcastable(a::GenericAffExpr) = Ref(a)
-Base.getindex(a::GenericAffExpr{C,V}, v::V) where {C,V} = get(a.terms, v, zero(V))
-Base.getindex(a::GenericAffExpr{C,V}, v1::V, v2::V) where {C,V} = zero(V)
+coefficient(a::GenericAffExpr{C,V}, v::V) where {C,V} = get(a.terms, v, zero(C))
+coefficient(a::GenericAffExpr{C,V}, v1::V, v2::V) where {C,V} = zero(C)
 
 """
     drop_zeros!(expr::GenericAffExpr)

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -153,6 +153,12 @@ Base.zero(a::GenericAffExpr) = zero(typeof(a))
 Base.one(a::GenericAffExpr) = one(typeof(a))
 Base.copy(a::GenericAffExpr) = GenericAffExpr(copy(a.constant), copy(a.terms))
 Base.broadcastable(a::GenericAffExpr) = Ref(a)
+
+"""
+    coefficient(a::GenericAffExpr{C,V}, v::V) where {C,V}
+
+Return the coefficient associated with variable `v` in the affine expression `a`.
+"""
 coefficient(a::GenericAffExpr{C,V}, v::V) where {C,V} = get(a.terms, v, zero(C))
 coefficient(a::GenericAffExpr{C,V}, v1::V, v2::V) where {C,V} = zero(C)
 

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -102,10 +102,24 @@ Base.zero(q::GenericQuadExpr) = zero(typeof(q))
 Base.one(q::GenericQuadExpr)  = one(typeof(q))
 Base.copy(q::GenericQuadExpr) = GenericQuadExpr(copy(q.aff), copy(q.terms))
 Base.broadcastable(q::GenericQuadExpr) = Ref(q)
-coefficient(q::GenericQuadExpr{C,V}, v::V) where {C,V} = coefficient(q.aff, v)
+
+"""
+    coefficient(a::GenericAffExpr{C,V}, v1::V, v2::V) where {C,V}
+
+Return the coefficient associated with the term `v1 * v2` in the quadratic expression `a`.
+
+Note that `coefficient(a, v1, v2)` is the same as `coefficient(a, v2, v1)`.
+"""
 function coefficient(q::GenericQuadExpr{C,V}, v1::V, v2::V) where {C,V}
     return get(q.terms, UnorderedPair(v1,v2), zero(C))
 end
+
+"""
+    coefficient(a::GenericQuadExpr{C,V}, v::V) where {C,V}
+
+Return the coefficient associated with variable `v` in the affine component of `a`.
+"""
+coefficient(q::GenericQuadExpr{C,V}, v::V) where {C,V} = coefficient(q.aff, v)
 
 """
     drop_zeros!(expr::GenericQuadExpr)

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -102,6 +102,10 @@ Base.zero(q::GenericQuadExpr) = zero(typeof(q))
 Base.one(q::GenericQuadExpr)  = one(typeof(q))
 Base.copy(q::GenericQuadExpr) = GenericQuadExpr(copy(q.aff), copy(q.terms))
 Base.broadcastable(q::GenericQuadExpr) = Ref(q)
+Base.getindex(q::GenericQuadExpr{C,V}, v::V) where {C,V} = q.aff[v]
+function Base.getindex(q::GenericQuadExpr{C,V}, v1::V, v2::V) where {C,V}
+    return get(q.terms, UnorderedPair(v1,v2), zero(V))
+end
 
 """
     drop_zeros!(expr::GenericQuadExpr)

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -102,9 +102,9 @@ Base.zero(q::GenericQuadExpr) = zero(typeof(q))
 Base.one(q::GenericQuadExpr)  = one(typeof(q))
 Base.copy(q::GenericQuadExpr) = GenericQuadExpr(copy(q.aff), copy(q.terms))
 Base.broadcastable(q::GenericQuadExpr) = Ref(q)
-Base.getindex(q::GenericQuadExpr{C,V}, v::V) where {C,V} = q.aff[v]
-function Base.getindex(q::GenericQuadExpr{C,V}, v1::V, v2::V) where {C,V}
-    return get(q.terms, UnorderedPair(v1,v2), zero(V))
+coefficient(q::GenericQuadExpr{C,V}, v::V) where {C,V} = coefficient(q.aff, v)
+function coefficient(q::GenericQuadExpr{C,V}, v1::V, v2::V) where {C,V}
+    return get(q.terms, UnorderedPair(v1,v2), zero(C))
 end
 
 """

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -161,8 +161,8 @@ end
 Base.iszero(::VariableRef) = false
 Base.copy(v::VariableRef) = VariableRef(v.model, v.index)
 Base.broadcastable(v::VariableRef) = Ref(v)
-Base.getindex(v1::VariableRef, v2::VariableRef) = (v1 == v2 ? one(v1) : zero(v1))
-Base.getindex(v1::VariableRef, v2::VariableRef, v3::VariableRef) = zero(v1)
+coefficient(v1::VariableRef, v2::VariableRef) = (v1 == v2 ? 1.0 : 0.0)
+coefficient(v1::VariableRef, v2::VariableRef, v3::VariableRef) = 0.0
 
 isequal_canonical(v::VariableRef, other::VariableRef) = isequal(v, other)
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -161,6 +161,17 @@ end
 Base.iszero(::VariableRef) = false
 Base.copy(v::VariableRef) = VariableRef(v.model, v.index)
 Base.broadcastable(v::VariableRef) = Ref(v)
+
+
+
+"""
+    coefficient(v1::VariableRef, v2::VariableRef)
+
+Return `1.0` if `v1 == v2`, and `0.0` otherwise.
+
+This is a fallback for other [`coefficient`](@ref) methods to simplify code in 
+which the expression may be a single variable.
+"""
 coefficient(v1::VariableRef, v2::VariableRef) = (v1 == v2 ? 1.0 : 0.0)
 coefficient(v1::VariableRef, v2::VariableRef, v3::VariableRef) = 0.0
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -161,6 +161,8 @@ end
 Base.iszero(::VariableRef) = false
 Base.copy(v::VariableRef) = VariableRef(v.model, v.index)
 Base.broadcastable(v::VariableRef) = Ref(v)
+Base.getindex(v1::VariableRef, v2::VariableRef) = (v1 == v2 ? one(v1) : zero(v1))
+Base.getindex(v1::VariableRef, v2::VariableRef, v3::VariableRef) = zero(v1)
 
 isequal_canonical(v::VariableRef, other::VariableRef) = isequal(v, other)
 

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -154,6 +154,13 @@ function expressions_test(
         @test k == 0
     end
 
+    @testset "getindex(aff::AffExpr, v::VariableRef)" begin
+        m = ModelType()
+        x = @variable(m, x)
+        aff = @expression(m, 1.0 * x)
+        @test aff[x] == 1.0
+    end
+
     @testset "MA.add_mul!(ex::Number, c::Number, x::GenericAffExpr)" begin
         aff = MA.add_mul!(1.0, 2.0, JuMP.GenericAffExpr(1.0, :a => 1.0))
         @test JuMP.isequal_canonical(aff, JuMP.GenericAffExpr(3.0, :a => 2.0))

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -162,8 +162,15 @@ function expressions_test(
         @test coefficient(aff, x) == 1.0
         @test coefficient(aff, y) == 0.0
     end
+    
+    @testset "coefficient(aff::AffExpr, v1::VariableRef, v2::VariableRef)" begin
+        m = ModelType()
+        x = @variable(m, x)
+        aff = @expression(m, 1.0 * x)
+        @test coefficient(aff, x, x) == 0.0
+    end
 
-    @testset "coefficient(quad::AffExpr, v::VariableRef)" begin
+    @testset "coefficient(quad::QuadExpr, v::VariableRef)" begin
         m = ModelType()
         x = @variable(m, x)
         y = @variable(m, y)
@@ -174,7 +181,7 @@ function expressions_test(
         @test coefficient(quad, z) == 0.0
     end
 
-    @testset "coefficient(quad::AffExpr, v1::VariableRef, v2::VariableRef)" begin
+    @testset "coefficient(quad::Quad, v1::VariableRef, v2::VariableRef)" begin
         m = ModelType()
         x = @variable(m, x)
         y = @variable(m, y)

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -154,11 +154,36 @@ function expressions_test(
         @test k == 0
     end
 
-    @testset "getindex(aff::AffExpr, v::VariableRef)" begin
+    @testset "coefficient(aff::AffExpr, v::VariableRef)" begin
         m = ModelType()
         x = @variable(m, x)
+        y = @variable(m, y)
         aff = @expression(m, 1.0 * x)
-        @test aff[x] == 1.0
+        @test coefficient(aff, x) == 1.0
+        @test coefficient(aff, y) == 0.0
+    end
+
+    @testset "coefficient(quad::AffExpr, v::VariableRef)" begin
+        m = ModelType()
+        x = @variable(m, x)
+        y = @variable(m, y)
+        z = @variable(m, z)
+        quad = @expression(m, 6.0 * x^2 + 5.0*x*y + 2.0*y +  3.0 * x)
+        @test coefficient(quad, x) == 3.0
+        @test coefficient(quad, y) == 2.0
+        @test coefficient(quad, z) == 0.0
+    end
+
+    @testset "coefficient(quad::AffExpr, v1::VariableRef, v2::VariableRef)" begin
+        m = ModelType()
+        x = @variable(m, x)
+        y = @variable(m, y)
+        z = @variable(m, z)
+        quad = @expression(m, 6.0 * x^2 + 5.0*x*y + 2.0*y +  3.0 * x)
+        @test coefficient(quad, x, y) == 5.0
+        @test coefficient(quad, x, x) == 6.0
+        @test coefficient(quad, x, y) == coefficient(quad, y, x)
+        @test coefficient(quad, z, z) == 0.0
     end
 
     @testset "MA.add_mul!(ex::Number, c::Number, x::GenericAffExpr)" begin

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -651,6 +651,17 @@ function test_Model_value_containers(::Any, ::Any)
     @test_throws exception JuMP.value(x)
 end
 
+function test_Model_get_variable_coefficient(::Any, ::Any)
+    m = Model()
+    x = @variable(m, x)
+    y = @variable(m, y)
+    @test coefficient(x, x) == 1.0
+    @test coefficient(x, y) == 0.0
+    @test coefficient(x, x, x) == 0.0
+    @test coefficient(x, y, x) == coefficient(x, x, y) == 0.0
+    @test coefficient(x, y, y) == 0.0
+end
+
 function _mock_reduced_cost_util(
     obj_sense::MOI.OptimizationSense,
     #obj_value::Float64,


### PR DESCRIPTION
Currently there is some discussion over whether to overload `getindex` or instead create a new function called `coefficient` whose use would be more transparent. Personally I would prefer the former - it makes sense to me, it's pretty syntactically and I can't see it being confused with something else you may try to do.

Edit(odow): Closes #2371 