### PR TITLE
Allow AbstractVector in VectorConstraints

### DIFF
--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -431,6 +431,13 @@ function VectorConstraint(func::Vector{<:AbstractJuMPScalar},
     VectorConstraint(func, set, VectorShape())
 end
 
+function VectorConstraint(
+    func::AbstractVector{<:AbstractJuMPScalar},
+    set::MOI.AbstractVectorSet,
+)
+    return VectorConstraint(collect(func), set)
+end
+
 reshape_set(set::MOI.AbstractVectorSet, ::VectorShape) = set
 shape(con::VectorConstraint) = con.shape
 function constraint_object(con_ref::ConstraintRef{<:AbstractModel, _MOICON{FuncType, SetType}}) where

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -300,8 +300,11 @@ function build_constraint(
     return build_constraint(_error, zero(AffExpr), set)
 end
 
-function build_constraint(_error::Function, x::Vector{<:AbstractJuMPScalar},
-                          set::MOI.AbstractVectorSet)
+function build_constraint(
+    ::Function,
+    x::AbstractVector{<:AbstractJuMPScalar},
+    set::MOI.AbstractVectorSet,
+)
     return VectorConstraint(x, set)
 end
 function build_constraint(_error::Function, a::Vector{<:Number},
@@ -357,12 +360,18 @@ function build_constraint(_error::Function, expr, lb, ub)
 end
 
 function build_constraint(
-        ::Function, x::Vector{<:AbstractJuMPScalar}, set::MOI.SOS1)
+    ::Function,
+    x::AbstractVector{<:AbstractJuMPScalar},
+    set::MOI.SOS1,
+)
     return VectorConstraint(x, MOI.SOS1{Float64}(set.weights))
 end
 
 function build_constraint(
-        ::Function, x::Vector{<:AbstractJuMPScalar}, set::MOI.SOS2)
+    ::Function,
+    x::AbstractVector{<:AbstractJuMPScalar},
+    set::MOI.SOS2,
+)
     return VectorConstraint(x, MOI.SOS2{Float64}(set.weights))
 end
 

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -906,6 +906,15 @@ function test_Model_shadow_price(::Any, ::Any)
     )
 end
 
+function test_abstractarray_vector_constraint(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, x[1:2, 1:2])
+    c = @constraint(model, view(x, 1:4) in SOS1())
+    obj = constraint_object(c)
+    @test obj.func == x[1:4]
+    @test obj.set == MOI.SOS1([1.0, 2.0, 3.0, 4.0])
+end
+
 function runtests()
     for name in names(@__MODULE__; all = true)
         if !startswith("$(name)", "test_")


### PR DESCRIPTION
Closes #1950 

There are a few ways to make `AbstractArray`s, so it makes sense to support them more generally throughout the interface.