### PR TITLE
Restructure API Reference material

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -122,10 +122,18 @@ makedocs(
                 _EXAMPLE_SUBDIR,
             ),
         ),
-        "API Reference" => map(
-            file -> joinpath("reference", file),
-            sort(readdir(joinpath(@__DIR__, "src", "reference"))),
-        ),
+        "API Reference" => [
+            "reference/models.md",
+            "reference/variables.md",
+            "reference/expressions.md",
+            "reference/objectives.md",
+            "reference/constraints.md",
+            "reference/containers.md",
+            "reference/solutions.md",
+            "reference/nlp.md",
+            "reference/callbacks.md",
+            "reference/moi.md",
+        ],
         "Developer Docs" => [
             "Extensions" => "developers/extensions.md",
             "Style Guide" => "developers/style.md",

--- a/docs/src/reference/callbacks.md
+++ b/docs/src/reference/callbacks.md
@@ -1,4 +1,4 @@
-# Callback API
+# [Callbacks](@id CallbackAPI)
 
 More information can be found in the [Callbacks](@ref callbacks_manual) section
 of the manual.

--- a/docs/src/reference/callbacks.md
+++ b/docs/src/reference/callbacks.md
@@ -3,8 +3,23 @@
 More information can be found in the [Callbacks](@ref callbacks_manual) section
 of the manual.
 
+## Macros
+
 ```@docs
 @build_constraint
-callback_node_status
+```
+
+## Callback variable primal
+
+```@docs
 callback_value
+MOI.CallbackVariablePrimal
+```
+
+## Callback node status
+
+```@docs
+callback_node_status
+MOI.CallbackNodeStatus
+MOI.CallbackNodeStatusCode
 ```

--- a/docs/src/reference/constraints.md
+++ b/docs/src/reference/constraints.md
@@ -2,16 +2,30 @@
 
 More information can be found in the [Constraints](@ref) section of the manual.
 
+## Macros
+
 ```@docs
 @constraint
 @constraints
 @SDconstraint
 @SDconstraints
+ConstraintRef
+AbstractConstraint
+ScalarConstraint
+VectorConstraint
+```
 
+## Names
+
+```@docs
 name(::ConstraintRef{Model,<:JuMP._MOICON})
 set_name(::ConstraintRef{Model,<:JuMP._MOICON}, ::String)
 constraint_by_name
+```
 
+## Modification
+
+```@docs
 normalized_coefficient
 set_normalized_coefficient
 
@@ -19,21 +33,37 @@ normalized_rhs
 set_normalized_rhs
 
 add_to_function_constant
+```
 
-is_valid
+## Deletion
+
+```@docs
 JuMP.delete
+is_valid
+ConstraintNotOwned
+```
 
+## Query constraints
+
+```@docs
 list_of_constraint_types
-
 all_constraints
-
 num_constraints
+index(::ConstraintRef)
+optimizer_index(::ConstraintRef{Model})
+constraint_object
+```
 
+## Start values
+
+```@docs
 set_dual_start_value
 dual_start_value
+```
 
-ConstraintRef
+## Special sets
 
+```@docs
 SecondOrderCone
 RotatedSecondOrderCone
 PSDCone
@@ -41,21 +71,14 @@ SOS1
 SOS2
 SkewSymmetricMatrixSpace
 SkewSymmetricMatrixShape
-
-AbstractConstraint
-ScalarConstraint
-VectorConstraint
-
-index(::ConstraintRef)
-optimizer_index(::ConstraintRef{Model})
-
-constraint_object
 moi_set
+```
 
+## Printing
+
+```@docs
 function_string
 constraints_string
 in_set_string
 show_constraints_summary
-
-ConstraintNotOwned
 ```

--- a/docs/src/reference/constraints.md
+++ b/docs/src/reference/constraints.md
@@ -1,4 +1,4 @@
-# Constraint API
+# [Constraints](@id ConstraintAPI)
 
 More information can be found in the [Constraints](@ref) section of the manual.
 

--- a/docs/src/reference/containers.md
+++ b/docs/src/reference/containers.md
@@ -1,4 +1,4 @@
-# Containers API
+# [Containers](@id ContainersAPI)
 
 More information can be found in the [Containers](@ref) section of the manual.
 

--- a/docs/src/reference/expressions.md
+++ b/docs/src/reference/expressions.md
@@ -2,27 +2,48 @@
 
 More information can be found in the [Expressions](@ref) section of the manual.
 
+
+## Macros
+
 ```@docs
 @expression
 @expressions
+```
 
+## Affine expressions
+
+```@docs
 GenericAffExpr
 AffExpr
+linear_terms
+```
+
+## Quadratic expressions
+
+
+```@docs
 GenericQuadExpr
 QuadExpr
 UnorderedPair
+quad_terms
+```
 
-add_to_expression!
+## Utilities and modifications
+
+```@docs
 constant
 coefficient
-drop_zeros!
 isequal_canonical
-linear_terms
+add_to_expression!
+drop_zeros!
 map_coefficients
 map_coefficients_inplace!
-quad_terms
-variable_ref_type
+```
 
+## JuMP-to-MOI converters
+
+```@docs
+variable_ref_type
 jump_function
 jump_function_type
 moi_function

--- a/docs/src/reference/expressions.md
+++ b/docs/src/reference/expressions.md
@@ -1,4 +1,4 @@
-# Expression API
+# [Expressions](@id ExpressionAPI)
 
 More information can be found in the [Expressions](@ref) section of the manual.
 

--- a/docs/src/reference/models.md
+++ b/docs/src/reference/models.md
@@ -1,52 +1,68 @@
-# Model API
+# [Models](@id ModelAPI)
 
 More information can be found in the [Models](@ref) section of
 the manual.
 
+## Constructors
+
 ```@docs
 Model
-
 direct_model
+```
 
+## Basic functions
+
+```@docs
+backend
+solver_name
+Base.empty!(::Model)
 mode
-
-set_optimizer
-optimizer_with_attributes
-
 object_dictionary
 unregister
+```
 
-set_silent
-unset_silent
+## Working with attributes
 
-set_time_limit_sec
-unset_time_limit_sec
-time_limit_sec
-
-solver_name
-
-backend
-
-Base.empty!(::Model)
-
+```@docs
+set_optimizer
+optimizer_with_attributes
 get_optimizer_attribute
 set_optimizer_attribute
 set_optimizer_attributes
+set_silent
+unset_silent
+set_time_limit_sec
+unset_time_limit_sec
+time_limit_sec
+```
 
-bridge_constraints
-print_bridge_graph
+## Copying
 
-write_to_file
-Base.write(::IO, ::Model; ::MOI.FileFormats.FileFormat)
-
-read_from_file
-Base.read(::IO, ::Type{Model}; ::MOI.FileFormats.FileFormat)
-
+```@docs
 ReferenceMap
 copy_model
 copy_extension_data
 Base.copy(::AbstractModel)
+```
+## I/O
 
+```@docs
+write_to_file
+Base.write(::IO, ::Model; ::MOI.FileFormats.FileFormat)
+read_from_file
+Base.read(::IO, ::Type{Model}; ::MOI.FileFormats.FileFormat)
+```
+
+## Bridge tools
+
+```@docs
+bridge_constraints
+print_bridge_graph
+```
+
+## Extension tools
+
+```@docs
 operator_warn
 error_if_direct_mode
 ```

--- a/docs/src/reference/moi.md
+++ b/docs/src/reference/moi.md
@@ -1,4 +1,4 @@
-# MathOptInterface API
+# [MathOptInterface](@id MOIAPI)
 
 This page contains extracts from the `MathOptInterface` documentation. More
 information can be found at in the [MathOptInterface documentation](https://jump.dev/MathOptInterface.jl/stable/).

--- a/docs/src/reference/moi.md
+++ b/docs/src/reference/moi.md
@@ -4,12 +4,8 @@ This page contains extracts from the `MathOptInterface` documentation. More
 information can be found at in the [MathOptInterface documentation](https://jump.dev/MathOptInterface.jl/stable/).
 
 ```@docs
-MOI.CallbackNodeStatus
-MOI.CallbackNodeStatusCode
-MOI.CallbackVariablePrimal
-
 MOI.get
-
+MOI.optimize!
 MOIU.reset_optimizer(::JuMP.Model)
 MOIU.drop_optimizer(::JuMP.Model)
 MOIU.attach_optimizer(::JuMP.Model)

--- a/docs/src/reference/nlp.md
+++ b/docs/src/reference/nlp.md
@@ -3,21 +3,48 @@
 More information can be found in the [Nonlinear Modeling](@ref) section of the
 manual.
 
+## [Constraints](@id ref_nl_constraints)
+
 ```@docs
 @NLconstraint
 @NLconstraints
+NonlinearConstraintIndex
+num_nl_constraints
+add_NL_constraint
+```
+
+## [Expressions](@id ref_nl_expressions)
+
+```@docs
 @NLexpression
 @NLexpressions
+NonlinearExpression
+```
+
+## [Objectives](@id ref_nl_objectives)
+
+```@docs
 @NLobjective
+set_NL_objective
+```
+
+## [Parameters](@id ref_nl_parameters)
+
+```@docs
 @NLparameter
+NonlinearParameter
 value(::JuMP.NonlinearParameter)
 set_value(::JuMP.NonlinearParameter, ::Number)
-num_nl_constraints
+```
+
+## User-defined functions
+
+```@docs
 register
-set_NL_objective
-add_NL_constraint
+```
+
+## Derivatives
+
+```@docs
 NLPEvaluator
-NonlinearConstraintIndex
-NonlinearExpression
-NonlinearParameter
 ```

--- a/docs/src/reference/nlp.md
+++ b/docs/src/reference/nlp.md
@@ -1,4 +1,4 @@
-# Nonlinear API
+# [Nonlinear Modeling](@id NonlinearAPI)
 
 More information can be found in the [Nonlinear Modeling](@ref) section of the
 manual.

--- a/docs/src/reference/objectives.md
+++ b/docs/src/reference/objectives.md
@@ -1,4 +1,4 @@
-# Objective API
+# [Objectives](@id ObjectiveAPI)
 
 More information can be found in the [Objectives](@ref) section of the manual.
 

--- a/docs/src/reference/objectives.md
+++ b/docs/src/reference/objectives.md
@@ -2,18 +2,22 @@
 
 More information can be found in the [Objectives](@ref) section of the manual.
 
+## Objective functions
+
 ```@docs
 @objective
-
 objective_function
-objective_function_type
-objective_sense
-
-set_objective
-set_objective_coefficient
 set_objective_function
-set_objective_sense
-
+set_objective_coefficient
+set_objective
+objective_function_type
 objective_function_string
 show_objective_function_summary
+```
+
+## Objective sense
+
+```@docs
+objective_sense
+set_objective_sense
 ```

--- a/docs/src/reference/solutions.md
+++ b/docs/src/reference/solutions.md
@@ -3,50 +3,72 @@
 More information can be found in the [Querying Solutions](@ref) section of the
 manual.
 
+
+## Basic utilities
+
 ```@docs
 JuMP.optimize!
 NoOptimizer
+OptimizeNotCalled
+```
 
+## Termination status
+
+```@docs
 termination_status
 MOI.TerminationStatusCode
-
 raw_status
-primal_status
-MOI.ResultStatusCode
-
 result_count
+```
 
+## Primal solutions
+
+```@docs
+primal_status
 has_values
 value
+MOI.ResultStatusCode
+```
 
+## Dual solutions
+
+```@docs
 dual_status
 has_duals
 dual
 shadow_price
 reduced_cost
+```
 
-objective_bound
+## Basic attributes
+
+```@docs
 objective_value
+objective_bound
 dual_objective_value
-
 solve_time
 relative_gap
 simplex_iterations
 barrier_iterations
 node_count
+```
 
-OptimizeNotCalled
-MOI.optimize!
+## [Conflicts](@id ref_conflicts)
 
+```@docs
 JuMP.compute_conflict!
 MOI.compute_conflict!
 MOI.ConflictStatus
 MOI.ConflictStatusCode
 MOI.ConstraintConflictStatus
 MOI.ConflictParticipationStatusCode
+```
 
-lp_objective_perturbation_range
-lp_rhs_perturbation_range
+## Sensitivity
+
+```@docs
 lp_sensitivity_report
 SensitivityReport
+lp_objective_perturbation_range
+lp_rhs_perturbation_range
 ```

--- a/docs/src/reference/solutions.md
+++ b/docs/src/reference/solutions.md
@@ -1,4 +1,4 @@
-# Solution API
+# [Solutions](@id SolutionAPI)
 
 More information can be found in the [Querying Solutions](@ref) section of the
 manual.

--- a/docs/src/reference/variables.md
+++ b/docs/src/reference/variables.md
@@ -1,4 +1,4 @@
-# Variable API
+# [Variables](@id VariableAPI)
 
 More information can be found in the [Variables](@ref) section of the manual.
 

--- a/docs/src/reference/variables.md
+++ b/docs/src/reference/variables.md
@@ -2,62 +2,103 @@
 
 More information can be found in the [Variables](@ref) section of the manual.
 
+## Macros
+
 ```@docs
 @variable
 @variables
+```
 
+## Basic utilities
+
+```@docs
+VariableRef
+num_variables
+all_variables
+owner_model
+index(::VariableRef)
+optimizer_index(::VariableRef)
+check_belongs_to_model
+VariableNotOwned
+VariableConstrainedOnCreation
+VariablesConstrainedOnCreation
+```
+
+## Names
+
+```@docs
 name(::JuMP.VariableRef)
 set_name(::JuMP.VariableRef, ::String)
 variable_by_name
+```
 
+## Start values
+
+```@docs
 set_start_value
 start_value
+```
 
+## Lower bounds
+
+```@docs
 has_lower_bound
 lower_bound
 set_lower_bound
 delete_lower_bound
 LowerBoundRef
+```
 
+## Upper bounds
+
+```@docs
 has_upper_bound
 upper_bound
 set_upper_bound
 delete_upper_bound
 UpperBoundRef
+```
 
+## Fixed bounds
+
+```@docs
 is_fixed
 fix_value
 fix
 unfix
 FixRef
+```
 
+## Integer variables
+
+```@docs
 is_integer
 set_integer
 unset_integer
 IntegerRef
+```
 
+## Binary variables
+
+```@docs
 is_binary
 set_binary
 unset_binary
 BinaryRef
+```
 
+## Integrality utilities
+
+```@docs
 relax_integrality
+```
 
-all_variables
-owner_model
-num_variables
-VariableRef
-index(::VariableRef)
-optimizer_index(::VariableRef)
+## Extensions
 
-add_variable
-check_belongs_to_model
-build_variable
-parse_one_operator_variable
-
+```@docs
 AbstractVariable
 AbstractVariableRef
-VariableNotOwned
-VariableConstrainedOnCreation
-VariablesConstrainedOnCreation
+add_variable
+build_variable
+parse_one_operator_variable
 ```


### PR DESCRIPTION
Previously, were just long unstructured lists. Now there is structure, and the layout of the pages matches that of the manual.