### PR TITLE
Fix printing in IJuliaMode

### DIFF
--- a/src/print.jl
+++ b/src/print.jl
@@ -591,6 +591,12 @@ function in_set_string(print_mode, set::Union{PSDCone, MOI.AbstractSet})
     end
 end
 
+"""
+    in_set_string(print_mode::Type{<:PrintMode}, constraint::AbstractConstraint)
+
+Return a `String` representing the membership to the set of the constraint
+`constraint` using print mode `print_mode`.
+"""
 function in_set_string(print_mode, constraint::AbstractConstraint)
     set = reshape_set(moi_set(constraint), shape(constraint))
     return in_set_string(print_mode, set)

--- a/src/print.jl
+++ b/src/print.jl
@@ -201,7 +201,7 @@ end
 function model_string(print_mode, model::AbstractModel)
     ijl = print_mode == IJuliaMode
     sep = ijl ? " & " : " "
-    eol = ijl ? "\\\\\n" : "\n"
+    eol = ijl ? "\\\\" : "\n"
     sense = objective_sense(model)
     str = ""
     if sense == MOI.MAX_SENSE
@@ -241,7 +241,7 @@ function model_string(print_mode, model::AbstractModel)
         str *= eol
     end
     if ijl
-        str = "\\begin{alignat*}{1}" * str * "\\end{alignat*}\n"
+        str = "\\begin{aligned}" * str * "\\end{aligned}"
     end
     return str
 end
@@ -519,7 +519,7 @@ end
 function function_string(print_mode::Type{IJuliaMode},
                          A::AbstractMatrix{<:AbstractJuMPScalar})
     str = sprint(show, MIME"text/plain"(), A)
-    str = "\\begin{bmatrix}\n"
+    str = "\\begin{bmatrix}"
     for i in 1:size(A, 1)
         line = ""
         for j in 1:size(A, 2)
