### PR TITLE
WIP: only bridge if needed

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -712,7 +712,7 @@ the attribute MathOptInterface.SolveTime()" if the attribute is
 not implemented.
 """
 function solve_time(model::Model)
-    return MOI.get(model, MOI.SolveTime())
+    return MOI.get(model, MOI.SolveTimeSec())
 end
 
 """

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -555,7 +555,7 @@ end
 function AffExpr(m::Model, f::MOI.ScalarAffineFunction)
     aff = AffExpr()
     for t in f.terms
-        add_to_expression!(aff, t.coefficient, VariableRef(m, t.variable_index))
+        add_to_expression!(aff, t.coefficient, VariableRef(m, t.variable))
     end
     aff.constant = f.constant
     return aff

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -531,8 +531,8 @@ function QuadExpr(m::Model, f::MOI.ScalarQuadraticFunction)
         AffExpr(m, MOI.ScalarAffineFunction(f.affine_terms, f.constant)),
     )
     for t in f.quadratic_terms
-        v1 = t.variable_index_1
-        v2 = t.variable_index_2
+        v1 = t.variable_1
+        v2 = t.variable_2
         coef = t.coefficient
         if v1 == v2
             coef /= 2

--- a/test/print.jl
+++ b/test/print.jl
@@ -928,7 +928,7 @@ end
     MOI.set(mockoptimizer, MOI.SimplexIterations(), 1)
     MOI.set(mockoptimizer, MOI.BarrierIterations(), 1)
     MOI.set(mockoptimizer, MOI.NodeCount(), 1)
-    MOI.set(mockoptimizer, MOI.SolveTime(), 5.0)
+    MOI.set(mockoptimizer, MOI.SolveTimeSec(), 5.0)
 
     @test sprint(show, solution_summary(model)) == """
 * Solver : Mock


### PR DESCRIPTION
JuMP code to go with the MOI PR https://github.com/jump-dev/MathOptInterface.jl/pull/1252.

If we lazily bridge the lazy bridges, we get much improved speed in the case that the user writes a model without bridges. (The first two benchmark calls.) This comes from avoiding a copy, and from not having to infer the bridging call-chain.

Importantly, because JuMP already has a `MOI.AbstractOptimizer` backend, there are no performance implications when bridges are used.

For now I've just added a new function, but we could add this as opt-in to the standard `Model` constructor, and change it to the default in the next breaking JuMP release.

```Julia
julia> using BenchmarkTools

julia> @btime old_foo()
  570.573 μs (2429 allocations: 175.06 KiB)

julia> @btime new_foo()
  176.522 μs (962 allocations: 82.81 KiB)

julia> @btime old_foo_obj()
  581.474 μs (2438 allocations: 175.31 KiB)

julia> @btime new_foo_obj()
  581.940 μs (2437 allocations: 175.23 KiB)

julia> @btime old_foo_var()
  1.002 ms (2801 allocations: 203.28 KiB)

julia> @btime new_foo_var()
  1.002 ms (2801 allocations: 203.22 KiB)

julia> @btime old_foo_con()
  915.958 μs (2628 allocations: 188.42 KiB)

julia> @btime new_foo_con()
  921.349 μs (2628 allocations: 188.38 KiB)
```

## Code

```julia
using JuMP, Clp

### No bridging

function new_foo()
    model = AutoModel(Clp.Optimizer)
    set_silent(model)
    @variable(model, x >= 0)
    @constraint(model, 2x + 1 <= 1)
    @objective(model, Max, 1.0 * x)
    optimize!(model)
end

function old_foo()
    model = Model(Clp.Optimizer)
    set_silent(model)
    @variable(model, x >= 0)
    @constraint(model, 2x + 1 <= 1)
    @objective(model, Max, 1.0 * x)
    optimize!(model)
end

### ObjectiveFunction bridging

function new_foo_obj()
    model = AutoModel(Clp.Optimizer)
    set_silent(model)
    @variable(model, x >= 0)
    @constraint(model, 2x + 1 <= 1)
    @objective(model, Max, x)
    optimize!(model)
end

function old_foo_obj()
    model = Model(Clp.Optimizer)
    set_silent(model)
    @variable(model, x >= 0)
    @constraint(model, 2x + 1 <= 1)
    @objective(model, Max, x)
    optimize!(model)
end

### variable bridging

function old_foo_var()
    model = Model(Clp.Optimizer)
    set_silent(model)
    @variable(model, x[1:1] in MOI.Nonnegatives(1))
    @constraint(model, 2x[1] + 1 <= 1)
    @objective(model, Max, 1.0 * x[1])
    optimize!(model)
end

function new_foo_var()
    model = AutoModel(Clp.Optimizer)
    set_silent(model)
    @variable(model, x[1:1] in MOI.Nonnegatives(1))
    @constraint(model, 2x[1] + 1 <= 1)
    @objective(model, Max, 1.0 * x[1])
    optimize!(model)
end

### constraint bridging

function old_foo_con()
    model = Model(Clp.Optimizer)
    set_silent(model)
    @variable(model, x[1:2])
    @constraint(model, x in MOI.Nonpositives(2))
    @objective(model, Max, 1.0 * x[1])
    optimize!(model)
end

function new_foo_con()
    model = AutoModel(Clp.Optimizer)
    set_silent(model)
    @variable(model, x[1:2])
    @constraint(model, x in MOI.Nonpositives(2))
    @objective(model, Max, 1.0 * x[1])
    optimize!(model)
end
```