### PR TITLE
Refactor printing to reduce content printed in IJulia mode

### DIFF
--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -92,7 +92,8 @@ Solver name: No optimizer attached.
 Names registered in the model: x
 ```
 
-Use [`print(::AbstractModel)`](@ref) to print the formulation of the model.
+Use `print` to print the formulation of the model (in IJulia, this will render
+as LaTeX.
 ```jldoctest model_print
 julia> print(model)
 Max x
@@ -104,15 +105,20 @@ Subject to
     [`write_to_file`](@ref) instead.
 
 
-Pass `latex = true` to print the model in LaTeX form.
-```julia
-julia> print(model; latex = true)
+Use [`latex_formulation`](@ref) to display the model in LaTeX form.
+```jldoctest model_print
+julia> latex_formulation(model)
 $$ \begin{aligned}\max\quad & x\\\text{Subject to} \quad & x \geq 0.0\\\end{aligned} $$
 ```
 
-In IJulia (and Documenter), this will render as LaTeX!
-```@example getting_started_with_JuMP
-print(model; latex = true)
+In IJulia (and Documenter), ending a cell in with [`latex_formulation`](@ref)
+will render the model in LaTeX!
+```@example
+using JuMP                # hide
+model = Model()           # hide
+@variable(model, x >= 0)  # hide
+@objective(model, Max, x) # hide
+latex_formulation(model)
 ```
 
 ## Turn off output

--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -105,7 +105,7 @@ Subject to
 
 
 Pass `latex = true` to print the model in LaTeX form.
-```jldoctest model_print; filter=["$$ \begin{aligned}\max\quad & x\\\text{Subject to} \quad & x \geq 0.0\\\end{aligned} $$"]
+```jldoctest model_print; filter=[raw"$$ \begin{aligned}\max\quad & x\\\text{Subject to} \quad & x \geq 0.0\\\end{aligned} $$"]
 julia> print(model; latex = true)
 $$ \begin{aligned}\max\quad & x\\\text{Subject to} \quad & x \geq 0.0\\\end{aligned} $$
 ```

--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -105,7 +105,7 @@ Subject to
 
 
 Pass `latex = true` to print the model in LaTeX form.
-```jldoctesst model_print
+```jldoctest model_print
 julia> print(model; latex = true)
 $$ \begin{aligned}\max\quad & x\\\text{Subject to} \quad & x \geq 0.0\\\end{aligned} $$
 ```

--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -105,7 +105,7 @@ Subject to
 
 
 Pass `latex = true` to print the model in LaTeX form.
-```jldoctest model_print
+```jldoctest model_print; filter=["$$ \begin{aligned}\max\quad & x\\\text{Subject to} \quad & x \geq 0.0\\\end{aligned} $$"]
 julia> print(model; latex = true)
 $$ \begin{aligned}\max\quad & x\\\text{Subject to} \quad & x \geq 0.0\\\end{aligned} $$
 ```

--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -109,8 +109,11 @@ Pass `latex = true` to print the model in LaTeX form.
 julia> print(model; latex = true)
 $$ \begin{aligned}\max\quad & x\\\text{Subject to} \quad & x \geq 0.0\\\end{aligned} $$
 ```
-!!! info
-    In IJulia, this will render as LaTeX!
+
+In IJulia (and Documenter), this will render as LaTeX!
+```@example getting_started_with_JuMP
+print(model; latex = true)
+```
 
 ## Turn off output
 

--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -105,7 +105,7 @@ Subject to
 
 
 Pass `latex = true` to print the model in LaTeX form.
-```jldoctest model_print; filter=[raw"$$ \begin{aligned}\max\quad & x\\\text{Subject to} \quad & x \geq 0.0\\\end{aligned} $$"]
+```julia
 julia> print(model; latex = true)
 $$ \begin{aligned}\max\quad & x\\\text{Subject to} \quad & x \geq 0.0\\\end{aligned} $$
 ```

--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -74,6 +74,44 @@ CachingOptimizer state: EMPTY_OPTIMIZER
 Solver name: GLPK
 ```
 
+## Print the model
+
+By default, `show(model)` will print a summary of the problem.
+```jldoctest model_print
+julia> model = Model(); @variable(model, x >= 0); @objective(model, Max, x);
+
+julia> model
+A JuMP Model
+Maximization problem with:
+Variable: 1
+Objective function type: VariableRef
+`VariableRef`-in-`MathOptInterface.GreaterThan{Float64}`: 1 constraint
+Model mode: AUTOMATIC
+CachingOptimizer state: NO_OPTIMIZER
+Solver name: No optimizer attached.
+Names registered in the model: x
+```
+
+Use [`print(::AbstractModel)`](@ref) to print the formulation of the model.
+```jldoctest model_print
+julia> print(model)
+Max x
+Subject to
+ x ≥ 0.0
+```
+!!! warning
+    This format is specific to JuMP. To write the model to a file, use
+    [`write_to_file`](@ref) instead.
+
+
+Pass `latex = true` to print the model in LaTeX form.
+```jldoctesst model_print
+julia> print(model; latex = true)
+$$ \begin{aligned}\max\quad & x\\\text{Subject to} \quad & x \geq 0.0\\\end{aligned} $$
+```
+!!! info
+    In IJulia, this will render as LaTeX!
+
 ## Turn off output
 
 Use [`set_silent`](@ref) and [`unset_silent`](@ref) to disable or enable

--- a/docs/src/reference/models.md
+++ b/docs/src/reference/models.md
@@ -28,7 +28,7 @@ Base.empty!(::Model)
 mode
 object_dictionary
 unregister
