### PR TITLE
First pass at a feasibility checker.

### DIFF
--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -493,21 +493,31 @@ end
 ## Checking feasibility of solutions
 
 To check the feasibility of a primal solution, use
-[`primal_feasibility_report`](@ref). The returned `report` is `nothing` if the
-point is feasible. Otherwise, it is a dictionary mapping the infeasible
-constraint references to the distance between the point and the nearest point in
-the set.
+[`primal_feasibility_report`](@ref), which takes a `model`, a dictionary mapping
+each variable to a primal solution value, and a tolerance `atol`. If a variable
+is not given in dictionary, the value is assumed to be `0.0`.
 
-```@example
+The function returns a dictionary which maps the infeasible constraint
+references to the distance between the point and the nearest point in the
+corresponding set. A point is classed as infeasible if the distance is greater
+than a supplied tolerance `atol`, and feasible otherwise.
+```@example feasibility
 using JuMP
 model = Model()
 @variable(model, x >= 1, Int)
-@constraint(model, c1, x <= 1.95)
+@variable(model, y)
+@constraint(model, c1, x + y <= 1.95)
 point = Dict(x => 2.5)
-report = primal_feasibility_report(model, point)
+report = primal_feasibility_report(model, point; atol = 1e-6)
 ```
 
-To use the point from a previous solve, use:
+If the point is feasible, this function returns `nothing`.
+```@example feasibility
+point = Dict(x => 1.0)
+report = primal_feasibility_report(model, point; atol = 1e-6)
+```
+
+To obtain the primal point from a previous solve, use:
 ```julia
 point = Dict(v => value(v) for v in all_variables(model))
 ```

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -501,9 +501,10 @@ The function returns a dictionary which maps the infeasible constraint
 references to the distance between the point and the nearest point in the
 corresponding set. A point is classed as infeasible if the distance is greater
 than a supplied tolerance `atol`, and feasible otherwise.
+
 ```@example feasibility
-using JuMP
-model = Model()
+using JuMP, GLPK
+model = Model(GLPK.Optimizer)
 @variable(model, x >= 1, Int)
 @variable(model, y)
 @constraint(model, c1, x + y <= 1.95)
@@ -511,14 +512,14 @@ point = Dict(x => 2.5)
 report = primal_feasibility_report(model, point; atol = 1e-6)
 ```
 
-If the point is feasible, this function returns `nothing`.
+If the point is feasible, this function returns an empty dictionary.
 ```@example feasibility
 point = Dict(x => 1.0)
 report = primal_feasibility_report(model, point; atol = 1e-6)
-report === nothing
 ```
 
-To obtain the primal point from a previous solve, use:
-```julia
-point = Dict(v => value(v) for v in all_variables(model))
+To use the primal solution from a solve, omit the `point` argument:
+```@example feasibility
+optimize!(model)
+report = primal_feasibility_report(model)
 ```

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -502,7 +502,7 @@ references to the distance between the primal value of the constraint and the
 nearest point in the corresponding set. A point is classed as infeasible if the
 distance is greater than the supplied tolerance `atol`.
 
-```jldoctest feasibility
+```jldoctest feasibility; filter=["x integer         => 0.1", "c1 : x + y ≤ 1.95 => 0.01"]
 julia> model = Model(GLPK.Optimizer);
 
 julia> @variable(model, x >= 1, Int);

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -127,7 +127,7 @@ FEASIBLE_POINT::ResultStatusCode = 1
 ```
 Other common returns are `MOI.NO_SOLUTION`, and `MOI.INFEASIBILITY_CERTIFICATE`.
 The first means that the solver doesn't have a solution to return, and the
-second means that the primal solution is a certificate of dual infeasbility (a 
+second means that the primal solution is a certificate of dual infeasbility (a
 primal unbounded ray).
 
 You can also use [`has_values`](@ref), which returns `true` if there is a
@@ -200,7 +200,7 @@ FEASIBLE_POINT::ResultStatusCode = 1
 ```
 Other common returns are `MOI.NO_SOLUTION`, and `MOI.INFEASIBILITY_CERTIFICATE`.
 The first means that the solver doesn't have a solution to return, and the
