### PR TITLE
Special case deg2rad and rad2deg in 2nd_deriv

### DIFF
--- a/src/_Derivatives/forward.jl
+++ b/src/_Derivatives/forward.jl
@@ -477,6 +477,8 @@ for i in 1:length(univariate_operators)
         deriv_expr = :(-fval)
     elseif op == :exp
         deriv_expr = :(fval)
+    elseif op == :rad2deg || op == :deg2rad
+        deriv_expr = :(zero(T))
     else
         deriv_expr = Calculus.differentiate(univariate_operator_deriv[i], :x)
     end

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -843,4 +843,14 @@ end
         )
         @test_throws(err, @NLexpression(model, sqrt(x)))
     end
+
+    @testset "rad2deg and deg2rad" begin
+        x = 1.0
+        id = JuMP._Derivatives.univariate_operator_to_id[:rad2deg]
+        y = rad2deg(x)
+        @test JuMP._Derivatives.eval_univariate_2nd_deriv(id, x, y) == 0.0
+        id = JuMP._Derivatives.univariate_operator_to_id[:deg2rad]
+        y = deg2rad(x)
+        @test JuMP._Derivatives.eval_univariate_2nd_deriv(id, x, y) == 0.0
+    end
 end


### PR DESCRIPTION
Closes #2455

These were the only two ones with constant integer returns. I guess that's why we do the same for `+` and `-`.

The issue comes from this line in Calculus which just has  a `return 0` if the input is a `Number`: https://github.com/JuliaMath/Calculus.jl/blob/8da321ab3404c1bb53c7418e8d1da4806cbeaca8/src/differentiate.jl#L13