-print(::IO, ::AbstractModel)
+latex_formulation
 ```
 
 ## Working with attributes

--- a/docs/src/reference/models.md
+++ b/docs/src/reference/models.md
@@ -28,6 +28,7 @@ Base.empty!(::Model)
 mode
 object_dictionary
 unregister
+print(::IO, ::AbstractModel)
 ```
 
 ## Working with attributes

--- a/docs/src/tutorials/Optimization concepts/benders_decomposition.jl
+++ b/docs/src/tutorials/Optimization concepts/benders_decomposition.jl
@@ -187,6 +187,8 @@ master_problem_model = Model(GLPK.Optimizer);
 @objective(master_problem_model, Max, t)
 global iter_num = 1
 
+print(master_problem_model)
+
 # Here is the loop that checks the status of the master problem and the
 # subproblem and then adds necessary Benders cuts accordingly.
 
@@ -197,7 +199,7 @@ while true
     println("Iteration number = ", iter_num)
     println("-----------------------\n")
     println("The current master problem is")
-    print(master_problem_model, latex = false)
+    print(master_problem_model)
 
     optimize!(master_problem_model)
 
@@ -238,8 +240,8 @@ while true
 
     @objective(sub_problem_model, Min, c1' * x_current + c_sub' * u)
 
-    println("\nThe current subproblem model is ")
-    print(sub_problem_model, latex = false)
+    print("\nThe current subproblem model is \n")
+    print(sub_problem_model)
 
     optimize!(sub_problem_model)
 

--- a/docs/src/tutorials/Optimization concepts/benders_decomposition.jl
+++ b/docs/src/tutorials/Optimization concepts/benders_decomposition.jl
@@ -187,8 +187,6 @@ master_problem_model = Model(GLPK.Optimizer);
 @objective(master_problem_model, Max, t)
 global iter_num = 1
 
-print(master_problem_model)
-
 # Here is the loop that checks the status of the master problem and the
 # subproblem and then adds necessary Benders cuts accordingly.
 
@@ -199,7 +197,7 @@ while true
     println("Iteration number = ", iter_num)
     println("-----------------------\n")
     println("The current master problem is")
-    print(master_problem_model)
+    print(master_problem_model, latex = false)
 
     optimize!(master_problem_model)
 
@@ -240,7 +238,8 @@ while true
 
     @objective(sub_problem_model, Min, c1' * x_current + c_sub' * u)
 
-    print("\nThe current subproblem model is \n", sub_problem_model)
+    println("\nThe current subproblem model is ")
+    print(sub_problem_model, latex = false)
 
     optimize!(sub_problem_model)
 

--- a/docs/src/tutorials/Optimization concepts/benders_lazy_constraints.jl
+++ b/docs/src/tutorials/Optimization concepts/benders_lazy_constraints.jl
@@ -130,6 +130,8 @@ master_problem_model = Model(GLPK.Optimizer);
 
 @objective(master_problem_model, Max, t)
 
+print(master_problem_model)
+
 # Track the calls to the callback
 
 iter_num = 0
@@ -148,8 +150,8 @@ function benders_lazy_constraint_callback(cb_data)
     @objective(sub_problem_model, Min, c1' * x_current + c_sub' * u)
     optimize!(sub_problem_model)
 
-    println("\nThe current subproblem model is ")
-    print(sub_problem_model, latex = false)
+    print("\nThe current subproblem model is \n")
+    print(sub_problem_model)
 
     t_status_sub = termination_status(sub_problem_model)
     p_status_sub = primal_status(sub_problem_model)

--- a/docs/src/tutorials/Optimization concepts/benders_lazy_constraints.jl
+++ b/docs/src/tutorials/Optimization concepts/benders_lazy_constraints.jl
@@ -130,8 +130,6 @@ master_problem_model = Model(GLPK.Optimizer);
 
 @objective(master_problem_model, Max, t)
 
-print(master_problem_model)
-
 # Track the calls to the callback
 
 iter_num = 0
@@ -150,7 +148,8 @@ function benders_lazy_constraint_callback(cb_data)
     @objective(sub_problem_model, Min, c1' * x_current + c_sub' * u)
     optimize!(sub_problem_model)
 
-    print("\nThe current subproblem model is \n", sub_problem_model)
+    println("\nThe current subproblem model is ")
+    print(sub_problem_model, latex = false)
 
     t_status_sub = termination_status(sub_problem_model)
     p_status_sub = primal_status(sub_problem_model)

--- a/docs/src/tutorials/Quadratic programs/qcp.jl
+++ b/docs/src/tutorials/Quadratic programs/qcp.jl
@@ -23,6 +23,7 @@ function example_qcp(; verbose = true)
     @constraint(model, x * x - y * z <= 0)
     optimize!(model)
     if verbose
+        print(model)
         println("Objective value: ", objective_value(model))
         println("x = ", value(x))
         println("y = ", value(y))

--- a/docs/src/tutorials/Quadratic programs/qcp.jl
+++ b/docs/src/tutorials/Quadratic programs/qcp.jl
@@ -23,7 +23,6 @@ function example_qcp(; verbose = true)
     @constraint(model, x * x - y * z <= 0)
     optimize!(model)
     if verbose
-        print(model)
         println("Objective value: ", objective_value(model))
         println("x = ", value(x))
         println("y = ", value(y))