@@ -532,7 +532,7 @@ function function_string(print_mode::Type{IJuliaMode},
                 line *= function_string(print_mode, A[i, j])
             end
         end
-        str *= line * "\\\\\n"
+        str *= line * "\\\\"
     end
     return str * "\\end{bmatrix}"
 end
@@ -548,6 +548,14 @@ function function_string(print_mode, constraint::AbstractConstraint)
     f = reshape_vector(jump_function(constraint), shape(constraint))
     return function_string(print_mode, f)
 end
+
+"""
+    in_set_string(print_mode::Type{<:PrintMode}, set)
+
+Return a `String` representing the membership to the set `set` using print mode
+`print_mode`.
+"""
+function in_set_string end
 
 function in_set_string(print_mode, set::MOI.LessThan)
     return string(_math_symbol(print_mode, :leq), " ", set.upper)
@@ -570,27 +578,19 @@ end
 in_set_string(print_mode, ::MOI.ZeroOne) = "binary"
 in_set_string(print_mode, ::MOI.Integer) = "integer"
 
-# TODO: Convert back to JuMP types for sets like PSDCone.
-# TODO: Consider fancy latex names for some sets. They're currently printed as
-# regular text in math mode which looks a bit awkward.
-"""
-    in_set_string(print_mode::Type{<:JuMP.PrintMode},
-                  set::Union{PSDCone, MOI.AbstractSet})
+in_set_string(::Type{IJuliaMode}, ::MOI.ZeroOne) = "\\in \\{0, 1\\}"
+in_set_string(::Type{IJuliaMode}, ::MOI.Integer) = "\\in \\mathbb{Z}"
 
-Return a `String` representing the membership to the set `set` using print mode
-`print_mode`.
-"""
 function in_set_string(print_mode, set::Union{PSDCone, MOI.AbstractSet})
-    return string(_math_symbol(print_mode, :in), " ", set)
+    # Use an `if` here instead of multiple dispatch to avoid ambiguity errors.
+    if print_mode == REPLMode
+        return _math_symbol(print_mode, :in) * " $(set)"
+    else
+        set_str = replace(replace(string(set), "{" => "\\{"), "}" => "\\}")
+        return "\\in \\text{$(set_str)}"
+    end
 end
 
-"""
-    in_set_string(print_mode::Type{<:JuMP.PrintMode},
-                  constraint::JuMP.AbstractConstraint)
-
-Return a `String` representing the membership to the set of the constraint
-`constraint` using print mode `print_mode`.
-"""
 function in_set_string(print_mode, constraint::AbstractConstraint)
     set = reshape_set(moi_set(constraint), shape(constraint))
     return in_set_string(print_mode, set)
@@ -607,18 +607,25 @@ function constraint_string(print_mode, constraint_object::AbstractConstraint)
         return func_str * " " * in_set_str
     end
 end
-function constraint_string(print_mode, constraint_name,
-                           constraint_object::AbstractConstraint;
-                           in_math_mode = false)
-    constraint_without_name = constraint_string(print_mode, constraint_object)
-    if print_mode == IJuliaMode && !in_math_mode
-        constraint_without_name = _wrap_in_inline_math_mode(constraint_without_name)
-    end
-    # Names don't print well in LaTeX math mode
-    if isempty(constraint_name) || (print_mode == IJuliaMode && in_math_mode)
-        return constraint_without_name
+
+function constraint_string(
+    print_mode,
+    constraint_name::String,
+    constraint_object::AbstractConstraint;
+    in_math_mode::Bool = false,
+)
+    prefix = isempty(constraint_name) ? "" : constraint_name * " : "
+    constraint_str = constraint_string(print_mode, constraint_object)
+    if print_mode == IJuliaMode
+        if in_math_mode
+            return constraint_str
+        elseif isempty(prefix)
+            return _wrap_in_math_mode(constraint_str)
+        else
+            return prefix * _wrap_in_inline_math_mode(constraint_str)
+        end
     else
-        return constraint_name * " : " * constraint_without_name
+        return prefix * constraint_str
     end
 end
 function constraint_string(print_mode, ref::ConstraintRef; in_math_mode = false)

--- a/test/print.jl
+++ b/test/print.jl
@@ -378,7 +378,7 @@ function printing_test(ModelType::Type{<:JuMP.AbstractModel})
               "linear_eq : \$ x = 1.0 \$"
         @test sprint(show, "text/latex", linear_range) ==
               "linear_range : \$ x \\in \\[-1.0, 1.0\\] \$"
-        @test sprint(show, "text/latex", linear_noname) == "\$ x \\leq 1.0 \$"
+        @test sprint(show, "text/latex", linear_noname) == "\$\$ x \\leq 1.0 \$\$"
     end
 
     @testset "Vector AffExpr constraints" begin
@@ -529,40 +529,38 @@ Names registered in the model: a, a1, b, b1, c, c1, con, fi, soc, u, x, y, z""",
         io_test(
             IJuliaMode,
             model_1,
-            """
-\\begin{alignat*}{1}\\max\\quad & a - b + 2 a1 - 10 x\\\\
-\\text{Subject to} \\quad & a + b - 10 c + c1 - 2 x \\leq 1.0\\\\
- & a\\times b \\leq 2.0\\\\
- & \\begin{bmatrix}
-a & b\\\\
-\\cdot & x\\\\
-\\end{bmatrix} \\in PSDCone()\\\\
- & [a, b, c] \\in MathOptInterface.PositiveSemidefiniteConeTriangle(2)\\\\
- & \\begin{bmatrix}
-a & b\\\\
-c & x\\\\
-\\end{bmatrix} \\in PSDCone()\\\\
- & [a, b, c, x] \\in MathOptInterface.PositiveSemidefiniteConeSquare(2)\\\\
- & [-a + 1, u_{1}, u_{2}, u_{3}] \\in MathOptInterface.SecondOrderCone(4)\\\\
- & fi = 9.0\\\\
- & a \\geq 1.0\\\\
- & c \\geq -1.0\\\\
- & a1 \\geq 1.0\\\\
- & c1 \\geq -1.0\\\\
- & b \\leq 1.0\\\\
- & c \\leq 1.0\\\\
- & b1 \\leq 1.0\\\\
- & c1 \\leq 1.0\\\\
- & a1 integer\\\\
- & b1 integer\\\\
- & c1 integer\\\\
- & z integer\\\\
- & x binary\\\\
- & u_{1} binary\\\\
- & u_{2} binary\\\\
- & u_{3} binary\\\\
-\\end{alignat*}
-""",
+            "\\begin{aligned}\\max\\quad & a - b + 2 a1 - 10 x\\\\" *
+            "\\text{Subject to} \\quad & a + b - 10 c + c1 - 2 x \\leq 1.0\\\\" *
+            " & a\\times b \\leq 2.0\\\\" *
+            " & \\begin{bmatrix}" *
+            "a & b\\\\" *
+            "\\cdot & x\\\\" *
+            "\\end{bmatrix} \\in \\text{PSDCone()}\\\\" *
+            " & [a, b, c] \\in \\text{MathOptInterface.PositiveSemidefiniteConeTriangle(2)}\\\\" *
+            " & \\begin{bmatrix}" *
+            "a & b\\\\" *
+            "c & x\\\\" *
+            "\\end{bmatrix} \\in \\text{PSDCone()}\\\\" *
+            " & [a, b, c, x] \\in \\text{MathOptInterface.PositiveSemidefiniteConeSquare(2)}\\\\" *
+            " & [-a + 1, u_{1}, u_{2}, u_{3}] \\in \\text{MathOptInterface.SecondOrderCone(4)}\\\\" *
+            " & fi = 9.0\\\\" *
+            " & a \\geq 1.0\\\\" *
+            " & c \\geq -1.0\\\\" *
+            " & a1 \\geq 1.0\\\\" *
+            " & c1 \\geq -1.0\\\\" *
+            " & b \\leq 1.0\\\\" *
+            " & c \\leq 1.0\\\\" *
+            " & b1 \\leq 1.0\\\\" *
+            " & c1 \\leq 1.0\\\\" *
+            " & a1 \\in \\mathbb{Z}\\\\" *
+            " & b1 \\in \\mathbb{Z}\\\\" *
+            " & c1 \\in \\mathbb{Z}\\\\" *
+            " & z \\in \\mathbb{Z}\\\\" *
+            " & x \\in \\{0, 1\\}\\\\" *
+            " & u_{1} \\in \\{0, 1\\}\\\\" *
+            " & u_{2} \\in \\{0, 1\\}\\\\" *
+            " & u_{3} \\in \\{0, 1\\}\\\\" *
+            "\\end{aligned}",
         )
 
         #------------------------------------------------------------------
@@ -674,13 +672,11 @@ Names registered in the model: a, a1, b, b1, c, c1, fi, u, x, y, z""",
         io_test(
             IJuliaMode,
             model_1,
-            """
-\\begin{alignat*}{1}\\max\\quad & a - b + 2 a1 - 10 x\\\\
-\\text{Subject to} \\quad & a + b - 10 c - 2 x + c1 \\leq 1.0\\\\
- & a\\times b \\leq 2.0\\\\
- & [-a + 1, u_{1}, u_{2}, u_{3}] \\in MathOptInterface.SecondOrderCone(4)\\\\
-\\end{alignat*}
-""",
+            "\\begin{aligned}\\max\\quad & a - b + 2 a1 - 10 x\\\\" *
+            "\\text{Subject to} \\quad & a + b - 10 c - 2 x + c1 \\leq 1.0\\\\" *
+            " & a\\times b \\leq 2.0\\\\" *
+            " & [-a + 1, u_{1}, u_{2}, u_{3}] \\in \\text{MathOptInterface.SecondOrderCone(4)}\\\\" *
+            "\\end{aligned}",
         )
 
         #------------------------------------------------------------------
@@ -763,12 +759,10 @@ With NL expressions
         io_test(
             IJuliaMode,
             model,
-            """
-\\begin{alignat*}{1}\\max\\quad & sin(x)\\\\
-\\text{Subject to} \\quad & subexpression_{1} - 0.0 = 0\\\\
-\\text{With NL expressions} \\quad & subexpression_{1}: cos(x)\\\\
-\\end{alignat*}
-""",
+            "\\begin{aligned}\\max\\quad & sin(x)\\\\" *
+            "\\text{Subject to} \\quad & subexpression_{1} - 0.0 = 0\\\\" *
+            "\\text{With NL expressions} \\quad & subexpression_{1}: cos(x)\\\\" *
+            "\\end{aligned}",
         )
     end
     @testset "SingleVariable constraints" begin


### PR DESCRIPTION
A few printing changes that were needed to fix the printing issues in the tutorials: https://github.com/jump-dev/JuMP.jl/pull/2444#issuecomment-771318608

Fixes some of the points in #2446 

* IJulia strings now created as a single line without `\n`. Makes no difference to latex, but Documenter struggled to print these.
* `\\begin{alignat*}{1}` becomes `\\begin{aligned}`
* `x binary` becomes `x ∈ {0, 1}`
* `x integer` becomes `x ∈ Z`
* Sets without a nice fallback are printed in `\text{}` instead of math. 
* Constraints, by themselves, without names, are printed as display equations instead of in-line.

I'll post before/after screenshots from IJulia in a bit.

## Before

![image](https://user-images.githubusercontent.com/8177701/106677338-794b6100-661d-11eb-80b3-20e0d54852a9.png)

## After 

![image](https://user-images.githubusercontent.com/8177701/106677320-6fc1f900-661d-11eb-8d7e-f214f9b05d88.png)
