### PR TITLE
Throw a helpful error for begin...end in NL macros

### DIFF
--- a/src/parse_nlp.jl
+++ b/src/parse_nlp.jl
@@ -19,6 +19,12 @@ end
 # parent is the index of the parent expression
 # values is the name of the list of constants which appear in the expression
 function _parse_NL_expr(m, x, tapevar, parent, values)
+    if isexpr(x, :block)
+        error(
+            "`begin...end` blocks are not supported in nonlinear macros. The " *
+            "nonlinear expression must be a single statement."
+        )
+    end
     if isexpr(x,:call) && length(x.args) >= 2 && (isexpr(x.args[2],:generator) || isexpr(x.args[2],:flatten))
         header = x.args[1]
         if _is_sum(header)

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -193,6 +193,16 @@ end
         @test_macro_throws ErrorException @NLexpression(model, (*)((x / 2)...))
     end
 
+    @testset "Error on begin...end" begin
+        model = Model()
+        @variable(model, x)
+        err = ErrorException(
+            "`begin...end` blocks are not supported in nonlinear macros. The " *
+            "nonlinear expression must be a single statement."
+        )
+        @test_macro_throws(err, @NLexpression(model, begin sin(x) + 1 end))
+    end
+
     @testset "Error on unexpected splatting" begin
         model = Model()
         @variable(model, x[1:2])


### PR DESCRIPTION
Closes #2448 

I didn't realize that things like this worked in `@objective`:
```Julia
julia> using JuMP

julia> model = Model();

julia> @variable(model, x);

julia> @objective(model, Min, begin
           y = 2 * x
           z = y + 1
           2 * z + 2
       end)
4 x + 4
```
But we can't make this work in general for nonlinear expressions, so I've opted to just make it a more informative error:
```Julia
julia> using JuMP

julia> model = Model();

julia> @variable(model, x);

julia> @NLexpression(model, begin sin(x) + 1 end)
ERROR: LoadError: `begin...end` blocks are not supported in nonlinear macros. The nonlinear expression must be a single statement.
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] _parse_NL_expr(::Symbol, ::Expr, ::Symbol, ::Int64, ::Symbol) at /Users/oscar/.julia/dev/JuMP/src/parse_nlp.jl:23
 [3] _process_NL_expr(::Symbol, ::Expr) at /Users/oscar/.julia/dev/JuMP/src/parse_nlp.jl:257
 [4] @NLexpression(::LineNumberNode, ::Module, ::Vararg{Any,N} where N) at /Users/oscar/.julia/dev/JuMP/src/macros.jl:1619
in expression starting at REPL[5]:1
```