--- a/src/print.jl
+++ b/src/print.jl
@@ -46,6 +46,45 @@ A type used for dispatching printing. Produces LaTeX representations.
 """
 abstract type IJuliaMode <: PrintMode end
 
+struct LaTeXModel{T<:AbstractModel}
+    model::T
+end
+
+Base.show(io::IO, model::AbstractModel) = _print_summary(io, model)
+Base.show(io::IO, model::LaTeXModel) = _print_latex(io, model.model)
+Base.show(io::IO, ::MIME"text/latex", model::LaTeXModel) = show(io, model)
+
+"""
+    Base.print([io::IO,] model::AbstractModel; latex::Bool = false)
+
+If `latex == false`, print the plain-text formulation of `model` to `io`, which
+defaults to `stdout`.
+
+If `latex == true`, returns a struct that does one of two things:
+ * In the REPL, prints the latex formulation as a `String` that can be pasted
+   into a `.tex` document.
+ * In notebooks and documentation, `show`s the formulation in rendered LaTeX.
+
+To obtain the LaTeX formulation as a `String`, use
+```julia
+string(print(model; latex = true))
+```
+
+## Examples
+
+    print(model)
+    print(io, model)
+    print(model; latex = true)
+    string(print(model; latex = true))
+"""
+function Base.print(io::IO, model::AbstractModel; latex::Bool = false)
+    return latex ? LaTeXModel(model) : _print_model(io, model)
+end
+
+function Base.print(model::AbstractModel; latex::Bool = false)
+    return print(stdout, model; latex = latex)
+end
+
 # Whether something is zero or not for the purposes of printing it
 # oneunit is useful e.g. if coef is a Unitful quantity.
 _is_zero_for_printing(coef) = abs(coef) < 1e-10 * oneunit(coef)
@@ -168,9 +207,15 @@ _plural(n) = (isone(n) ? "" : "s")
 ## Model
 #------------------------------------------------------------------------
 
-# An `AbstractModel` subtype should implement `show_objective_function_summary`,
-# `show_constraints_summary` and `show_backend_summary` for this method to work.
-function Base.show(io::IO, model::AbstractModel)
+"""
+    _print_summary(io::IO, model::AbstractModel)
+
+Print a plain-text summary of `model` to `io`.
+
+An `AbstractModel` subtype should implement `show_objective_function_summary`,
+`show_constraints_summary` and `show_backend_summary` for this method to work.
+"""
+function _print_summary(io::IO, model::AbstractModel)
     println(io, "A JuMP Model")
     sense = objective_sense(model)
     if sense == MOI.MAX_SENSE
@@ -205,6 +250,13 @@ function Base.show(io::IO, model::AbstractModel)
     end
 end
 
+"""
+    show_backend_summary(io::IO, model::Model)
+
+Print a summary of the optimizer backing `model`.
+
+`AbstractModel`s should implement this method.
+"""
 function show_backend_summary(io::IO, model::Model)
     model_mode = mode(model)
     println(io, "Model mode: ", model_mode)
@@ -212,65 +264,88 @@ function show_backend_summary(io::IO, model::Model)
         println(io, "CachingOptimizer state: ", MOIU.state(backend(model)))
     end
     # The last print shouldn't have a new line
-    return print(io, "Solver name: ", solver_name(model))
+    print(io, "Solver name: ", solver_name(model))
+    return
 end
 
-function Base.print(io::IO, model::AbstractModel)
-    return print(io, model_string(REPLMode, model))
-end
-function Base.show(io::IO, ::MIME"text/latex", model::AbstractModel)
-    return print(io, _wrap_in_math_mode(model_string(IJuliaMode, model)))
-end
+"""
+    _print_model(io::IO, model::AbstractModel)
 
