### PR TITLE
Collect axes in DenseAxisArray on construction

### DIFF
--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -112,6 +112,9 @@ function Base.get(
     return i
 end
 
+_collect(x::AbstractVector) = x
+_collect(x) = collect(x)
+
 """
     DenseAxisArray(data::Array{T, N}, axes...) where {T, N}
 
@@ -133,9 +136,10 @@ julia> array[:b, 3]
 4
 ```
 """
-function DenseAxisArray(data::Array{T,N}, axs...) where {T,N}
-    @assert length(axs) == N
-    return DenseAxisArray(data, axs, build_lookup.(axs))
+function DenseAxisArray(data::Array{T,N}, axes...) where {T,N}
+    @assert length(axes) == N
+    new_axes = _collect.(axes)
+    return DenseAxisArray(data, new_axes, build_lookup.(new_axes))
 end
 
 """

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -219,7 +219,7 @@ And data, a 0-dimensional $(Array{Int,0}):
         @test a isa Vector{Pair{Symbol,Int}}
         @test_throws KeyError A[(:a, 3), 1]
         @test_throws KeyError A[:a, 3]
-        @test_throws KeyError A[:b => 1, 2]
+        @test_throws KeyError A[:b=>1, 2]
     end
     @testset "AxisLookup" begin
         A = DenseAxisArray([5.0 6.0; 7.0 8.0], [:a, :b], [:a, :b])

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -208,6 +208,19 @@ And data, a 0-dimensional $(Array{Int,0}):
             @test k[2] == Containers.DenseAxisArrayKey((2, :b))
         end
     end
+    @testset "Iterable axis" begin
+        A = DenseAxisArray(rand(3, 2), Dict(:a => 1, :b => 2, :c => 3), 1:2)
+        a, b = axes(A)
+        @test b == 1:2
+        @test (:a => 1) in a
+        @test (:b => 2) in a
+        @test (:c => 3) in a
+        @test length(a) == 3
+        @test a isa Vector{Pair{Symbol,Int}}
+        @test_throws KeyError A[(:a, 3), 1]
+        @test_throws KeyError A[:a, 3]
+        @test_throws KeyError A[:b => 1, 2]
+    end
     @testset "AxisLookup" begin
         A = DenseAxisArray([5.0 6.0; 7.0 8.0], [:a, :b], [:a, :b])
         @test A.lookup[1] isa Containers._AxisLookup{Dict{Symbol,Int}}


### PR DESCRIPTION
This partially resolves the non-obvious behavior in #2424, because now the dimension is a vector with `Pair` elements, but it doesn't address the printing issue.
```Julia
julia> @variable(model, x[(k, v) in d])
1-dimensional DenseAxisArray{VariableRef,1,...} with index sets:
    Dimension 1, ["b" => 2, "a" => 1]
And data, a 2-element Array{VariableRef,1}:
 x[("b", 2)]
 x[("a", 1)]
```

It's more obvious what is going on with a second dimension:
```julia
julia> @variable(model, y[(k, v) in d, 1:2])
2-dimensional DenseAxisArray{VariableRef,2,...} with index sets:
    Dimension 1, ["b" => 2, "a" => 1]
    Dimension 2, Base.OneTo(2)
And data, a 2×2 Array{VariableRef,2}:
 y[("b", 2),1]  y[("b", 2),2]
 y[("a", 1),1]  y[("a", 1),2]
```
We should print the key as it is, not how it appears in the macro constructor.