-second means that the dual solution is a certificate of primal infeasbility (a 
+second means that the dual solution is a certificate of primal infeasbility (a
 dual unbounded ray).
 
 You can also use [`has_duals`](@ref), which returns `true` if there is a
@@ -258,7 +258,7 @@ And data, a 2-element Array{Float64,1}:
 
 ## Recommended workflow
 
-The recommended workflow for solving a model and querying the solution is 
+The recommended workflow for solving a model and querying the solution is
 something like the following:
 ```jldoctest solutions
 if termination_status(model) == MOI.OPTIMAL
@@ -427,7 +427,7 @@ For instance, this is how you can use this functionality:
 
 ```julia
 using JuMP
-model = Model() # You must use a solver that supports conflict refining/IIS 
+model = Model() # You must use a solver that supports conflict refining/IIS
 # computation, like CPLEX or Gurobi
 @variable(model, x >= 0)
 @constraint(model, c1, x >= 2)
@@ -488,4 +488,26 @@ for i in 2:result_count(model)
         print("Solution $(i) is also optimal!")
     end
 end
+```
+
+## Checking feasibility of solutions
+
+To check the feasibility of a primal solution, use
+[`primal_feasibility_report`](@ref). The returned `report` is `nothing` if the
+point is feasible. Otherwise, it is a dictionary mapping the infeasible
+constraint references to the distance between the point and the nearest point in
+the set.
+
+```@example
+using JuMP
+model = Model()
+@variable(model, x >= 1, Int)
+@constraint(model, c1, x <= 1.95)
+point = Dict(x => 2.5)
+report = primal_feasibility_report(model, point)
+```
+
+To use the point from a previous solve, use:
+```julia
+point = Dict(v => value(v) for v in all_variables(model))
 ```

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -516,8 +516,8 @@ julia> point = Dict(x => 1.9, y => 0.06);
 
 julia> primal_feasibility_report(model, point)
 Dict{Any,Float64} with 2 entries:
-  x integer         => 0.1
   c1 : x + y ≤ 1.95 => 0.01
+  x integer         => 0.1
 
 julia> primal_feasibility_report(model, point; atol = 0.02)
 Dict{Any,Float64} with 1 entry:

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -502,7 +502,11 @@ references to the distance between the primal value of the constraint and the
 nearest point in the corresponding set. A point is classed as infeasible if the
 distance is greater than the supplied tolerance `atol`.
 
-```jldoctest feasibility; filter=["x integer         => 0.1", "c1 : x + y ≤ 1.95 => 0.01"]
+```@meta
+# Add a filter here because the output of the dictionary is not ordered, and
+# changes in printing order will cause the doctest to fail.
+```
+```jldoctest feasibility; filter=[r"x.+?\=\> 0.1", r"c1.+? \=\> 0.01"]
 julia> model = Model(GLPK.Optimizer);
 
 julia> @variable(model, x >= 1, Int);

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -515,6 +515,7 @@ If the point is feasible, this function returns `nothing`.
 ```@example feasibility
 point = Dict(x => 1.0)
 report = primal_feasibility_report(model, point; atol = 1e-6)
+report === nothing
 ```
 
 To obtain the primal point from a previous solve, use:

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -521,7 +521,7 @@ Dict{Any,Float64} with 2 entries:
 
 julia> primal_feasibility_report(model, point; atol = 0.02)
 Dict{Any,Float64} with 1 entry:
-  x integer         => 0.1
+  x integer => 0.1
 ```
 
 If the point is feasible, an empty dictionary is returned:

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -495,12 +495,12 @@ end
 To check the feasibility of a primal solution, use
 [`primal_feasibility_report`](@ref), which takes a `model`, a dictionary mapping
 each variable to a primal solution value (defaults to the last solved solution),
-a tolerance `atol` (defaults to `0.0`).
+and a tolerance `atol` (defaults to `0.0`).
 
 The function returns a dictionary which maps the infeasible constraint
-references to the distance between the point and the nearest point in the
-corresponding set. A point is classed as infeasible if the distance is greater
-than the supplied tolerance `atol`.
+references to the distance between the primal value of the constraint and the 
+nearest point in the corresponding set. A point is classed as infeasible if the 
+distance is greater than the supplied tolerance `atol`.
 
 ```jldoctest feasibility
 julia> model = Model(GLPK.Optimizer);

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -495,8 +495,7 @@ end
 To check the feasibility of a primal solution, use
 [`primal_feasibility_report`](@ref), which takes a `model`, a dictionary mapping
 each variable to a primal solution value (defaults to the last solved solution),
-a tolerance `atol` (defaults to `0.0`), and a `default` value for variables not
-given in dictionary (defaults to `0.0`).
+a tolerance `atol` (defaults to `0.0`).
 
 The function returns a dictionary which maps the infeasible constraint
 references to the distance between the point and the nearest point in the
@@ -538,18 +537,10 @@ julia> primal_feasibility_report(model)
 Dict{Any,Float64} with 0 entries
 ```
 
-Use the `default` keyword argument to provide a value for variables not in the
-`point`:
-```jldoctest feasibility
-julia> primal_feasibility_report(model, Dict(x => 1.0); default = 1.5)
-Dict{Any,Float64} with 1 entry:
-  c1 : x + y ≤ 1.95 => 0.55
-```
-
-Pass `default = missing` to skip constraints which contain variables that are
+Pass `skip_mising = true` to skip constraints which contain variables that are
 not in `point`:
 ```jldoctest feasibility
-julia> primal_feasibility_report(model, Dict(x => 2.1); default = missing)
+julia> primal_feasibility_report(model, Dict(x => 2.1); skip_missing = true)
 Dict{Any,Float64} with 1 entry:
   x integer => 0.1
 ```

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -498,8 +498,8 @@ each variable to a primal solution value (defaults to the last solved solution),
 and a tolerance `atol` (defaults to `0.0`).
 
 The function returns a dictionary which maps the infeasible constraint
-references to the distance between the primal value of the constraint and the 
-nearest point in the corresponding set. A point is classed as infeasible if the 
+references to the distance between the primal value of the constraint and the
+nearest point in the corresponding set. A point is classed as infeasible if the
 distance is greater than the supplied tolerance `atol`.
 
 ```jldoctest feasibility

--- a/docs/src/reference/solutions.md
+++ b/docs/src/reference/solutions.md
@@ -72,3 +72,9 @@ SensitivityReport
 lp_objective_perturbation_range
 lp_rhs_perturbation_range
 ```
+
+## Feasibility
+
+```@docs
+primal_feasibility_report
+```

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -1281,6 +1281,7 @@ include("lp_sensitivity.jl")
 include("lp_sensitivity2.jl")
 include("callbacks.jl")
 include("file_formats.jl")
+include("feasibility_checker.jl")
 
 # JuMP exports everything except internal symbols, which are defined as those
 # whose name starts with an underscore. Macros whose names start with

--- a/src/feasibility_checker.jl
+++ b/src/feasibility_checker.jl
@@ -5,10 +5,20 @@
 
 using LinearAlgebra
 
+function _last_primal_solution(model::Model)
+    if !has_values(model)
+        error(
+            "No primal solution is available. You must provide a point at " *
+            "which to check feasibility."
+        )
+    end
+    return Dict(v => value(v) for v in all_variables(model))
+end
+
 """
     primal_feasibility_report(
         model::Model,
-        [point::AbstractDict{VariableRef,Float64}];
+        point::AbstractDict{VariableRef,Float64} = _last_primal_solution(model),
         atol::Float64 = 0.0,
         skip_missing::Bool = false,
     )::Dict{Any,Float64}
@@ -39,11 +49,11 @@ Dict{Any,Float64} with 1 entry:
 """
 function primal_feasibility_report(
     model::Model,
-    point::AbstractDict{VariableRef,Float64};
+    point::AbstractDict{VariableRef,Float64} = _last_primal_solution(model);
     atol::Float64 = 0.0,
     skip_missing::Bool = false,
 )
-    function point_f(x)
+    function point_f(x::VariableRef)
         fx = get(point, x, missing)
         if ismissing(fx) && !skip_missing
             error(
@@ -71,17 +81,6 @@ function primal_feasibility_report(
         )
     end
     return violated_constraints
-end
-
-function primal_feasibility_report(model::Model; kwargs...)
-    if !has_values(model)
-        error(
-            "No primal solution is available. You must provide a point at " *
-            "which to check feasibility."
-        )
-    end
-    point = Dict(v => value(v) for v in all_variables(model))
-    return primal_feasibility_report(model, point; kwargs...)
 end
 
 function _add_infeasible_constraints(

--- a/src/feasibility_checker.jl
+++ b/src/feasibility_checker.jl
@@ -65,18 +65,15 @@ function primal_feasibility_report(
     return violated_constraints
 end
 
-function primal_feasibility_report(model::Model; atol::Float64 = 0.0)
+function primal_feasibility_report(model::Model; kwargs...)
     if !has_values(model)
         error(
             "No primal solution is available. You must provide a point at " *
             "which to check feasibility."
         )
     end
-    return primal_feasibility_report(
-        model,
-        Dict(v => value(v) for v in all_variables(model));
-        atol = atol,
-    )
+    point = Dict(v => value(v) for v in all_variables(model))
+    return primal_feasibility_report(model, point; kwargs...)
 end
 
 function _add_infeasible_constraints(

--- a/src/feasibility_checker.jl
+++ b/src/feasibility_checker.jl
@@ -9,7 +9,7 @@ function _last_primal_solution(model::Model)
     if !has_values(model)
         error(
             "No primal solution is available. You must provide a point at " *
-            "which to check feasibility."
+            "which to check feasibility.",
         )
     end
     return Dict(v => value(v) for v in all_variables(model))
@@ -68,7 +68,12 @@ function primal_feasibility_report(
     violated_constraints = Dict{Any,Float64}()
     for (F, S) in list_of_constraint_types(model)
         _add_infeasible_constraints(
-            model, F, S, violated_constraints, point_f, atol
+            model,
+            F,
+            S,
+            violated_constraints,
+            point_f,
+            atol,
         )
     end
     if num_nl_constraints(model) > 0
@@ -79,7 +84,10 @@ function primal_feasibility_report(
             )
         end
         _add_infeasible_nonlinear_constraints(
-            model, violated_constraints, point_f, atol
+            model,
+            violated_constraints,
+            point_f,
+            atol,
         )
     end
     return violated_constraints
@@ -116,11 +124,8 @@ function _add_infeasible_nonlinear_constraints(
     for (i, con) in enumerate(model.nlp_data.nlconstr)
         d = max(0.0, con.lb - g[i], g[i] - con.ub)
         if d > atol
-            cref = ConstraintRef(
-                model,
-                NonlinearConstraintIndex(i),
-                ScalarShape(),
-            )
+            cref =
+                ConstraintRef(model, NonlinearConstraintIndex(i), ScalarShape())
             violated_constraints[cref] = d
         end
     end
@@ -128,9 +133,9 @@ function _add_infeasible_nonlinear_constraints(
 end
 
 function _distance_to_set(::Any, set::MOI.AbstractSet)
-    error(
+    return error(
         "Feasibility checker for set type $(typeof(set)) has not been " *
-        "implemented yet."
+        "implemented yet.",
     )
 end
 
@@ -169,11 +174,7 @@ function _distance_to_set(x::T, set::MOI.Semicontinuous{T}) where {T<:Real}
 end
 
 function _distance_to_set(x::T, set::MOI.Semiinteger{T}) where {T<:Real}
-    d = max(
-        ceil(set.lower) - x,
-        x - floor(set.upper),
-        abs(x - round(x)),
-    )
+    d = max(ceil(set.lower) - x, x - floor(set.upper), abs(x - round(x)))
     return min(d, abs(x))
 end
 
@@ -188,36 +189,22 @@ function _check_dimension(v::AbstractVector, s)
     return
 end
 
-function _distance_to_set(
-    x::Vector{T},
-    set::MOI.Nonnegatives,
-) where {T<:Real}
+function _distance_to_set(x::Vector{T}, set::MOI.Nonnegatives) where {T<:Real}
     _check_dimension(x, set)
     return LinearAlgebra.norm(max(-xi, zero(T)) for xi in x)
 end
 
-function _distance_to_set(
-    x::Vector{T},
-    set::MOI.Nonpositives,
-) where {T<:Real}
+function _distance_to_set(x::Vector{T}, set::MOI.Nonpositives) where {T<:Real}
     _check_dimension(x, set)
     return LinearAlgebra.norm(max(xi, zero(T)) for xi in x)
 end
 
-function _distance_to_set(
-    x::Vector{T},
-    set::MOI.Zeros
-) where {T<:Number}
+function _distance_to_set(x::Vector{T}, set::MOI.Zeros) where {T<:Number}
     _check_dimension(x, set)
     return LinearAlgebra.norm(x)
 end
 
-
-function _distance_to_set(
-    x::Vector{T},
-    set::MOI.Reals
-) where {T<:Real}
+function _distance_to_set(x::Vector{T}, set::MOI.Reals) where {T<:Real}
     _check_dimension(x, set)
     return zero(T)
 end
-

--- a/src/feasibility_checker.jl
+++ b/src/feasibility_checker.jl
@@ -32,6 +32,8 @@ greater than `atol`.
 
  * If `skip_missing = true`, constraints containing variables that are not in
    `point` will be ignored.
+ * If `skip_missing = false` and a partial primal solution is provided, an error
+   will be thrown.
  * If no point is provided, the primal solution from the last time the model was
    solved is used.
 

--- a/src/feasibility_checker.jl
+++ b/src/feasibility_checker.jl
@@ -9,16 +9,19 @@ using LinearAlgebra
     primal_feasibility_report(
         model::Model,
         [point::AbstractDict{VariableRef,Float64}];
-        atol::Float64 = 1e-8,
+        atol::Float64,
     )::Union{Nothing,Dict{Any,Float64}}
 
 Check the primal feasibility of `model` at the point given by the dictionary
 `point` mapping variables to primal values. If a variable is not given in
 `point`, the value is assumed to be `0.0`.
 
+A point is classed as feasible if the distance between the point and the set is
+less than or equal to `atol`.
+
 If the point is feasible, this function returns `nothing`. If infeasible, this
-function returns a dictionary mapping the constriant reference of each violated
-constraint to the distance it is from being feasible.
+function returns a dictionary mapping the constraint reference of each violated
+constraint to the distance from feasibility.
 
 To obtain `point` from a solution of a solved model, use:
 ```julia
@@ -28,7 +31,7 @@ point = Dict(v => value(v) for v in all_variables(model))
 function primal_feasibility_report(
     model::Model,
     point::AbstractDict{VariableRef,Float64};
-    atol::Float64 = 1e-8,
+    atol::Float64,
 )
     point_f = x -> get(point, x, 0.0)
     violated_constraints = Dict{Any,Float64}()

--- a/src/feasibility_checker.jl
+++ b/src/feasibility_checker.jl
@@ -8,7 +8,7 @@ using LinearAlgebra
 """
     primal_feasibility_report(
         model::Model,
-        [point::AbstractDict{VariableRef,Float64}];
+        point::AbstractDict{VariableRef,Float64};
         atol::Float64,
     )::Union{Nothing,Dict{Any,Float64}}
 

--- a/src/feasibility_checker.jl
+++ b/src/feasibility_checker.jl
@@ -44,6 +44,23 @@ function primal_feasibility_report(
             end
         end
     end
+    if num_nl_constraints(model) > 0
+        evaluator = NLPEvaluator(model)
+        MOI.initialize(evaluator, Symbol[])
+        g = zeros(num_nl_constraints(model))
+        MOI.eval_constraint(evaluator, g, point_f.(all_variables(model)))
+        for (i, con) in enumerate(model.nlp_data.nlconstr)
+            d = max(0.0, con.lb - g[i], g[i] - con.ub)
+            if d > atol
+                cref = ConstraintRef(
+                   model,
+                   NonlinearConstraintIndex(i),
+                    ScalarShape(),
+                )
+                violated_constraints[cref] = d
+            end
+        end
+    end
     return length(violated_constraints) == 0 ? nothing : violated_constraints
 end
 

--- a/src/feasibility_checker.jl
+++ b/src/feasibility_checker.jl
@@ -14,10 +14,8 @@ using LinearAlgebra
 
 Given a dictionary `point`, which maps variables to primal values, return a
 dictionary mapping the constraint reference of each constraint in `model` to the
-distance between the point and the nearest feasible point.
-
-Use `atol` to exclude constraints for which the distance is less-than or
-equal-to `atol`. `atol` defaults to `0.0`.
+distance between the point and the nearest feasible point, if the distance is
+greater than `atol`.
 
 ## Notes
 
@@ -28,12 +26,11 @@ equal-to `atol`. `atol` defaults to `0.0`.
 ## Examples
 
 ```jldoctest; setup=:(using JuMP)
-model = Model()
-@variable(model, 0.5 <= x <= 1)
-primal_feasibility_report(model, Dict(x => 0.2))
+julia> model = Model();
 
-# output
+julia> @variable(model, 0.5 <= x <= 1);
 
+julia> primal_feasibility_report(model, Dict(x => 0.2))
 Dict{Any,Float64} with 1 entry:
   x ≥ 0.5 => 0.3
 ```

--- a/src/feasibility_checker.jl
+++ b/src/feasibility_checker.jl
@@ -1,0 +1,77 @@
+#  Copyright 2017, Iain Dunning, Joey Huchette, Miles Lubin, and contributors
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""
+    primal_feasibility_report(
+        model::Model,
+        [point::Dict{VariableRef,Float64}];
+        atol::Float64 = 1e-8,
+    )::Union{Nothing,Dict{Any,Float64}}
+
+Check the primal feasibility of `model` at the point given by the dictionary
+`point` mapping variables to primal values. If a variable is not given in
+`point`, the value is assumed to be `0.0`.
+
+If the point is feasible, this function returns `nothing`. If infeasible, this
+function returns a dictionary mapping the constriant reference of each violated
+constraint to the distance it is from being feasible.
+
+To obtain `point` from a solution of a solved model, use:
+```julia
+point = Dict(v => value(v) for v in all_variables(model))
+```
+"""
+function primal_feasibility_report(
+    model::Model,
+    point::Dict{VariableRef,Float64};
+    atol::Float64 = 1e-8,
+)
+    point_f = x -> get(point, x, 0.0)
+    violated_constraints = Dict{Any,Float64}()
+    for (F, S) in list_of_constraint_types(model)
+        # This loop is not type-stable because `F` and `S` change, but it should
+        # be fine because no one should be using this in performance-critical
+        # code.
+        for con in all_constraints(model, F, S)
+            obj = constraint_object(con)
+            d = _distance_to_set(value(obj.func, point_f), obj.set)
+            if d > atol
+                violated_constraints[con] = d
+            end
+        end
+    end
+    return length(violated_constraints) == 0 ? nothing : violated_constraints
+end
+
+function _distance_to_set(::Any, set::MOI.AbstractSet)
+    error(
+        "Feasibility checker for set type $(typeof(set)) has not been " *
+        "implemented yet."
+    )
+end
+
+function _distance_to_set(x::Float64, set::MOI.LessThan{Float64})
+    return max(x - set.upper, 0.0)
+end
+
+function _distance_to_set(x::Float64, set::MOI.GreaterThan{Float64})
+    return max(set.lower - x, 0.0)
+end
+
+function _distance_to_set(x::Float64, set::MOI.EqualTo{Float64})
+    return abs(set.value - x)
+end
+
+function _distance_to_set(x::Float64, set::MOI.Interval{Float64})
+    return max(x - set.upper, set.lower - x, 0.0)
+end
+
+function _distance_to_set(x::Float64, ::MOI.ZeroOne)
+    return min(abs(x - 0.0), abs(x - 1.0))
+end
+
+function _distance_to_set(x::Float64, ::MOI.Integer)
+    return abs(x - round(Int, x))
+end

--- a/src/feasibility_checker.jl
+++ b/src/feasibility_checker.jl
@@ -8,7 +8,7 @@ using LinearAlgebra
 """
     primal_feasibility_report(
         model::Model,
-        [point::Dict{VariableRef,Float64}];
+        [point::AbstractDict{VariableRef,Float64}];
         atol::Float64 = 1e-8,
     )::Union{Nothing,Dict{Any,Float64}}
 
@@ -27,7 +27,7 @@ point = Dict(v => value(v) for v in all_variables(model))
 """
 function primal_feasibility_report(
     model::Model,
-    point::Dict{VariableRef,Float64};
+    point::AbstractDict{VariableRef,Float64};
     atol::Float64 = 1e-8,
 )
     point_f = x -> get(point, x, 0.0)
@@ -66,7 +66,7 @@ function _distance_to_set(x::T, set::MOI.GreaterThan{T}) where {T<:Real}
     return max(set.lower - x, zero(T))
 end
 
-function _distance_to_set(x::T, set::MOI.EqualTo{T}) where {T<:Real}
+function _distance_to_set(x::T, set::MOI.EqualTo{T}) where {T<:Number}
     return abs(set.value - x)
 end
 
@@ -125,7 +125,7 @@ end
 function _distance_to_set(
     x::Vector{T},
     set::MOI.Zeros
-) where {T<:Real}
+) where {T<:Number}
     _check_dimension(x, set)
     return LinearAlgebra.norm(x)
 end

--- a/test/feasibility_checker.jl
+++ b/test/feasibility_checker.jl
@@ -128,6 +128,17 @@ function test_feasible()
     @test isempty(report)
 end
 
+function test_missing()
+    model = Model()
+    @variable(model, x, Bin)
+    @variable(model, 0 <= y <= 2, Int)
+    @variable(model, z == 0.5)
+    @constraint(model, x + y + z >= 0.5)
+    report = primal_feasibility_report(model, Dict(z => 0.0), default = missing)
+    @test report[FixRef(z)] == 0.5
+    @test length(report) == 1
+end
+
 function test_bounds()
     model = Model()
     @variable(model, x, Bin)
@@ -216,6 +227,19 @@ function test_nonlinear()
     @test !haskey(report, c2)
     @test report[c3] ≈ 2 - exp(0.5)
     @test report[c4] ≈ 0.125
+end
+
+function test_nonlinear_missing()
+    model = Model()
+    @variable(model, x)
+    @NLconstraint(model, c1, sin(x) <= 0.0)
+    @test_throws(
+        ErrorException(
+            "`default` cannot be `missing` when nonlinear constraints are " *
+            "present.",
+        ),
+        primal_feasibility_report(model, Dict(x => 0.5); default = missing)
+    )
 end
 
 function runtests()

--- a/test/feasibility_checker.jl
+++ b/test/feasibility_checker.jl
@@ -8,27 +8,79 @@ module TestFeasibilityChecker
 using JuMP
 using Test
 
-function test_distance_to_set()
+function test_unsupported()
+    @test_throws(
+        ErrorException,
+        JuMP._distance_to_set([1.0, 1.0], MOI.Complements(1)),
+    )
+end
+
+function test_lessthan()
     @test JuMP._distance_to_set(1.0, MOI.LessThan(2.0)) ≈ 0.0
     @test JuMP._distance_to_set(1.0, MOI.LessThan(0.5)) ≈ 0.5
+end
+
+function test_greaterthan()
     @test JuMP._distance_to_set(1.0, MOI.GreaterThan(2.0)) ≈ 1.0
     @test JuMP._distance_to_set(1.0, MOI.GreaterThan(0.5)) ≈ 0.0
+end
+
+function test_equalto()
     @test JuMP._distance_to_set(1.0, MOI.EqualTo(2.0)) ≈ 1.0
     @test JuMP._distance_to_set(1.0, MOI.EqualTo(0.5)) ≈ 0.5
+end
+
+function test_interval()
     @test JuMP._distance_to_set(1.0, MOI.Interval(1.0, 2.0)) ≈ 0.0
     @test JuMP._distance_to_set(0.5, MOI.Interval(1.0, 2.0)) ≈ 0.5
     @test JuMP._distance_to_set(2.75, MOI.Interval(1.0, 2.0)) ≈ 0.75
+end
+
+function test_zeroone()
     @test JuMP._distance_to_set(0.6, MOI.ZeroOne()) ≈ 0.4
     @test JuMP._distance_to_set(-0.01, MOI.ZeroOne()) ≈ 0.01
     @test JuMP._distance_to_set(1.01, MOI.ZeroOne()) ≈ 0.01
+end
+
+function test_integer()
     @test JuMP._distance_to_set(0.6, MOI.Integer()) ≈ 0.4
     @test JuMP._distance_to_set(3.1, MOI.Integer()) ≈ 0.1
     @test JuMP._distance_to_set(-0.01, MOI.Integer()) ≈ 0.01
     @test JuMP._distance_to_set(1.01, MOI.Integer()) ≈ 0.01
-    @test_throws(
-        ErrorException,
-        JuMP._distance_to_set([1.0], MOI.Zeros(1)),
-    )
+end
+
+function test_semicontinuous()
+    s = MOI.Semicontinuous(2.0, 4.0)
+    @test JuMP._distance_to_set(-2.0, s) ≈ 2.0
+    @test JuMP._distance_to_set(0.5, s) ≈ 0.5
+    @test JuMP._distance_to_set(1.9, s) ≈ 0.1
+    @test JuMP._distance_to_set(2.1, s) ≈ 0.0
+    @test JuMP._distance_to_set(4.1, s) ≈ 0.1
+end
+
+function test_semiintger()
+    s = MOI.Semiinteger(1.9, 4.0)
+    @test JuMP._distance_to_set(-2.0, s) ≈ 2.0
+    @test JuMP._distance_to_set(0.5, s) ≈ 0.5
+    @test JuMP._distance_to_set(1.9, s) ≈ 0.1
+    @test JuMP._distance_to_set(2.1, s) ≈ 0.1
+    @test JuMP._distance_to_set(4.1, s) ≈ 0.1
+end
+
+function test_nonnegatives()
+    @test JuMP._distance_to_set([-1.0, 1.0], MOI.Nonnegatives(2)) ≈ 1.0
+end
+
+function test_nonpositives()
+    @test JuMP._distance_to_set([-1.0, 1.0], MOI.Nonpositives(2)) ≈ 1.0
+end
+
+function test_reals()
+    @test JuMP._distance_to_set([-1.0, 1.0], MOI.Reals(2)) ≈ 0.0
+end
+
+function test_zeros()
+    @test JuMP._distance_to_set([-1.0, 1.0], MOI.Zeros(2)) ≈ sqrt(2)
 end
 
 function test_feasible()
@@ -53,7 +105,7 @@ function test_bounds()
     @test length(report) == 4
 end
 
-function test_affine()
+function test_scalar_affine()
     model = Model()
     @variable(model, x)
     @constraint(model, c1, x <= 0.5)
@@ -66,6 +118,21 @@ function test_affine()
     @test report[c3] ≈ 0.1
     @test report[c4] ≈ 0.5
     @test length(report) == 4
+end
+
+function test_vector_affine()
+    model = Model()
+    @variable(model, x[1:3])
+    @constraint(model, c1, x in MOI.Nonnegatives(3))
+    @constraint(model, c2, x in MOI.Nonpositives(3))
+    @constraint(model, c3, x in MOI.Reals(3))
+    @constraint(model, c4, x in MOI.Zeros(3))
+    report = primal_feasibility_report(model, Dict(x[1] => 1.0, x[2] => -1.0))
+    @test report[c1] ≈ 1.0
+    @test report[c2] ≈ 1.0
+    @test !haskey(report, c3)
+    @test report[c4] ≈ sqrt(2)
+    @test length(report) == 3
 end
 
 function runtests()

--- a/test/feasibility_checker.jl
+++ b/test/feasibility_checker.jl
@@ -105,7 +105,8 @@ function test_feasible()
     @variable(model, 0 <= y <= 2, Int)
     @variable(model, z == 0.5)
     @constraint(model, x + y + z >= 0.5)
-    @test primal_feasibility_report(model, Dict(z => 0.5)) === nothing
+    report = primal_feasibility_report(model, Dict(z => 0.5); atol = 1e-6)
+    @test report === nothing
 end
 
 function test_bounds()
@@ -113,7 +114,8 @@ function test_bounds()
     @variable(model, x, Bin)
     @variable(model, 0 <= y <= 2, Int)
     @variable(model, z == 0.5)
-    report = primal_feasibility_report(model, Dict(x => 0.1, y => 2.1))
+    point = Dict(x => 0.1, y => 2.1)
+    report = primal_feasibility_report(model, point; atol = 1e-6)
     @test report[BinaryRef(x)] ≈ 0.1
     @test report[UpperBoundRef(y)] ≈ 0.1
     @test report[IntegerRef(y)] ≈ 0.1
@@ -128,7 +130,7 @@ function test_scalar_affine()
     @constraint(model, c2, x >= 1.25)
     @constraint(model, c3, x == 1.1)
     @constraint(model, c4, 0 <= x <= 0.5)
-    report = primal_feasibility_report(model, Dict(x => 1.0))
+    report = primal_feasibility_report(model, Dict(x => 1.0); atol = 1e-6)
     @test report[c1] ≈ 0.5
     @test report[c2] ≈ 0.25
     @test report[c3] ≈ 0.1
@@ -143,7 +145,7 @@ function test_scalar_quadratic()
     @constraint(model, c2, x^2 - x >= 1.25)
     @constraint(model, c3, x^2 + x == 1.1)
     @constraint(model, c4, 0 <= x^2 + x <= 0.5)
-    report = primal_feasibility_report(model, Dict(x => 1.0))
+    report = primal_feasibility_report(model, Dict(x => 1.0); atol = 1e-6)
     @test report[c1] ≈ 1.5
     @test report[c2] ≈ 1.25
     @test report[c3] ≈ 0.9
@@ -158,7 +160,8 @@ function test_vector()
     @constraint(model, c2, x in MOI.Nonpositives(3))
     @constraint(model, c3, x in MOI.Reals(3))
     @constraint(model, c4, x in MOI.Zeros(3))
-    report = primal_feasibility_report(model, Dict(x[1] => 1.0, x[2] => -1.0))
+    point = Dict(x[1] => 1.0, x[2] => -1.0)
+    report = primal_feasibility_report(model, point; atol = 1e-6)
     @test report[c1] ≈ 1.0
     @test report[c2] ≈ 1.0
     @test !haskey(report, c3)
@@ -173,7 +176,8 @@ function test_vector_affine()
     @constraint(model, c2, 2 * x in MOI.Nonpositives(3))
     @constraint(model, c3, 2 * x in MOI.Reals(3))
     @constraint(model, c4, 2 * x in MOI.Zeros(3))
-    report = primal_feasibility_report(model, Dict(x[1] => 1.0, x[2] => -1.0))
+    point = Dict(x[1] => 1.0, x[2] => -1.0)
+    report = primal_feasibility_report(model, point; atol = 1e-6)
     @test report[c1] ≈ 2.0
     @test report[c2] ≈ 2.0
     @test !haskey(report, c3)
@@ -188,7 +192,7 @@ function test_nonlinear()
     @NLconstraint(model, c2, sin(x) <= 1.0)
     @NLconstraint(model, c3, exp(x) >= 2.0)
     @NLconstraint(model, c4, x + x^2 - x^3 == 0.5)
-    report = primal_feasibility_report(model, Dict(x => 0.5))
+    report = primal_feasibility_report(model, Dict(x => 0.5); atol = 1e-6)
     @test report[c1] ≈ sin(0.5)
     @test !haskey(report, c2)
     @test report[c3] ≈ 2 - exp(0.5)

--- a/test/feasibility_checker.jl
+++ b/test/feasibility_checker.jl
@@ -1,0 +1,80 @@
+#  Copyright 2017, Iain Dunning, Joey Huchette, Miles Lubin, and contributors
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+module TestFeasibilityChecker
+
+using JuMP
+using Test
+
+function test_distance_to_set()
+    @test JuMP._distance_to_set(1.0, MOI.LessThan(2.0)) ≈ 0.0
+    @test JuMP._distance_to_set(1.0, MOI.LessThan(0.5)) ≈ 0.5
+    @test JuMP._distance_to_set(1.0, MOI.GreaterThan(2.0)) ≈ 1.0
+    @test JuMP._distance_to_set(1.0, MOI.GreaterThan(0.5)) ≈ 0.0
+    @test JuMP._distance_to_set(1.0, MOI.EqualTo(2.0)) ≈ 1.0
+    @test JuMP._distance_to_set(1.0, MOI.EqualTo(0.5)) ≈ 0.5
+    @test JuMP._distance_to_set(1.0, MOI.Interval(1.0, 2.0)) ≈ 0.0
+    @test JuMP._distance_to_set(0.5, MOI.Interval(1.0, 2.0)) ≈ 0.5
+    @test JuMP._distance_to_set(2.75, MOI.Interval(1.0, 2.0)) ≈ 0.75
+    @test JuMP._distance_to_set(0.6, MOI.ZeroOne()) ≈ 0.4
+    @test JuMP._distance_to_set(-0.01, MOI.ZeroOne()) ≈ 0.01
+    @test JuMP._distance_to_set(1.01, MOI.ZeroOne()) ≈ 0.01
+    @test JuMP._distance_to_set(0.6, MOI.Integer()) ≈ 0.4
+    @test JuMP._distance_to_set(3.1, MOI.Integer()) ≈ 0.1
+    @test JuMP._distance_to_set(-0.01, MOI.Integer()) ≈ 0.01
+    @test JuMP._distance_to_set(1.01, MOI.Integer()) ≈ 0.01
+end
+
+function test_feasible()
+    model = Model()
+    @variable(model, x, Bin)
+    @variable(model, 0 <= y <= 2, Int)
+    @variable(model, z == 0.5)
+    @constraint(model, x + y + z >= 0.5)
+    @test primal_feasibility_report(model, Dict(z => 0.5)) === nothing
+end
+
+function test_bounds()
+    model = Model()
+    @variable(model, x, Bin)
+    @variable(model, 0 <= y <= 2, Int)
+    @variable(model, z == 0.5)
+    report = primal_feasibility_report(model, Dict(x => 0.1, y => 2.1))
+    @test report[BinaryRef(x)] ≈ 0.1
+    @test report[UpperBoundRef(y)] ≈ 0.1
+    @test report[IntegerRef(y)] ≈ 0.1
+    @test report[FixRef(z)] ≈ 0.5
+    @test length(report) == 4
+end
+
+function test_affine()
+    model = Model()
+    @variable(model, x)
+    @constraint(model, c1, x <= 0.5)
+    @constraint(model, c2, x >= 1.25)
+    @constraint(model, c3, x == 1.1)
+    @constraint(model, c4, 0 <= x <= 0.5)
+    report = primal_feasibility_report(model, Dict(x => 1.0))
+    @test report[c1] ≈ 0.5
+    @test report[c2] ≈ 0.25
+    @test report[c3] ≈ 0.1
+    @test report[c4] ≈ 0.5
+    @test length(report) == 4
+end
+
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if !startswith("$(name)", "test_")
+            continue
+        end
+        @testset "$(name)" begin
+            getfield(@__MODULE__, name)()
+        end
+    end
+end
+
+end
+
+TestFeasibilityChecker.runtests()

--- a/test/feasibility_checker.jl
+++ b/test/feasibility_checker.jl
@@ -117,14 +117,14 @@ function test_primal_solution()
     @test isempty(report)
 end
 
-
 function test_feasible()
     model = Model()
     @variable(model, x, Bin)
     @variable(model, 0 <= y <= 2, Int)
     @variable(model, z == 0.5)
     @constraint(model, x + y + z >= 0.5)
-    report = primal_feasibility_report(model, Dict(x => 0.0, y => 0.0, z => 0.5))
+    report =
+        primal_feasibility_report(model, Dict(x => 0.0, y => 0.0, z => 0.5))
     @test isempty(report)
 end
 
@@ -134,11 +134,8 @@ function test_missing()
     @variable(model, 0 <= y <= 2, Int)
     @variable(model, z == 0.5)
     @constraint(model, x + y + z >= 0.5)
-    report = primal_feasibility_report(
-        model,
-        Dict(z => 0.0),
-        skip_missing = true,
-    )
+    report =
+        primal_feasibility_report(model, Dict(z => 0.0), skip_missing = true)
     @test report[FixRef(z)] == 0.5
     @test length(report) == 1
 end

--- a/test/feasibility_checker.jl
+++ b/test/feasibility_checker.jl
@@ -120,7 +120,22 @@ function test_scalar_affine()
     @test length(report) == 4
 end
 
-function test_vector_affine()
+function test_scalar_quadratic()
+    model = Model()
+    @variable(model, x)
+    @constraint(model, c1, x^2 + x <= 0.5)
+    @constraint(model, c2, x^2 - x >= 1.25)
+    @constraint(model, c3, x^2 + x == 1.1)
+    @constraint(model, c4, 0 <= x^2 + x <= 0.5)
+    report = primal_feasibility_report(model, Dict(x => 1.0))
+    @test report[c1] ≈ 1.5
+    @test report[c2] ≈ 1.25
+    @test report[c3] ≈ 0.9
+    @test report[c4] ≈ 1.5
+    @test length(report) == 4
+end
+
+function test_vector()
     model = Model()
     @variable(model, x[1:3])
     @constraint(model, c1, x in MOI.Nonnegatives(3))
@@ -132,6 +147,21 @@ function test_vector_affine()
     @test report[c2] ≈ 1.0
     @test !haskey(report, c3)
     @test report[c4] ≈ sqrt(2)
+    @test length(report) == 3
+end
+
+function test_vector_affine()
+    model = Model()
+    @variable(model, x[1:3])
+    @constraint(model, c1, 2 * x in MOI.Nonnegatives(3))
+    @constraint(model, c2, 2 * x in MOI.Nonpositives(3))
+    @constraint(model, c3, 2 * x in MOI.Reals(3))
+    @constraint(model, c4, 2 * x in MOI.Zeros(3))
+    report = primal_feasibility_report(model, Dict(x[1] => 1.0, x[2] => -1.0))
+    @test report[c1] ≈ 2.0
+    @test report[c2] ≈ 2.0
+    @test !haskey(report, c3)
+    @test report[c4] ≈ sqrt(8)
     @test length(report) == 3
 end
 

--- a/test/feasibility_checker.jl
+++ b/test/feasibility_checker.jl
@@ -25,6 +25,10 @@ function test_distance_to_set()
     @test JuMP._distance_to_set(3.1, MOI.Integer()) ≈ 0.1
     @test JuMP._distance_to_set(-0.01, MOI.Integer()) ≈ 0.01
     @test JuMP._distance_to_set(1.01, MOI.Integer()) ≈ 0.01
+    @test_throws(
+        ErrorException,
+        JuMP._distance_to_set([1.0], MOI.Zeros(1)),
+    )
 end
 
 function test_feasible()

--- a/test/feasibility_checker.jl
+++ b/test/feasibility_checker.jl
@@ -181,6 +181,20 @@ function test_vector_affine()
     @test length(report) == 3
 end
 
+function test_nonlinear()
+    model = Model()
+    @variable(model, x)
+    @NLconstraint(model, c1, sin(x) <= 0.0)
+    @NLconstraint(model, c2, sin(x) <= 1.0)
+    @NLconstraint(model, c3, exp(x) >= 2.0)
+    @NLconstraint(model, c4, x + x^2 - x^3 == 0.5)
+    report = primal_feasibility_report(model, Dict(x => 0.5))
+    @test report[c1] ≈ sin(0.5)
+    @test !haskey(report, c2)
+    @test report[c3] ≈ 2 - exp(0.5)
+    @test report[c4] ≈ 0.125
+end
+
 function runtests()
     for name in names(@__MODULE__; all = true)
         if !startswith("$(name)", "test_")

--- a/test/feasibility_checker.jl
+++ b/test/feasibility_checker.jl
@@ -68,18 +68,34 @@ function test_semiintger()
 end
 
 function test_nonnegatives()
+    @test_throws(
+        DimensionMismatch,
+        JuMP._distance_to_set([-1.0, 1.0], MOI.Nonnegatives(1))
+    )
     @test JuMP._distance_to_set([-1.0, 1.0], MOI.Nonnegatives(2)) ≈ 1.0
 end
 
 function test_nonpositives()
+    @test_throws(
+        DimensionMismatch,
+        JuMP._distance_to_set([-1.0, 1.0], MOI.Nonpositives(1))
+    )
     @test JuMP._distance_to_set([-1.0, 1.0], MOI.Nonpositives(2)) ≈ 1.0
 end
 
 function test_reals()
+    @test_throws(
+        DimensionMismatch,
+        JuMP._distance_to_set([-1.0, 1.0], MOI.Reals(1))
+    )
     @test JuMP._distance_to_set([-1.0, 1.0], MOI.Reals(2)) ≈ 0.0
 end
 
 function test_zeros()
+    @test_throws(
+        DimensionMismatch,
+        JuMP._distance_to_set([-1.0, 1.0], MOI.Zeros(1))
+    )
     @test JuMP._distance_to_set([-1.0, 1.0], MOI.Zeros(2)) ≈ sqrt(2)
 end
 


### PR DESCRIPTION
This is a significant item for JuMP 1.0, but there is debate on how
to define and implement distances for different sets. 

See https://github.com/jump-dev/MathOptInterface.jl/pull/1023 for the 
last time this was attempted.

See https://github.com/matbesancon/MathOptSetDistances.jl for a WIP
package exploring the options.

This PR also only addresses primal feasibility. See
https://github.com/joaquimg/FeasibilityOptInterface.jl/pull/1
for a WIP attempt at dual feasibility as well.

In future, the _distance_to_set definitions will be merged into MOI.

This PR is more about defining the JuMP-level interface so we can
change internal details without breaking compatibility of JuMP 1.0.

Edit: for example, if MOI introduces a `AbstractDistance` argument, 
we can add a `; distance = DefaultDistance()` kwarg to `primal_feasibility_report`
without violating compatibility.

For now I've implemented sets for MILP, since this should cover 90% of 
users wishing to implement this. Perhaps for the trickier sets, we can tell
users to load MathOptSetDistances, and that package can contain heavier
dependencies for computing the minimum eigen-value, etc.

Closes #693 

Doc preview: https://jump.dev/JuMP.jl/previews/PR2466/manual/solutions/#Checking-feasibility-of-solutions