-# An `AbstractModel` subtype should implement `objective_function_string` and
-# `constraints_string` for this method to work.
-function model_string(print_mode, model::AbstractModel)
-    ijl = print_mode == IJuliaMode
-    sep = ijl ? " & " : " "
-    eol = ijl ? "\\\\" : "\n"
+Print a plain-text formulation of `model` to `io`.
+
+An `AbstractModel` subtype should implement `objective_function_string`,
+`constraints_string` and `_nl_subexpression_string` for this method to work.
+"""
+function _print_model(io::IO, model::AbstractModel)
     sense = objective_sense(model)
-    str = ""
     if sense == MOI.MAX_SENSE
-        str *= ijl ? "\\max" : "Max"
+        print(io, "Max ")
+        println(io, objective_function_string(REPLMode, model))
     elseif sense == MOI.MIN_SENSE
-        str *= ijl ? "\\min" : "Min"
+        print(io, "Min ")
+        println(io, objective_function_string(REPLMode, model))
     else
-        str *= ijl ? "\\text{feasibility}" : "Feasibility"
+        println(io, "Feasibility")
     end
-    if sense != MOI.FEASIBILITY_SENSE
-        if ijl
-            str *= "\\quad"
-        end
-        str *= sep
-        str *= objective_function_string(print_mode, model)
-    end
-    str *= eol
-    str *= ijl ? "\\text{Subject to} \\quad" : "Subject to" * eol
-    constraints = constraints_string(print_mode, model)
-    if print_mode == REPLMode
-        constraints = map(str -> replace(str, '\n' => eol * sep), constraints)
-    end
-    if !isempty(constraints)
-        str *= sep
-    end
-    str *= join(constraints, eol * sep)
-    if !isempty(constraints)
-        str *= eol
+    println(io, "Subject to")
+    for constraint in constraints_string(REPLMode, model)
+        println(io, " ", replace(constraint, '\n' => "\n "))
     end
     # TODO: Generalize this when similar functionality is needed for
-    # AbstractModel.
-    nl_subexpressions = _nl_subexpression_string(print_mode, model)
+    # `AbstractModel`.
+    nl_subexpressions = _nl_subexpression_string(REPLMode, model)
     if !isempty(nl_subexpressions)
-        str *=
-            ijl ? "\\text{With NL expressions} \\quad" :
-            "With NL expressions" * eol
-        str *= sep * join(nl_subexpressions, eol * sep)
-        str *= eol
+        println(io, "With NL expressions")
     end
-    if ijl
-        str = "\\begin{aligned}" * str * "\\end{aligned}"
+    for expr in nl_subexpressions
+        println(io, " ", expr)
     end
-    return str
+    return
+end
+
+"""
+    _print_latex(io::IO, model::AbstractModel)
+
+Print a LaTeX formulation of `model` to `io`.
+
+An `AbstractModel` subtype should implement `objective_function_string`,
+`constraints_string` and `_nl_subexpression_string` for this method to work.
+"""
+function _print_latex(io::IO, model::AbstractModel)
+    print(io, "\$\$ \\begin{aligned}")
+    sense = objective_sense(model)
+    if sense == MOI.MAX_SENSE
+        print(io, "\\max\\quad & ")
+        print(io, objective_function_string(IJuliaMode, model), "\\\\")
+    elseif sense == MOI.MIN_SENSE
+        print(io, "\\min\\quad & ")
+        print(io, objective_function_string(IJuliaMode, model), "\\\\")
+    else
+        print(io, "\\text{feasibility}\\\\")
+    end
+    print(io, "\\text{Subject to} \\quad")
+    for constraint in constraints_string(IJuliaMode, model)
+        print(io, " & ", constraint, "\\\\")
+    end
+    # TODO: Generalize this when similar functionality is needed for
+    # `AbstractModel`.
+    nl_subexpressions = _nl_subexpression_string(IJuliaMode, model)
+    if !isempty(nl_subexpressions)
+        print(io, "\\text{With NL expressions} \\quad")
+    end
+    for expr in nl_subexpressions
+        print(io, " & ", expr, "\\\\")
+    end
+    print(io, "\\end{aligned} \$\$")
+end
+
+# TODO(odow): deprecate this?
+function model_string(print_mode, model::AbstractModel)
+    if print_mode == IJuliaMode
+        return sprint(_print_latex, model)
+    else
+        return sprint(_print_model, model)
+    end
 end
 
 _nl_subexpression_string(print_mode, ::AbstractModel) = String[]

--- a/src/print.jl
+++ b/src/print.jl
@@ -48,43 +48,28 @@ abstract type IJuliaMode <: PrintMode end
 
 Base.show(io::IO, model::AbstractModel) = _print_summary(io, model)
 
-"""
-    Base.print([io::IO = stdout,] model::AbstractModel)
-
-Print the plain-text formulation of `model` to `io` as a string (or to `stdout`
-if `io` is not given).
-
-See also: [LaTeXify](@ref).
-"""
-Base.print(io::IO, model::AbstractModel) = _print_model(io, model)
-
-"""
-    LaTeXify(model)
-
-Return an object that, when called with `show` or `print`, displays the LaTeX
-formulation of model.
-
-In the REPL, calling
-```julia
-julia> PrettyPrinter(model)
-```
-prints the formulation of `model` as a LaTeX string, which can be copied into a
-`.tex` document.
-
-In IJulia, if `PrettyPrinter(model)` is the last line in a cell, then the
-rendered LaTeX version of the model will be displayed.
-
-In the REPL and IJulia, you can get the formulation as a string by calling
-```julia
-sprint(show, LaTeXify(model))
-```
-"""
-struct LaTeXify{T<:AbstractModel}
+struct _LatexWrapper{T<:AbstractModel}
     model::T
 end
 
-Base.show(io::IO, model::LaTeXify) = _print_latex(io, model.model)
-Base.show(io::IO, ::MIME"text/latex", model::LaTeXify) = show(io, model)
+Base.show(io::IO, model::_LatexWrapper) = _print_latex(io, model.model)
+Base.show(io::IO, ::MIME"text/latex", model::_LatexWrapper) = show(io, model)
+
+"""
+    Base.print([io::IO = stdout,] model::AbstractModel; latex::Bool = false)
+
+Print the formulation of `model` to `io` as a string (or to `stdout` if `io` is
+not given).
+
+If `latex=true` print the model in LaTeX. If `latex=false`, print in plain-text.
+"""
+function Base.print(io::IO, model::AbstractModel; latex::Bool = false)
+    return latex ? _print_latex(io, model) : _print_model(io, model)
+end
+
+function Base.print(model::AbstractModel; latex::Bool = false)
+    return latex ? display(_LatexWrapper(model)) : _print_model(stdout, model)
+end
 
 # Whether something is zero or not for the purposes of printing it
 # oneunit is useful e.g. if coef is a Unitful quantity.

--- a/src/print.jl
+++ b/src/print.jl
@@ -46,61 +46,45 @@ A type used for dispatching printing. Produces LaTeX representations.
 """
 abstract type IJuliaMode <: PrintMode end
 
