### PR TITLE
Improve performance of value(NonlinearExpression)

### DIFF
--- a/src/_Derivatives/forward.jl
+++ b/src/_Derivatives/forward.jl
@@ -36,7 +36,7 @@ function forward_eval(
     adj,
     const_values,
     parameter_values,
-    x_values::AbstractVector{T},
+    x_values,
     subexpression_values,
     user_input_buffer,
     user_output_buffer,

--- a/src/_Derivatives/forward.jl
+++ b/src/_Derivatives/forward.jl
@@ -54,7 +54,7 @@ function forward_eval(
         # compute the value of node k
         @inbounds nod = nd[k]
         partials_storage[k] = zero(T)
-        if nod.nodetype == VARIABLE
+        if nod.nodetype == VARIABLE || nod.nodetype == MOIVARIABLE
             @inbounds storage[k] = x_values[nod.index]
         elseif nod.nodetype == VALUE
             @inbounds storage[k] = const_values[nod.index]

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -1689,9 +1689,7 @@ function value(ex::NonlinearExpression, var_value::Function)
     subexpressions = Vector{NodeData}[nl_expr.nd for nl_expr in nlp_data.nlexpr]
     original_ex = nlp_data.nlexpr[ex.index]
     ex_nd = original_ex.nd
-    main_expressions = Vector{NodeData}[ex_nd]
-    subexpression_order, _ =
-        order_subexpressions(main_expressions, subexpressions)
+    subexpression_order = order_subexpression(ex_nd, subexpressions)
     max_len = length(ex_nd)
     for k in subexpression_order
         max_len = max(max_len, length(subexpressions[k]))


### PR DESCRIPTION
Closes #746 

### Before

```
 25.632534 seconds (255.83 M allocations: 44.247 GiB, 28.27% gc time)
```

### After

<s>` 15.168178 seconds (178.42 M allocations: 23.602 GiB, 32.04% gc time)`</s>

<s>The new bottleneck is `order_subexpressions`</s>

![image](https://user-images.githubusercontent.com/8177701/109719194-2f01d380-7c0d-11eb-831e-f3abc60c6d9a.png)

Fixed
```
  1.497348 seconds (2.21 M allocations: 977.662 MiB, 41.23% gc time)
```

![image](https://user-images.githubusercontent.com/8177701/109730540-82305200-7c1e-11eb-9b6d-a7b2fe1a295a.png)

## Code

```Julia
using JuMP, Ipopt
function main(n)
    m = Model(Ipopt.Optimizer)
    γ = 2
    ρ = 0.05
    r = 0.041
    μR = 0.051
    ζ = 1.5
    σR = sqrt((ζ/γ+ 1)/2*(μR-r)^2/(ρ - r))
    amin = -0.3
    amax = 1e4
    x = map(x-> x + 5 * x^10, range(0, stop = 1, length = n))
    a = (amax-amin) / (maximum(x) - minimum(x)) * x .+ amin
    z = 3.0 * [0.01, 0.03]
    λ = [0.5, 0.5]
    @variable(m, V[i=1:n, j=1:2], start = (z[j] +  r * a[i])^(1-γ) / (1-γ) / ρ)
    @NLexpression(m, Vpb1[j=1:2], (z[j] + a[1] * r)^(-γ))
    @NLexpression(m, Vpbo[i=2:n, j=1:2], (V[i,j] - V[i-1,j]) / (a[i] - a[i-1]))
    @NLexpression(m, Vpb[i=1:n, j=1:2], (i==1) * Vpb1[j] + (i>1) * Vpbo[max(i, 2), j])
    @NLexpression(m, Vpfo[i=1:(n-1), j=1:2], (V[i+1,j] - V[i,j]) / (a[i+1] - a[i]))
    @NLexpression(m, Vpfn[j=1:2], (z[j] + a[n] * r + (μR-r)^2/(γ * σR^2) * a[n])^(-γ))
    @NLexpression(m, Vpf[i=1:n, j=1:2], (i==n) * Vpfn[j] + (i<n) * Vpfo[min(i, n-1), j])
    @NLexpression(m, Vp[i=1:n, j=1:2, s=1:2], (s==1) * Vpb[i, j] + (s==2) * Vpf[i, j])
    @NLexpression(m, Vpp1[j=1:2], 0.0)
    @NLexpression(m, Vppn[j=1:2], - γ * Vp[n, j, 1] / a[n])
    @NLexpression(m, Vppo[i=2:(n-1), j=1:2], ((a[i] - a[i-1]) * V[i+1,j] + (a[i+1] - a[i]) * V[i-1,j] - (a[i+1]- a[i-1]) * V[i,j]) / (0.5 * (a[i+1] - a[i-1]) * (a[i+1] - a[i]) * (a[i] - a[i-1])))
    @NLexpression(m, Vpp[i=1:n, j=1:2], (i==1) * Vpp1[j] + (i==n) * Vppn[j] + (i>1) * (i<n) * Vppo[min(max(i,2), n-1), j])
    @NLexpression(m, c[i=1:n, j=1:2, s=1:2], abs(Vp[i,j,s])^(-1/γ))
    @NLexpression(m, k1[j=1:2, s=1:2], 0.0)
    @NLexpression(m, ko[i=2:n, j=1:2, s=1:2], (- Vp[i,j,s] / Vpp[i,j]) * (μR - r) / σR^2)
    @NLexpression(m, kk[i=1:n, j=1:2, s=1:2], (i==1) * k1[j,s]  + (i>1) * ko[max(i, 2),j,s])
    @NLexpression(m, k[i=1:n, j=1:2, s=1:2], (kk[i,j,s] <= (a[i] - a[1])) * (kk[i,j,s] >= 0) * kk[i, j,s]  + (kk[i,j,s] >= (a[i]-a[1])) * (a[i]-a[1]))
    @NLexpression(m, savings[i=1:n, j=1:2, s=1:2],  (z[j] + r * a[i] + (μR - r) * k[i, j, s] - c[i, j, s]))
    @NLexpression(m, UVp[i=1:n, j=1:2], (savings[i, j, 1] <= 0) * Vp[i, j, 1] +  (savings[i, j, 1] > 0) * (savings[i, j, 2] >= 0) * Vp[i, j, 2])
    @NLexpression(m, Uk[i=1:n, j=1:2], (savings[i, j, 1] <= 0) * k[i, j, 1] +  (savings[i, j, 1] > 0) * (savings[i, j, 2] >= 0) * k[i, j, 2] + (savings[i, j, 1] > 0) * (savings[i, j, 2] < 0) * (k[i,j,1]+k[i,j,2])/2)
    @NLexpression(m, Uc[i=1:n, j=1:2], (savings[i, j, 1] <= 0) * c[i, j, 1] +  (savings[i, j, 1] > 0) * (savings[i, j, 2] >= 0) * c[i, j, 2] + (savings[i, j, 1] > 0) * (savings[i, j, 2] < 0) * (z[j] + r * a[i] + (μR-r) * Uk[i,j]))
    @NLexpression(m, HJB[i=1:n, j=1:2], Uc[i,j]^(1 - γ) / (1 - γ) + UVp[i,j] * (z[j] + r * a[i] + (μR - r) *Uk[i, j] - Uc[i, j]) + Vpp[i,j] * 0.5 * Uk[i,j]^2 * σR^2 + λ[j] * (V[i, (j==1) * 2 + (j==2) * 1]- V[i, j]))
    @NLconstraint(m, CHJB[i=1:n, j=1:2], ρ * V[i, j] == HJB[i, j])
    @NLobjective(m, Max, 1.0)
    optimize!(m)
    return value.(c)
end

@time main(500);
```