### PR TITLE
Support broadcasting over multiple DenseAxisArrays

### DIFF
--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -337,9 +337,11 @@ end
 
 function _broadcast_axes_check(x::NTuple{N}) where {N}
     axes = first(x)
-    for i = 2:N
+    for i in 2:N
         if x[i][1] != axes[1]
-            error("Unable to broadcast over DenseAxisArrays with different axes.")
+            error(
+                "Unable to broadcast over DenseAxisArrays with different axes.",
+            )
         end
     end
     return axes

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -258,7 +258,7 @@ And data, a 0-dimensional $(Array{Int,0}):
     @testset "Broadcast" begin
         foo(x, y) = x + y
         foo_b(x, y) = foo.(x, y)
-        bar(x, y) = (foo.(x, y) .+ x).^2
+        bar(x, y) = (foo.(x, y) .+ x) .^ 2
         a = [5.0 6.0; 7.0 8.0]
         A = DenseAxisArray(a, [:a, :b], [:a, :b])
         b = a .+ 1

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -258,7 +258,7 @@ And data, a 0-dimensional $(Array{Int,0}):
     @testset "Broadcast" begin
         foo(x, y) = x + y
         foo_b(x, y) = foo.(x, y)
-        bar(x, y) = foo.(x, y) .+ x
+        bar(x, y) = (foo.(x, y) .+ x).^2
         a = [5.0 6.0; 7.0 8.0]
         A = DenseAxisArray(a, [:a, :b], [:a, :b])
         b = a .+ 1

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -256,18 +256,18 @@ And data, a 0-dimensional $(Array{Int,0}):
         @test x == y
     end
     @testset "Broadcast" begin
+        foo(x, y) = x + y
+        foo_b(x, y) = foo.(x, y)
+        bar(x, y) = foo.(x, y) .+ x
         a = [5.0 6.0; 7.0 8.0]
         A = DenseAxisArray(a, [:a, :b], [:a, :b])
         b = a .+ 1
         B = A .+ 1
         @test B == DenseAxisArray(b, [:a, :b], [:a, :b])
-        foo = (x, y) -> x + y
-        c = foo.(a, b)
-        C = foo.(A, B)
-        @test C == DenseAxisArray(c, [:a, :b], [:a, :b])
-        d = (foo.(a, b) .+ a) .^ 2
-        D = (foo.(A, B) .+ A) .^ 2
-        @test D == DenseAxisArray(d, [:a, :b], [:a, :b])
+        C = @inferred foo_b(A, B)
+        @test C == DenseAxisArray(foo_b(a, b), [:a, :b], [:a, :b])
+        D = @inferred bar(A, B)
+        @test D == DenseAxisArray(bar(a, b), [:a, :b], [:a, :b])
     end
     @testset "Broadcast_errors" begin
         a = [5.0 6.0; 7.0 8.0]

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -255,4 +255,26 @@ And data, a 0-dimensional $(Array{Int,0}):
         @test y isa DenseAxisArray
         @test x == y
     end
+    @testset "Broadcast" begin
+        a = [5.0 6.0; 7.0 8.0]
+        A = DenseAxisArray(a, [:a, :b], [:a, :b])
+        b = a .+ 1
+        B = A .+ 1
+        @test B == DenseAxisArray(b, [:a, :b], [:a, :b])
+        foo = (x, y) -> x + y
+        c = foo.(a, b)
+        C = foo.(A, B)
+        @test C == DenseAxisArray(c, [:a, :b], [:a, :b])
+        d = (foo.(a, b) .+ a) .^ 2
+        D = (foo.(A, B) .+ A) .^ 2
+        @test D == DenseAxisArray(d, [:a, :b], [:a, :b])
+    end
+    @testset "Broadcast_errors" begin
+        a = [5.0 6.0; 7.0 8.0]
+        A = DenseAxisArray(a, [:a, :b], [:a, :b])
+        B = DenseAxisArray(a, [:b, :a], [:a, :b])
+        @test_throws ErrorException A .+ B
+        b = [5.0 6.0; 7.0 8.0; 9.0 10.0]
+        @test_throws DimensionMismatch A .+ b
+    end
 end


### PR DESCRIPTION
Closes #2267 

Here's the proof:
```Julia
julia> using JuMP

julia> S = [:a, :b]
2-element Array{Symbol,1}:
 :a
 :b

julia> model = Model()
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: NO_OPTIMIZER
Solver name: No optimizer attached.

julia> @variable(model, x[S], start = 0.0)
1-dimensional DenseAxisArray{VariableRef,1,...} with index sets:
    Dimension 1, [:a, :b]
And data, a 2-element Array{VariableRef,1}:
 x[a]
 x[b]

julia> start_value.(x)
1-dimensional DenseAxisArray{Float64,1,...} with index sets:
    Dimension 1, [:a, :b]
And data, a 2-element Array{Float64,1}:
 0.0
 0.0

julia> set_start_value.(x, start_value.(x) .+ 1);

julia> start_value.(x)
1-dimensional DenseAxisArray{Float64,1,...} with index sets:
    Dimension 1, [:a, :b]
And data, a 2-element Array{Float64,1}:
 1.0
 1.0
```