-struct _ModelPrinter{T<:AbstractModel}
+Base.show(io::IO, model::AbstractModel) = _print_summary(io, model)
+
+"""
+    Base.print([io::IO = stdout,] model::AbstractModel)
+
+Print the plain-text formulation of `model` to `io` as a string (or to `stdout`
+if `io` is not given).
+
+See also: [LaTeXify](@ref).
+"""
+Base.print(io::IO, model::AbstractModel) = _print_model(io, model)
+
+"""
+    LaTeXify(model)
+
+Return an object that, when called with `show` or `print`, displays the LaTeX
+formulation of model.
+
+In the REPL, calling
+```julia
+julia> PrettyPrinter(model)
+```
+prints the formulation of `model` as a LaTeX string, which can be copied into a
+`.tex` document.
+
+In IJulia, if `PrettyPrinter(model)` is the last line in a cell, then the
+rendered LaTeX version of the model will be displayed.
+
+In the REPL and IJulia, you can get the formulation as a string by calling
+```julia
+sprint(show, LaTeXify(model))
+```
+"""
+struct LaTeXify{T<:AbstractModel}
     model::T
 end
 
-function Base.show(io::IO, model::AbstractModel)
-    return _print_summary(io, model)
-end
-
-function Base.show(io::IO, ::MIME"text/plain", model::_ModelPrinter)
-    return _print_model(io, model.model)
-end
-
-function Base.show(io::IO, ::MIME"text/latex", model::_ModelPrinter)
-    return _print_latex(io, model.model)
-end
-
-"""
-    Base.print([io::IO = stdout,] model::AbstractModel; [latex::Bool])
-
-Print the formulation of `model` to `io` (which defaults to `stdout` if not
-provided).
-
-In notebooks and documentation, calling `print(model)` will render the LaTeX
-formulation to the screen.
-
-## Examples
-
-Print the formulation of the model to `stdout`, rendering as LaTeX if called
-from a notebook or the documentation, or plain-text if called from the REPL.
-
-    print(model)
-
-Print the plain-text formulation to `io` as a string (or to `stdout` if `io` is
-not given).
-
-    print(io, model; latex = false)
-    print(model; latex = false)
-
-Print the latex formulation to the screen as a string  (or to `stdout` if `io`
-is not given) .
-
-    print(io, model; latex = true)
-    print(model; latex = true)
-"""
-function Base.print(io::IO, model::AbstractModel; latex::Bool = false)
-    return latex ? _print_latex(io, model) : _print_model(io, model)
-end
-
-function Base.print(model::AbstractModel; latex::Union{Nothing,Bool} = nothing)
-    if latex === nothing
-        return _ModelPrinter(model)
-    else
-        return print(stdout, model; latex = latex)
-    end
-end
+Base.show(io::IO, model::LaTeXify) = _print_latex(io, model.model)
+Base.show(io::IO, ::MIME"text/latex", model::LaTeXify) = show(io, model)
 
 # Whether something is zero or not for the purposes of printing it
 # oneunit is useful e.g. if coef is a Unitful quantity.

--- a/src/print.jl
+++ b/src/print.jl
@@ -322,7 +322,7 @@ function _print_latex(io::IO, model::AbstractModel)
     for expr in nl_subexpressions
         print(io, " & ", expr, "\\\\")
     end
-    print(io, "\\end{aligned} \$\$")
+    return print(io, "\\end{aligned} \$\$")
 end
 
 # TODO(odow): deprecate this?

--- a/src/print.jl
+++ b/src/print.jl
@@ -510,7 +510,7 @@ function _show_candidate_solution_summary(io::IO, summary::_SolutionSummary)
         summary.dual_objective_value,
     )
     if summary.verbose && summary.has_values
