### PR TITLE
Fix missing method in Containers when forcing the container type

### DIFF
--- a/src/Containers/container.jl
+++ b/src/Containers/container.jl
@@ -71,12 +71,20 @@ default_container(::ArrayIndices) = Array
 function container(f::Function, indices::ArrayIndices, ::Type{Array})
     return map(I -> f(I...), indices)
 end
-function _oneto(indices)
-    if indices isa UnitRange{Int} && indices == 1:length(indices)
+
+function _oneto(indices::AbstractVector{<:Integer})
+    if indices == 1:length(indices)
         return Base.OneTo(length(indices))
     end
     return error("Index set for array is not one-based interval.")
 end
+
+function _oneto(::Any)
+    return error("Index set for array is not one-based interval.")
+end
+
+_oneto(indices::Base.OneTo) = indices
+
 function container(
     f::Function,
     indices::VectorizedProductIterator,

--- a/test/Containers/macro.jl
+++ b/test/Containers/macro.jl
@@ -25,6 +25,10 @@ using Test
             ErrorException,
             Containers.@container([i=[:a, :b], j=1:2], i + j, container = Array)
         )
+        @test_throws(
+            ErrorException,
+            Containers.@container([i=1:2:4, j=1:2], i + j, container = Array)
+        )
     end
     @testset "DenseAxisArray" begin
         Containers.@container(x[i = 2:3], i^2)

--- a/test/Containers/macro.jl
+++ b/test/Containers/macro.jl
@@ -14,6 +14,18 @@ using Test
         Containers.@container(x[i∈1:3], i^2)
         @test x isa Vector{Int}
     end
+    @testset "Forced array" begin
+        set = 1:2
+        x = Containers.@container([i=set, j=1:2], i + j, container = Array)
+        @test x == [2 3; 3 4]
+        set_2 = [1, 2]
+        y = Containers.@container([i=set_2, j=1:2], i + j, container = Array)
+        @test y == [2 3; 3 4]
+        @test_throws(
+            ErrorException,
+            Containers.@container([i=[:a, :b], j=1:2], i + j, container = Array)
+        )
+    end
     @testset "DenseAxisArray" begin
         Containers.@container(x[i = 2:3], i^2)
         @test x isa Containers.DenseAxisArray{Int,1}


### PR DESCRIPTION
Found when writing docs for https://github.com/jump-dev/JuMP.jl/issues/1663