### PR TITLE
Register NLparameters and pretty print them

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1750,6 +1750,7 @@ macro NLparameter(m, ex, extra...)
     # TODO: NLparameters are not registered in the model because we don't yet
     # have an anonymous version.
     macro_code = _macro_assign_and_return(creation_code, variable,
-                                          Containers._get_name(c))
+                                          Containers._get_name(c),
+                                          model_for_registering = esc_m)
     return _finalize_macro(esc_m, macro_code, __source__)
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1750,7 +1750,6 @@ macro NLparameter(m, ex, extra...)
     # TODO: NLparameters are not registered in the model because we don't yet
     # have an anonymous version.
     macro_code = _macro_assign_and_return(creation_code, variable,
-                                          Containers._get_name(c),
-                                          model_for_registering = esc_m)
+                                          Containers._get_name(c))
     return _finalize_macro(esc_m, macro_code, __source__)
 end

--- a/src/print.jl
+++ b/src/print.jl
@@ -754,7 +754,13 @@ function function_string(::Type{<:PrintMode}, p::NonlinearExpression)
 end
 
 function function_string(::Type{<:PrintMode}, p::NonlinearParameter)
-    return "Reference to nonlinear parameter #$(p.index)"
+    relevant_parameters = filter(i->i[2] isa NonlinearParameter && i[2].index==p.index, p.m.obj_dict)
+    if length(relevant_parameters) == 1
+        par_name = first(relevant_parameters)[1]
+        return "Reference to nonlinear parameter $(par_name)"
+    else
+        return "Reference to nonlinear parameter #$(p.index)"
+    end
 end
 
 function Base.show(io::IO, ex::Union{NonlinearExpression,NonlinearParameter})

--- a/test/print.jl
+++ b/test/print.jl
@@ -180,6 +180,12 @@ end
         io_test(REPLMode, param, "\"Reference to nonlinear parameter #1\"")
     end
 
+    @testset "Registered nonlinear parameters" begin
+        model = Model()
+        model[:param] = @NLparameter(model, param == 1.0)
+        io_test(REPLMode, param, "\"Reference to nonlinear parameter param\"")
+    end
+
     @testset "NLPEvaluator" begin
         model = Model()
         evaluator = JuMP.NLPEvaluator(model)
@@ -242,6 +248,27 @@ end
         @variable(model, x)
         expr = @NLexpression(model, x + 1)
         @NLparameter(model, param == 1.0)
+
+        constr = @NLconstraint(model, expr - param <= 0)
+        io_test(
+            REPLMode,
+            constr,
+            "(subexpression[1] - parameter[1]) - 0.0 $le 0",
+        )
+        io_test(
+            IJuliaMode,
+            constr,
+            "(subexpression_{1} - parameter_{1}) - 0.0 \\leq 0",
+        )
+    end
+
+    @testset "Nonlinear constraints with embedded registered parameters/expressions" begin
+        le = JuMP._math_symbol(REPLMode, :leq)
+
+        model = Model()
+        @variable(model, x)
+        expr = @NLexpression(model, x + 1)
+        model[:param] = @NLparameter(model, param == 1.0)
 
         constr = @NLconstraint(model, expr - param <= 0)
         io_test(

--- a/test/print.jl
+++ b/test/print.jl
@@ -274,12 +274,12 @@ end
         io_test(
             REPLMode,
             constr,
-            "(subexpression[1] - parameter[1]) - 0.0 $le 0",
+            "(subexpression[1] - param) - 0.0 $le 0",
         )
         io_test(
             IJuliaMode,
             constr,
-            "(subexpression_{1} - parameter_{1}) - 0.0 \\leq 0",
+            "(subexpression_{1} - param) - 0.0 \\leq 0",
         )
     end
 


### PR DESCRIPTION
Fixes https://github.com/jump-dev/JuMP.jl/issues/2509.

I have to admit I'm not sure this makes sense or whether the implementation is a good idea. But it does start to print the parameter name in the `show` output rather than writing `parameter_1` etc :) But in any case, someone with a better understanding of the code base needs to weigh in and say whether this could potentially work or not.