-        println(io, "  Primal solution : ")
+        println(io, "  Primal solution :")
         for variable_name in sort(collect(keys(summary.primal_solution)))
             println(
                 io,
@@ -522,7 +522,7 @@ function _show_candidate_solution_summary(io::IO, summary::_SolutionSummary)
         end
     end
     if summary.verbose && summary.has_duals
-        println(io, "  Dual solution : ")
+        println(io, "  Dual solution :")
         for constraint_name in sort(collect(keys(summary.dual_solution)))
             println(
                 io,

--- a/src/print.jl
+++ b/src/print.jl
@@ -55,34 +55,30 @@ Base.show(io::IO, model::LaTeXModel) = _print_latex(io, model.model)
 Base.show(io::IO, ::MIME"text/latex", model::LaTeXModel) = show(io, model)
 
 """
-    Base.print([io::IO,] model::AbstractModel; latex::Bool = false)
+    Base.print([io::IO = stdout,] model::AbstractModel; latex::Bool = false)
 
-If `latex == false`, print the plain-text formulation of `model` to `io`, which
-defaults to `stdout`.
+Print the formulation of `model` to `io` (which defaults to `stdout` if not
+provided).
 
-If `latex == true`, returns a struct that does one of two things:
- * In the REPL, prints the latex formulation as a `String` that can be pasted
-   into a `.tex` document.
- * In notebooks and documentation, `show`s the formulation in rendered LaTeX.
+If `latex == false`, print the formulation in plain text.
+If `latex == true`, print the formulation formulation in LaTeX.
 
-To obtain the LaTeX formulation as a `String`, use
-```julia
-string(print(model; latex = true))
-```
+In notebooks and documentation, calling `print(model; latex = true)` will render
+the LaTeX formulation to the screen.
 
 ## Examples
 
     print(model)
-    print(io, model)
     print(model; latex = true)
-    string(print(model; latex = true))
+    print(stdout, model))
+    print(stout, model; latex = true))
 """
 function Base.print(io::IO, model::AbstractModel; latex::Bool = false)
-    return latex ? LaTeXModel(model) : _print_model(io, model)
+    return latex ? _print_latex(io, model) : _print_model(io, model)
 end
 
 function Base.print(model::AbstractModel; latex::Bool = false)
-    return print(stdout, model; latex = latex)
+    return latex ? LaTeXModel(model) : _print_model(stdout, model)
 end
 
 # Whether something is zero or not for the purposes of printing it

--- a/src/print.jl
+++ b/src/print.jl
@@ -90,7 +90,7 @@ is not given) .
     print(io, model; latex = true)
     print(model; latex = true)
 """
-function Base.print(io::IO, model::AbstractModel; latex::Bool)
+function Base.print(io::IO, model::AbstractModel; latex::Bool = false)
     return latex ? _print_latex(io, model) : _print_model(io, model)
 end
 

--- a/src/print.jl
+++ b/src/print.jl
@@ -69,7 +69,8 @@ Base.show(io::IO, ::MIME"text/latex", model::_LatexModel) = show(io, model)
 
 function Base.print(model::AbstractModel)
     for d in Base.Multimedia.displays
-        if Base.Multimedia.displayable(d, "text/latex") && startswith("$(typeof(d))", "IJulia.")
+        if Base.Multimedia.displayable(d, "text/latex") &&
+           startswith("$(typeof(d))", "IJulia.")
             return display(d, "text/latex", latex_formulation(model))
         end
     end

--- a/test/print.jl
+++ b/test/print.jl
@@ -37,13 +37,15 @@ function _io_test_print(::Type{IJuliaMode}, obj, exp_str)
 end
 function _io_test_print(::Type{REPLMode}, obj::AbstractModel, exp_str)
     @test sprint(print, obj) == exp_str
+    path = tempname()
+    open(io -> redirect_stdout(() -> print(obj; latex = false), io), path, "w")
+    @test read(path, String) == exp_str
 end
 function _io_test_print(::Type{IJuliaMode}, obj::AbstractModel, exp_str)
-    @test sprint(show, LaTeXify(obj)) == string("\$\$ ", exp_str, " \$\$")
-    @test sprint(show, MIME("text/latex"), LaTeXify(obj)) ==
-        string("\$\$ ", exp_str, " \$\$")
-    @test sprint(show, MIME("text/plain"), LaTeXify(obj)) ==
-        string("\$\$ ", exp_str, " \$\$")
+    @test sprint(io -> print(io, obj; latex = true)) == string("\$\$ ", exp_str, " \$\$")
+    # Don't know how to test a `display`, so let's just run the code to check it
+    # doesn't error.
+    print(obj; latex = true)
 end
 
 function io_test(mode, obj, exp_str; repl = :both)

--- a/test/print.jl
+++ b/test/print.jl
@@ -23,31 +23,31 @@ import JuMP.REPLMode
 end
 
 # Helper function to test IO methods work correctly
-function _io_test_show_latex(obj, exp_str)
+function _io_test_show(::Type{REPLMode}, obj, exp_str)
+    @test sprint(show, obj) == exp_str
+end
+function _io_test_show(::Type{IJuliaMode}, obj, exp_str)
     @test sprint(show, "text/latex", obj) == string("\$\$ ", exp_str, " \$\$")
 end
-function _io_test_print_latex(obj, exp_str)
+function _io_test_print(::Type{REPLMode}, obj, exp_str)
+    @test sprint(print, obj) == exp_str
+end
+function _io_test_print(::Type{IJuliaMode}, obj, exp_str)
     @test sprint(show, "text/latex", obj) == string("\$\$ ", exp_str, " \$\$")
 end
-function _io_test_print_latex(obj::AbstractModel, exp_str)
-    @test string(print(obj; latex = true)) == string("\$\$ ", exp_str, " \$\$")
+function _io_test_print(::Type{REPLMode}, obj::AbstractModel, exp_str)
+    @test sprint(io -> print(io, obj; latex = false)) == exp_str
+end
+function _io_test_print(::Type{IJuliaMode}, obj::AbstractModel, exp_str)
+    @test sprint(io -> print(io, obj; latex = true)) == string("\$\$ ", exp_str, " \$\$")
 end
 
 function io_test(mode, obj, exp_str; repl = :both)
-    if mode == REPLMode
-        if repl == :show || repl == :both
-            @test sprint(show, obj) == exp_str
-        end
-        if repl == :print || repl == :both
-            @test sprint(print, obj) == exp_str
-        end
-    else
-        if repl == :show || repl == :both
-            _io_test_show_latex(obj, exp_str)
-        end
-        if repl == :print || repl == :both
-            _io_test_print_latex(obj, exp_str)
-        end
+    if repl == :show || repl == :both
+        _io_test_show(mode, obj, exp_str)
+    end
+    if repl == :print || repl == :both
+        _io_test_print(mode, obj, exp_str)
     end
 end
 

--- a/test/print.jl
+++ b/test/print.jl
@@ -36,10 +36,14 @@ function _io_test_print(::Type{IJuliaMode}, obj, exp_str)
     @test sprint(show, "text/latex", obj) == string("\$\$ ", exp_str, " \$\$")
 end
 function _io_test_print(::Type{REPLMode}, obj::AbstractModel, exp_str)
-    @test sprint(io -> print(io, obj; latex = false)) == exp_str
+    @test sprint(print, obj) == exp_str
 end
 function _io_test_print(::Type{IJuliaMode}, obj::AbstractModel, exp_str)
-    @test sprint(io -> print(io, obj; latex = true)) == string("\$\$ ", exp_str, " \$\$")
+    @test sprint(show, LaTeXify(obj)) == string("\$\$ ", exp_str, " \$\$")
+    @test sprint(show, MIME("text/latex"), LaTeXify(obj)) ==
+        string("\$\$ ", exp_str, " \$\$")
+    @test sprint(show, MIME("text/plain"), LaTeXify(obj)) ==
+        string("\$\$ ", exp_str, " \$\$")
 end
 
 function io_test(mode, obj, exp_str; repl = :both)

--- a/test/print.jl
+++ b/test/print.jl
@@ -48,7 +48,7 @@ function _io_test_print(::Type{IJuliaMode}, obj::AbstractModel, exp_str)
           string("\$\$ ", exp_str, " \$\$")
     # TODO(odow): I don't know how to test an IJulia display without adding
     # IJulia as a test-dependency, so just print and check it doesn't error.
-    print(model)
+    print(obj)
     return
 end
 

--- a/test/print.jl
+++ b/test/print.jl
@@ -42,10 +42,11 @@ function _io_test_print(::Type{REPLMode}, obj::AbstractModel, exp_str)
     @test read(path, String) == exp_str
 end
 function _io_test_print(::Type{IJuliaMode}, obj::AbstractModel, exp_str)
-    @test sprint(io -> print(io, obj; latex = true)) == string("\$\$ ", exp_str, " \$\$")
+    @test sprint(io -> print(io, obj; latex = true)) ==
+          string("\$\$ ", exp_str, " \$\$")
     # Don't know how to test a `display`, so let's just run the code to check it
     # doesn't error.
-    print(obj; latex = true)
+    return print(obj; latex = true)
 end
 
 function io_test(mode, obj, exp_str; repl = :both)
@@ -738,7 +739,7 @@ Names registered in the model: a, a1, b, b1, c, c1, fi, u, x, y, z""",
             " & a\\times b \\leq 2.0\\\\" *
             " & [-a + 1, u_{1}, u_{2}, u_{3}] \\in \\text{MathOptInterface.SecondOrderCone(4)}\\\\" *
             "\\end{aligned}",
-            repl = :print
+            repl = :print,
         )
 
         #------------------------------------------------------------------
