### PR TITLE
Allow slicing of DenseAxisArray

### DIFF
--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -36,6 +36,10 @@ end
 
 Base.getindex(x::_AxisLookup{Dict{K,Int}}, key::K) where {K} = x.data[key]
 
+function Base.get(x::_AxisLookup{Dict{K,Int}}, key::K, default) where {K}
+    return get(x.data, key, default)
+end
+
 # _AxisLookup{<:Base.OneTo}: This one is an easy optimization, and avoids the
 # unnecessary Dict lookup.
 
@@ -43,6 +47,13 @@ build_lookup(ax::Base.OneTo) = _AxisLookup(ax)
 function Base.getindex(ax::_AxisLookup{<:Base.OneTo}, k::Integer)
     if !(1 <= k <= length(ax.data))
         throw(KeyError(k))
+    end
+    return k
+end
+
+function Base.get(ax::_AxisLookup{<:Base.OneTo}, k::Integer, default)
+    if !(1 <= k <= length(ax.data))
+        return default
     end
     return k
 end
@@ -60,6 +71,18 @@ function Base.getindex(
     i = key - x.data[1] + 1
     if !(1 <= i <= x.data[2])
         throw(KeyError(key))
+    end
+    return i
+end
+
+function Base.get(
+    x::_AxisLookup{Tuple{T,T}},
+    key::Integer,
+    default,
+) where {T<:Integer}
+    i = key - x.data[1] + 1
+    if !(1 <= i <= x.data[2])
+        return default
     end
     return i
 end

--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -309,9 +309,8 @@ function Base.getindex(
     a::DenseAxisArrayKeys{T,S,N},
     args::Vararg{Int,N},
 ) where {T,S,N}
-    return DenseAxisArrayKey(
-        ntuple(k -> getindex(a.product_iter.iterators[k], args[k]), Val(N)),
-    )
+    key = _getindex_recurse(a.product_iter.iterators, args, x -> true)
+    return DenseAxisArrayKey(key)
 end
 
 function Base.IndexStyle(::Type{DenseAxisArrayKeys{T,N,Ax}}) where {T,N,Ax}

--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -39,6 +39,8 @@ function build_lookup(ax)
 end
 
 Base.getindex(x::_AxisLookup{Dict{K,Int}}, key::K) where {K} = x.data[key]
+# Fix ambiguity with fallback method.
+Base.getindex(::_AxisLookup{Dict{<:Any,Int}}, key::Colon) = key
 
 function Base.getindex(
     x::_AxisLookup{Dict{K,Int}},

--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -228,11 +228,8 @@ Base.eachindex(A::DenseAxisArray) = CartesianIndices(size(A.data))
 function Base.to_index(A::DenseAxisArray{T,N}, idx) where {T,N}
     if length(idx) < N
         throw(BoundsError(A, idx))
-    end
-    for i = (N+1):length(idx)
-        if !isone(idx[i])
-            throw(KeyError(idx))
-        end
+    elseif any(i -> !isone(idx[i]), (N+1):length(idx))
+        throw(KeyError(idx))
     end
     return ntuple(Val(N)) do k
         return getindex(A.lookup[k], idx[k])

--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -9,7 +9,8 @@
 # https://github.com/JuliaArrays/AxisArrays.jl/issues/117
 # https://github.com/JuliaArrays/AxisArrays.jl/issues/84
 
-struct DenseAxisArray{T,N,Ax,L<:NTuple{N,Dict}} <: AbstractArray{T,N}
+
+struct DenseAxisArray{T,N,Ax,L<:NTuple{N,Union{Base.OneTo,Dict}}} <: AbstractArray{T,N}
     data::Array{T,N}
     axes::Ax
     lookup::L
@@ -27,6 +28,8 @@ function build_lookup(ax)
     end
     return d
 end
+
+build_lookup(ax::Base.OneTo) = ax
 
 """
     DenseAxisArray(data::Array{T, N}, axes...) where {T, N}

--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -300,12 +300,16 @@ function Base.keys(a::DenseAxisArray)
     return DenseAxisArrayKeys(a)
 end
 Base.getindex(a::DenseAxisArrayKeys, idx::CartesianIndex) = a[idx.I...]
+
 function Base.getindex(
     a::DenseAxisArrayKeys{T,S,N},
     args::Vararg{Int,N},
 ) where {T,S,N}
-    return DenseAxisArrayKey(_to_index_tuple(args, a.product_iter.iterators))
+    return DenseAxisArrayKey(
+        ntuple(k -> getindex(a.product_iter.iterators[k], args[k]), Val(N)),
+    )
 end
+
 function Base.IndexStyle(::Type{DenseAxisArrayKeys{T,N,Ax}}) where {T,N,Ax}
     return IndexCartesian()
 end

--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -40,7 +40,7 @@ end
 
 Base.getindex(x::_AxisLookup{Dict{K,Int}}, key::K) where {K} = x.data[key]
 # Fix ambiguity with fallback method, although this probably never gets called.
-Base.getindex(::_AxisLookup{Dict{Colon,Int}}, key::Colon) = key
+Base.getindex(::_AxisLookup{Dict{K,Int}}, key::Colon) where {K} = key
 
 function Base.getindex(
     x::_AxisLookup{Dict{K,Int}},

--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -39,8 +39,8 @@ function build_lookup(ax)
 end
 
 Base.getindex(x::_AxisLookup{Dict{K,Int}}, key::K) where {K} = x.data[key]
-# Fix ambiguity with fallback method.
-Base.getindex(::_AxisLookup{Dict{<:Any,Int}}, key::Colon) = key
+# Fix ambiguity with fallback method, although this probably never gets called.
+Base.getindex(::_AxisLookup{Dict{Colon,Int}}, key::Colon) = key
 
 function Base.getindex(
     x::_AxisLookup{Dict{K,Int}},

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -220,11 +220,7 @@ And data, a 0-dimensional $(Array{Int,0}):
         @test (@inferred A[:a, :b]) == 6.0
         @test (@inferred A[:a, :b, 1]) == 6.0
         @test (@inferred A[:b, :a]) == 7.0
-        if VERSION >= v"1.6.0-DEV"
-            @test (@inferred A[[:a, :b], [:a, :b]]) == A
-        else
-            @test_broken (@inferred A[[:a, :b], [:a, :b]]) == A
-        end
+        @test (@inferred A[[:a, :b], [:a, :b]]) == A
         @test A[[:a, :b], [:a, :b]] == A
         @test A[:a, [:a, :b]] == DenseAxisArray([5.0, 6.0], [:a, :b])
         @test A[[:a, :b], :b] == DenseAxisArray([6.0, 8.0], [:a, :b])
@@ -237,11 +233,7 @@ And data, a 0-dimensional $(Array{Int,0}):
 
         @test (@inferred B[1, :b]) == 6.0
         @test (@inferred B[2, :a]) == 7.0
-        if VERSION >= v"1.6.0-DEV"
-            @test (@inferred B[1:2, [:a, :b]]) == B
-        else
-            @test_broken (@inferred B[1:2, [:a, :b]]) == B
-        end
+        @test (@inferred B[1:2, [:a, :b]]) == B
         @test B[1:2, [:a, :b]] == B
         @test B[1, [:a, :b]] == DenseAxisArray([5.0, 6.0], [:a, :b])
         @test B[1:2, :b] == DenseAxisArray([6.0, 8.0], 1:2)
@@ -253,11 +245,7 @@ And data, a 0-dimensional $(Array{Int,0}):
         @test !isassigned(C, 4, :b)
         @test (@inferred C[2, :b]) == 6.0
         @test (@inferred C[3, :a]) == 7.0
-        if VERSION >= v"1.6.0-DEV"
-            @test (@inferred C[2:3, [:a, :b]]) == C
-        else
-            @test_broken (@inferred C[2:3, [:a, :b]]) == C
-        end
+        @test (@inferred C[2:3, [:a, :b]]) == C
         @test C[2:3, [:a, :b]] == C
         @test C[2, [:a, :b]] == DenseAxisArray([5.0, 6.0], [:a, :b])
         @test C[2:3, :b] == DenseAxisArray([6.0, 8.0], 2:3)

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -221,9 +221,8 @@ And data, a 0-dimensional $(Array{Int,0}):
         @test (@inferred A[:a, :b, 1]) == 6.0
         @test (@inferred A[:b, :a]) == 7.0
         @test (@inferred A[[:a, :b], [:a, :b]]) == A
-        @test A[[:a, :b], [:a, :b]] == A
-        @test A[:a, [:a, :b]] == DenseAxisArray([5.0, 6.0], [:a, :b])
-        @test A[[:a, :b], :b] == DenseAxisArray([6.0, 8.0], [:a, :b])
+        @test (@inferred A[:a, [:a, :b]]) == DenseAxisArray([5.0, 6.0], [:a, :b])
+        @test (@inferred A[[:a, :b], :b]) == DenseAxisArray([6.0, 8.0], [:a, :b])
 
         B = DenseAxisArray([5.0 6.0; 7.0 8.0], Base.OneTo(2), [:a, :b])
         @test B.lookup[1] isa Containers._AxisLookup{Base.OneTo{Int}}
@@ -234,9 +233,8 @@ And data, a 0-dimensional $(Array{Int,0}):
         @test (@inferred B[1, :b]) == 6.0
         @test (@inferred B[2, :a]) == 7.0
         @test (@inferred B[1:2, [:a, :b]]) == B
-        @test B[1:2, [:a, :b]] == B
-        @test B[1, [:a, :b]] == DenseAxisArray([5.0, 6.0], [:a, :b])
-        @test B[1:2, :b] == DenseAxisArray([6.0, 8.0], 1:2)
+        @test (@inferred B[1, [:a, :b]]) == DenseAxisArray([5.0, 6.0], [:a, :b])
+        @test (@inferred B[1:2, :b]) == DenseAxisArray([6.0, 8.0], 1:2)
 
         C = DenseAxisArray([5.0 6.0; 7.0 8.0], 2:3, [:a, :b])
         @test C.lookup[1] isa Containers._AxisLookup{Tuple{Int,Int}}
@@ -246,8 +244,7 @@ And data, a 0-dimensional $(Array{Int,0}):
         @test (@inferred C[2, :b]) == 6.0
         @test (@inferred C[3, :a]) == 7.0
         @test (@inferred C[2:3, [:a, :b]]) == C
-        @test C[2:3, [:a, :b]] == C
-        @test C[2, [:a, :b]] == DenseAxisArray([5.0, 6.0], [:a, :b])
-        @test C[2:3, :b] == DenseAxisArray([6.0, 8.0], 2:3)
+        @test (@inferred C[2, [:a, :b]]) == DenseAxisArray([5.0, 6.0], [:a, :b])
+        @test (@inferred C[2:3, :b]) == DenseAxisArray([6.0, 8.0], 2:3)
     end
 end

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -218,8 +218,11 @@ And data, a 0-dimensional $(Array{Int,0}):
         @test (@inferred A[:a, :b]) == 6.0
         @test (@inferred A[:a, :b, 1]) == 6.0
         @test (@inferred A[:b, :a]) == 7.0
-
-        @test_broken (@inferred A[[:a, :b], [:a, :b]]) == A
+        if VERSION >= v"1.6.0-DEV"
+            @test (@inferred A[[:a, :b], [:a, :b]]) == A
+        else
+            @test_broken (@inferred A[[:a, :b], [:a, :b]]) == A
+        end
         @test A[[:a, :b], [:a, :b]] == A
         @test A[:a, [:a, :b]] == DenseAxisArray([5.0, 6.0], [:a, :b])
         @test A[[:a, :b], :b] == DenseAxisArray([6.0, 8.0], [:a, :b])
@@ -229,7 +232,11 @@ And data, a 0-dimensional $(Array{Int,0}):
         @test_throws KeyError B[0, :a]
         @test (@inferred B[1, :b]) == 6.0
         @test (@inferred B[2, :a]) == 7.0
-        @test_broken (@inferred B[1:2, [:a, :b]]) == B
+        if VERSION >= v"1.6.0-DEV"
+            @test (@inferred B[1:2, [:a, :b]]) == B
+        else
+            @test_broken (@inferred B[1:2, [:a, :b]]) == B
+        end
         @test B[1:2, [:a, :b]] == B
         @test B[1, [:a, :b]] == DenseAxisArray([5.0, 6.0], [:a, :b])
         @test B[1:2, :b] == DenseAxisArray([6.0, 8.0], 1:2)
@@ -239,7 +246,11 @@ And data, a 0-dimensional $(Array{Int,0}):
         @test_throws KeyError C[0, :a]
         @test (@inferred C[2, :b]) == 6.0
         @test (@inferred C[3, :a]) == 7.0
-        @test_broken (@inferred C[2:3, [:a, :b]]) == C
+        if VERSION >= v"1.6.0-DEV"
+            @test (@inferred C[2:3, [:a, :b]]) == C
+        else
+            @test_broken (@inferred C[2:3, [:a, :b]]) == C
+        end
         @test C[2:3, [:a, :b]] == C
         @test C[2, [:a, :b]] == DenseAxisArray([5.0, 6.0], [:a, :b])
         @test C[2:3, :b] == DenseAxisArray([6.0, 8.0], 2:3)

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -212,9 +212,14 @@ And data, a 0-dimensional $(Array{Int,0}):
         A = DenseAxisArray([5.0 6.0; 7.0 8.0], [:a, :b], [:a, :b])
         @test A.lookup[1] isa Containers._AxisLookup{Dict{Symbol,Int}}
         @test_throws KeyError A[:c, :a]
-        @test @inferred A[:a, :b] == 6.0
-        @test @inferred A[:b, :a] == 7.0
         @test_throws KeyError A[1, 1]
+        @test_throws KeyError A[:a, :b, 2] == 6.0
+
+        @test (@inferred A[:a, :b]) == 6.0
+        @test (@inferred A[:a, :b, 1]) == 6.0
+        @test (@inferred A[:b, :a]) == 7.0
+
+        @test_broken (@inferred A[[:a, :b], [:a, :b]]) == A
         @test A[[:a, :b], [:a, :b]] == A
         @test A[:a, [:a, :b]] == DenseAxisArray([5.0, 6.0], [:a, :b])
         @test A[[:a, :b], :b] == DenseAxisArray([6.0, 8.0], [:a, :b])
@@ -222,8 +227,9 @@ And data, a 0-dimensional $(Array{Int,0}):
         B = DenseAxisArray([5.0 6.0; 7.0 8.0], Base.OneTo(2), [:a, :b])
         @test B.lookup[1] isa Containers._AxisLookup{Base.OneTo{Int}}
         @test_throws KeyError B[0, :a]
-        @test @inferred B[1, :b] == 6.0
-        @test @inferred B[2, :a] == 7.0
+        @test (@inferred B[1, :b]) == 6.0
+        @test (@inferred B[2, :a]) == 7.0
+        @test_broken (@inferred B[1:2, [:a, :b]]) == B
         @test B[1:2, [:a, :b]] == B
         @test B[1, [:a, :b]] == DenseAxisArray([5.0, 6.0], [:a, :b])
         @test B[1:2, :b] == DenseAxisArray([6.0, 8.0], 1:2)
@@ -231,8 +237,9 @@ And data, a 0-dimensional $(Array{Int,0}):
         C = DenseAxisArray([5.0 6.0; 7.0 8.0], 2:3, [:a, :b])
         @test C.lookup[1] isa Containers._AxisLookup{Tuple{Int,Int}}
         @test_throws KeyError C[0, :a]
-        @test @inferred C[2, :b] == 6.0
-        @test @inferred C[3, :a] == 7.0
+        @test (@inferred C[2, :b]) == 6.0
+        @test (@inferred C[3, :a]) == 7.0
+        @test_broken (@inferred C[2:3, [:a, :b]]) == C
         @test C[2:3, [:a, :b]] == C
         @test C[2, [:a, :b]] == DenseAxisArray([5.0, 6.0], [:a, :b])
         @test C[2:3, :b] == DenseAxisArray([6.0, 8.0], 2:3)

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -208,4 +208,10 @@ And data, a 0-dimensional $(Array{Int,0}):
             @test k[2] == Containers.DenseAxisArrayKey((2, :b))
         end
     end
+    @testset "Base.OneTo" begin
+        A = DenseAxisArray([5.0 6.0; 7.0 8.0], 1:2, [:a, :b])
+        @test A.lookup[1] isa Dict{Int,Int}
+        B = DenseAxisArray([5.0 6.0; 7.0 8.0], Base.OneTo(2), [:a, :b])
+        @test B.lookup[1] == Base.OneTo(2)
+    end
 end

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -212,19 +212,29 @@ And data, a 0-dimensional $(Array{Int,0}):
         A = DenseAxisArray([5.0 6.0; 7.0 8.0], [:a, :b], [:a, :b])
         @test A.lookup[1] isa Containers._AxisLookup{Dict{Symbol,Int}}
         @test_throws KeyError A[:c, :a]
-        @test A[:a, :b] == 6.0
-        @test A[:b, :a] == 7.0
+        @test @inferred A[:a, :b] == 6.0
+        @test @inferred A[:b, :a] == 7.0
+        @test_throws KeyError A[1, 1]
+        @test A[[:a, :b], [:a, :b]] == A
+        @test A[:a, [:a, :b]] == DenseAxisArray([5.0, 6.0], [:a, :b])
+        @test A[[:a, :b], :b] == DenseAxisArray([6.0, 8.0], [:a, :b])
 
         B = DenseAxisArray([5.0 6.0; 7.0 8.0], Base.OneTo(2), [:a, :b])
         @test B.lookup[1] isa Containers._AxisLookup{Base.OneTo{Int}}
         @test_throws KeyError B[0, :a]
-        @test B[1, :b] == 6.0
-        @test B[2, :a] == 7.0
+        @test @inferred B[1, :b] == 6.0
+        @test @inferred B[2, :a] == 7.0
+        @test B[1:2, [:a, :b]] == B
+        @test B[1, [:a, :b]] == DenseAxisArray([5.0, 6.0], [:a, :b])
+        @test B[1:2, :b] == DenseAxisArray([6.0, 8.0], 1:2)
 
         C = DenseAxisArray([5.0 6.0; 7.0 8.0], 2:3, [:a, :b])
         @test C.lookup[1] isa Containers._AxisLookup{Tuple{Int,Int}}
         @test_throws KeyError C[0, :a]
-        @test C[2, :b] == 6.0
-        @test C[3, :a] == 7.0
+        @test @inferred C[2, :b] == 6.0
+        @test @inferred C[3, :a] == 7.0
+        @test C[2:3, [:a, :b]] == C
+        @test C[2, [:a, :b]] == DenseAxisArray([5.0, 6.0], [:a, :b])
+        @test C[2:3, :b] == DenseAxisArray([6.0, 8.0], 2:3)
     end
 end

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -210,8 +210,10 @@ And data, a 0-dimensional $(Array{Int,0}):
     end
     @testset "Base.OneTo" begin
         A = DenseAxisArray([5.0 6.0; 7.0 8.0], 1:2, [:a, :b])
-        @test A.lookup[1] isa Dict{Int,Int}
+        @test A.lookup[1] isa Containers._AxisLookup{Dict{Int,Int}}
+        @test_throws KeyError A[0, :a]
         B = DenseAxisArray([5.0 6.0; 7.0 8.0], Base.OneTo(2), [:a, :b])
-        @test B.lookup[1] == Base.OneTo(2)
+        @test B.lookup[1] isa Containers._AxisLookup{Base.OneTo{Int}}
+        @test_throws KeyError B[0, :a]
     end
 end

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -214,6 +214,8 @@ And data, a 0-dimensional $(Array{Int,0}):
         @test_throws KeyError A[:c, :a]
         @test_throws KeyError A[1, 1]
         @test_throws KeyError A[:a, :b, 2] == 6.0
+        @test isassigned(A, :a, :a)
+        @test !isassigned(A, :a, :c)
 
         @test (@inferred A[:a, :b]) == 6.0
         @test (@inferred A[:a, :b, 1]) == 6.0
@@ -230,6 +232,9 @@ And data, a 0-dimensional $(Array{Int,0}):
         B = DenseAxisArray([5.0 6.0; 7.0 8.0], Base.OneTo(2), [:a, :b])
         @test B.lookup[1] isa Containers._AxisLookup{Base.OneTo{Int}}
         @test_throws KeyError B[0, :a]
+        @test isassigned(B, 1, :a)
+        @test !isassigned(B, 3, :b)
+
         @test (@inferred B[1, :b]) == 6.0
         @test (@inferred B[2, :a]) == 7.0
         if VERSION >= v"1.6.0-DEV"
@@ -244,6 +249,8 @@ And data, a 0-dimensional $(Array{Int,0}):
         C = DenseAxisArray([5.0 6.0; 7.0 8.0], 2:3, [:a, :b])
         @test C.lookup[1] isa Containers._AxisLookup{Tuple{Int,Int}}
         @test_throws KeyError C[0, :a]
+        @test isassigned(C, 2, :a)
+        @test !isassigned(C, 4, :b)
         @test (@inferred C[2, :b]) == 6.0
         @test (@inferred C[3, :a]) == 7.0
         if VERSION >= v"1.6.0-DEV"

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -208,12 +208,23 @@ And data, a 0-dimensional $(Array{Int,0}):
             @test k[2] == Containers.DenseAxisArrayKey((2, :b))
         end
     end
-    @testset "Base.OneTo" begin
-        A = DenseAxisArray([5.0 6.0; 7.0 8.0], 1:2, [:a, :b])
-        @test A.lookup[1] isa Containers._AxisLookup{Dict{Int,Int}}
-        @test_throws KeyError A[0, :a]
+    @testset "AxisLookup" begin
+        A = DenseAxisArray([5.0 6.0; 7.0 8.0], [:a, :b], [:a, :b])
+        @test A.lookup[1] isa Containers._AxisLookup{Dict{Symbol,Int}}
+        @test_throws KeyError A[:c, :a]
+        @test A[:a, :b] == 6.0
+        @test A[:b, :a] == 7.0
+
         B = DenseAxisArray([5.0 6.0; 7.0 8.0], Base.OneTo(2), [:a, :b])
         @test B.lookup[1] isa Containers._AxisLookup{Base.OneTo{Int}}
         @test_throws KeyError B[0, :a]
+        @test B[1, :b] == 6.0
+        @test B[2, :a] == 7.0
+
+        C = DenseAxisArray([5.0 6.0; 7.0 8.0], 2:3, [:a, :b])
+        @test C.lookup[1] isa Containers._AxisLookup{Tuple{Int,Int}}
+        @test_throws KeyError C[0, :a]
+        @test C[2, :b] == 6.0
+        @test C[3, :a] == 7.0
     end
 end

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -221,8 +221,10 @@ And data, a 0-dimensional $(Array{Int,0}):
         @test (@inferred A[:a, :b, 1]) == 6.0
         @test (@inferred A[:b, :a]) == 7.0
         @test (@inferred A[[:a, :b], [:a, :b]]) == A
-        @test (@inferred A[:a, [:a, :b]]) == DenseAxisArray([5.0, 6.0], [:a, :b])
-        @test (@inferred A[[:a, :b], :b]) == DenseAxisArray([6.0, 8.0], [:a, :b])
+        @test (@inferred A[:a, [:a, :b]]) ==
+              DenseAxisArray([5.0, 6.0], [:a, :b])
+        @test (@inferred A[[:a, :b], :b]) ==
+              DenseAxisArray([6.0, 8.0], [:a, :b])
 
         B = DenseAxisArray([5.0 6.0; 7.0 8.0], Base.OneTo(2), [:a, :b])
         @test B.lookup[1] isa Containers._AxisLookup{Base.OneTo{Int}}


### PR DESCRIPTION
DenseAxisArrays with `OneTo` axes used a dictionary that mapped `i => i`. This PR replaces that with a `Base.OneTo` for improved efficiency. But in doing so, I realized we can now define `get` for vectors, and support proper slicing of `DenseAxisArray`.

Closes #287