@@ -825,7 +826,7 @@ With NL expressions
             "\\text{Subject to} \\quad & subexpression_{1} - 0.0 = 0\\\\" *
             "\\text{With NL expressions} \\quad & subexpression_{1}: cos(x)\\\\" *
             "\\end{aligned}",
-            repl = :print
+            repl = :print,
         )
     end
     @testset "SingleVariable constraints" begin

--- a/test/print.jl
+++ b/test/print.jl
@@ -23,13 +23,31 @@ import JuMP.REPLMode
 end
 
 # Helper function to test IO methods work correctly
+function _io_test_show_latex(obj, exp_str)
+    @test sprint(show, "text/latex", obj) == string("\$\$ ", exp_str, " \$\$")
+end
+function _io_test_print_latex(obj, exp_str)
+    @test sprint(show, "text/latex", obj) == string("\$\$ ", exp_str, " \$\$")
+end
+function _io_test_print_latex(obj::AbstractModel, exp_str)
+    @test string(print(obj; latex = true)) == string("\$\$ ", exp_str, " \$\$")
+end
+
 function io_test(mode, obj, exp_str; repl = :both)
     if mode == REPLMode
-        repl != :show && @test sprint(print, obj) == exp_str
-        repl != :print && @test sprint(show, obj) == exp_str
+        if repl == :show || repl == :both
+            @test sprint(show, obj) == exp_str
+        end
+        if repl == :print || repl == :both
+            @test sprint(print, obj) == exp_str
+        end
     else
-        @test sprint(show, "text/latex", obj) ==
-              string("\$\$ ", exp_str, " \$\$")
+        if repl == :show || repl == :both
+            _io_test_show_latex(obj, exp_str)
+        end
+        if repl == :print || repl == :both
+            _io_test_print_latex(obj, exp_str)
+        end
     end
 end
 
@@ -597,6 +615,7 @@ Names registered in the model: a, a1, b, b1, c, c1, con, fi, soc, u, x, y, z""",
             " & u_{2} \\in \\{0, 1\\}\\\\" *
             " & u_{3} \\in \\{0, 1\\}\\\\" *
             "\\end{aligned}",
+            repl = :print,
         )
 
         #------------------------------------------------------------------
@@ -713,6 +732,7 @@ Names registered in the model: a, a1, b, b1, c, c1, fi, u, x, y, z""",
             " & a\\times b \\leq 2.0\\\\" *
             " & [-a + 1, u_{1}, u_{2}, u_{3}] \\in \\text{MathOptInterface.SecondOrderCone(4)}\\\\" *
             "\\end{aligned}",
+            repl = :print
         )
 
         #------------------------------------------------------------------
@@ -799,6 +819,7 @@ With NL expressions
             "\\text{Subject to} \\quad & subexpression_{1} - 0.0 = 0\\\\" *
             "\\text{With NL expressions} \\quad & subexpression_{1}: cos(x)\\\\" *
             "\\end{aligned}",
+            repl = :print
         )
     end
     @testset "SingleVariable constraints" begin

--- a/test/print.jl
+++ b/test/print.jl
@@ -840,6 +840,27 @@ With NL expressions
         io_test(REPLMode, zero_one, "x binary")
         # TODO: Test in IJulia mode
     end
+    @testset "Feasibility" begin
+        io_test(
+            IJuliaMode,
+            Model(),
+            "\\begin{aligned}\\text{feasibility}\\\\" *
+            "\\text{Subject to} \\quad\\end{aligned}",
+            repl = :print,
+        )
+    end
+    @testset "Min" begin
+        model = Model()
+        @variable(model, x)
+        @objective(model, Min, x)
+        io_test(
+            IJuliaMode,
+            model,
+            "\\begin{aligned}\\min\\quad & x\\\\" *
+            "\\text{Subject to} \\quad\\end{aligned}",
+            repl = :print,
+        )
+    end
 end
 
 @testset "Printing for JuMPExtension.MyModel" begin
@@ -946,10 +967,10 @@ end
   Objective value      : -1.0
   Objective bound      : 3.0
   Dual objective value : -1.0
-  Primal solution : 
+  Primal solution :
     x : 1.0
     y : 0.0
-  Dual solution : 
+  Dual solution :
     xub : 0.0
     ylb : 1.0
 

--- a/test/print.jl
+++ b/test/print.jl
@@ -37,16 +37,12 @@ function _io_test_print(::Type{IJuliaMode}, obj, exp_str)
 end
 function _io_test_print(::Type{REPLMode}, obj::AbstractModel, exp_str)
     @test sprint(print, obj) == exp_str
-    path = tempname()
-    open(io -> redirect_stdout(() -> print(obj; latex = false), io), path, "w")
-    @test read(path, String) == exp_str
 end
 function _io_test_print(::Type{IJuliaMode}, obj::AbstractModel, exp_str)
-    @test sprint(io -> print(io, obj; latex = true)) ==
+    model = JuMP.latex_formulation(obj)
+    @test sprint(io -> print(io, model)) ==
           string("\$\$ ", exp_str, " \$\$")
-    # Don't know how to test a `display`, so let's just run the code to check it
-    # doesn't error.
-    return print(obj; latex = true)
+    return
 end
 
 function io_test(mode, obj, exp_str; repl = :both)

--- a/test/print.jl
+++ b/test/print.jl
@@ -40,8 +40,7 @@ function _io_test_print(::Type{REPLMode}, obj::AbstractModel, exp_str)
 end
 function _io_test_print(::Type{IJuliaMode}, obj::AbstractModel, exp_str)
     model = JuMP.latex_formulation(obj)
-    @test sprint(io -> print(io, model)) ==
-          string("\$\$ ", exp_str, " \$\$")
+    @test sprint(io -> print(io, model)) == string("\$\$ ", exp_str, " \$\$")
     return
 end
 

--- a/test/print.jl
+++ b/test/print.jl
@@ -37,10 +37,18 @@ function _io_test_print(::Type{IJuliaMode}, obj, exp_str)
 end
 function _io_test_print(::Type{REPLMode}, obj::AbstractModel, exp_str)
     @test sprint(print, obj) == exp_str
+    @test JuMP.model_string(JuMP.REPLMode, obj) == exp_str
+    return
 end
 function _io_test_print(::Type{IJuliaMode}, obj::AbstractModel, exp_str)
     model = JuMP.latex_formulation(obj)
-    @test sprint(io -> print(io, model)) == string("\$\$ ", exp_str, " \$\$")
+    @test sprint(io -> show(io, MIME("text/latex"), model)) ==
+          string("\$\$ ", exp_str, " \$\$")
+    @test JuMP.model_string(JuMP.IJuliaMode, obj) ==
+          string("\$\$ ", exp_str, " \$\$")
+    # TODO(odow): I don't know how to test an IJulia display without adding
+    # IJulia as a test-dependency, so just print and check it doesn't error.
+    print(model)
     return
 end
 


### PR DESCRIPTION
Closes https://github.com/jump-dev/JuMP.jl/issues/957

Previous behavior was inconsistent between the REPL and IJulia/documentation.

This PR standardizes on the following
 * `Julia> model` or ending a cell with `model` prints the summary
 * `print(io, model)` prints the plain-text or latex version as a string to io
 * `print(model)` prints the latex version in IJulia, and the plain-text elsewhere.
 * `latex_formulation(model)` returns a type that will `show` the latex formulation in Documenter and IJulia, and the string of it in the REPL.

The user-visible change is that ending a cell with `model` prints the summary prints the plain-text summary instead of rendering the latex.

<s>We should probably merge #2447 first, and then rebase this PR on top.</s>

## IJulia

<img width="1091" alt="image" src="https://user-images.githubusercontent.com/8177701/112070591-dbaeef80-8bd2-11eb-9b92-2ce7121ac369.png">

## REPL

```Julia
julia> model
A JuMP Model
Minimization problem with:
Variable: 1
Objective function type: GenericAffExpr{Float64,VariableRef}
`GenericAffExpr{Float64,VariableRef}`-in-`MathOptInterface.GreaterThan{Float64}`: 1 constraint
`VariableRef`-in-`MathOptInterface.GreaterThan{Float64}`: 1 constraint
Model mode: AUTOMATIC
CachingOptimizer state: NO_OPTIMIZER
Solver name: No optimizer attached.
Names registered in the model: x

julia> function foo(model)
           print(model)
           return
       end
foo (generic function with 1 method)

julia> foo(model)
Min x - 1
Subject to
 2 x ≥ 1.0
 x ≥ 0.0

julia> latex_formulation(model)
$$ \begin{aligned}\min\quad & x - 1\\\text{Subject to} \quad & 2 x \geq 1.0\\ & x \geq 0.0\\\end{aligned} $$
```