### PR TITLE
Improve types of empty SparseAxisArrays

### DIFF
--- a/src/Containers/container.jl
+++ b/src/Containers/container.jl
@@ -137,7 +137,9 @@ function _container_dict(
     return Dict{K,Any}()
 end
 
-_container_dict(::Any, ::Any, K::Type{<:NTuple{N,Any}}) where {N} = Dict{K,Any}()
+function _container_dict(::Any, ::Any, K::Type{<:NTuple{N,Any}}) where {N}
+    return Dict{K,Any}()
+end
 
 function _container_dict(
     ::Type{Union{}},

--- a/src/Containers/container.jl
+++ b/src/Containers/container.jl
@@ -113,24 +113,34 @@ function container(f::Function, indices, ::Type{SparseAxisArray})
     mappings = Base.Generator(I -> I => f(I...), indices)
     # Same as `Dict(mapping)` but it will error if two indices are the same.
     data = NoDuplicateDict(mappings)
-    if !isempty(data.dict)
-        return SparseAxisArray(data.dict)
-    else
-        # If `dict` is empty, it was not able to determine the type of the key.
-        # To make a best-guess attemp, collect all of the keys excluding the
-        # conditional statement (these must be defined, because the conditional
-        # applies to the lowest-level of the index loops), then get the eltype
-        # of the result.
-        el = eltype(collect(nested(indices.iterators...)))
-        # If the eltype is a tuple, we can use that as the key for the
-        # SparseAxisArray. If it isn't, it may be something like `Any`, so we
-        # should just use an `NTuple{N,Any}` of appropriate length.
-        K = el <: Tuple ? el : _eltype_or_any(indices)
-        # For the key-type of the SparseAxisArray, use `Base.return_types`. But
-        # if there is more than one return type, just use `Any` as the return
-        # type.
-        ret = Base.return_types(f, K)
-        V = length(ret) == 1 ? first(ret) : Any
-        return SparseAxisArray(Dict{K,V}())
-    end
+    return _sparseaxisarray(data.dict, f, indices)
 end
+
+# The NoDuplicateDict was able to infer the element type.
+_sparseaxisarray(dict::Dict, ::Any, ::Any) = SparseAxisArray(dict)
+
+function _sparseaxisarray(dict::Dict{Any,Any}, ::Any, indices)
+    @assert isempty(dict)
+    return SparseAxisArray(Dict{_eltype_or_any(indices),Any}())
+end
+
+# If the eltype is a tuple, we can use that as the key for the SparseAxisArray.
+function _container_dict(K::Type{<:Tuple}, f, ::Any)
+    ret = Base.return_types(f, K)
+    V = length(ret) == 1 ? first(ret) : Any
+    return Dict{K,V}()
+end
+# Catch this case where Union{} <: Tuple.
+_container_dict(::Type{Union{}}, ::Any, K) = Dict{K,Any}()
+_container_dict(::Any, ::Any, K) = Dict{K,Any}()
+
+# The NoDuplicateDict was not able to infer the element type. To make a
+# best-guess attempt, collect all of the keys excluding the conditional
+# statement (these must be defined, because the conditional applies to the
+# lowest-level of the index loops), then get the eltype of the result.
+function _sparseaxisarray(dict::Dict{Any,Any}, f, indices::NestedIterator)
+    @assert isempty(dict)
+    el = eltype(collect(nested(indices.iterators...)))
+    return SparseAxisArray(_container_dict(el, f, _eltype_or_any(indices)))
+end
+

--- a/src/Containers/container.jl
+++ b/src/Containers/container.jl
@@ -137,6 +137,16 @@ function _container_dict(
     return Dict{K,Any}()
 end
 
+_container_dict(::Any, ::Any, K::Type{<:NTuple{N,Any}}) where {N} = Dict{K,Any}()
+
+function _container_dict(
+    ::Type{Union{}},
+    ::Function,
+    K::Type{<:NTuple{N,Any}},
+) where {N}
+    return Dict{K,Any}()
+end
+
 _default_eltype(x::NestedIterator) = Base.@default_eltype nested(x.iterators...)
 _default_eltype(x) = Base.@default_eltype x
 

--- a/src/Containers/container.jl
+++ b/src/Containers/container.jl
@@ -119,6 +119,8 @@ end
 # The NoDuplicateDict was able to infer the element type.
 _sparseaxisarray(dict::Dict, ::Any, ::Any) = SparseAxisArray(dict)
 
+# @default_eltype succeeded and inferred a tuple of the appropriate size!
+# Use `return_types` to get the value type of the dictionary.
 function _container_dict(
     K::Type{<:NTuple{N,Any}},
     f::Function,
@@ -129,10 +131,15 @@ function _container_dict(
     return Dict{K,V}()
 end
 
+# @default_eltype bailed and returned Any. Use an NTuple of Any of the
+# appropriate size intead.
 function _container_dict(::Any, ::Any, K::Type{<:NTuple{N,Any}}) where {N}
     return Dict{K,Any}()
 end
 
+# @default_eltype bailed and returned Union{}. Use an NTuple of Any of the
+# appropriate size intead. We need this method to avoid an ambiguity with
+# `::Type{<:NTuple{N,Any}}` and `::Any`.
 function _container_dict(
     ::Type{Union{}},
     ::Function,
@@ -141,6 +148,9 @@ function _container_dict(
     return Dict{K,Any}()
 end
 
+# Calling `@default_eltye` on `x` isn't sufficient, because the iterator may
+# skip every element based on the condition. Call it on an identical nested
+# iterator, but this time without the condition.
 _default_eltype(x::NestedIterator) = Base.@default_eltype nested(x.iterators...)
 _default_eltype(x) = Base.@default_eltype x
 

--- a/src/Containers/container.jl
+++ b/src/Containers/container.jl
@@ -125,13 +125,23 @@ function _sparseaxisarray(dict::Dict{Any,Any}, ::Any, indices)
 end
 
 # If the eltype is a tuple, we can use that as the key for the SparseAxisArray.
-function _container_dict(K::Type{<:Tuple}, f, ::Any)
+function _container_dict(
+    K::Type{<:NTuple{N,Any}},
+    f,
+    ::Type{<:NTuple{N,Any}},
+) where {N}
     ret = Base.return_types(f, K)
     V = length(ret) == 1 ? first(ret) : Any
     return Dict{K,V}()
 end
 # Catch this case where Union{} <: Tuple.
-_container_dict(::Type{Union{}}, ::Any, K) = Dict{K,Any}()
+function _container_dict(
+    ::Type{Union{}},
+    ::Any,
+    K::Type{<:NTuple{N,Any}},
+) where {N}
+    return Dict{K,Any}()
+end
 _container_dict(::Any, ::Any, K) = Dict{K,Any}()
 
 # The NoDuplicateDict was not able to infer the element type. To make a
@@ -143,4 +153,3 @@ function _sparseaxisarray(dict::Dict{Any,Any}, f, indices::NestedIterator)
     el = eltype(collect(nested(indices.iterators...)))
     return SparseAxisArray(_container_dict(el, f, _eltype_or_any(indices)))
 end
-

--- a/src/Containers/container.jl
+++ b/src/Containers/container.jl
@@ -129,14 +129,6 @@ function _container_dict(
     return Dict{K,V}()
 end
 
-function _container_dict(
-    ::Union{Any,Type{Union{}}},
-    ::Function,
-    K::Type{<:NTuple{N,Any}},
-) where {N}
-    return Dict{K,Any}()
-end
-
 function _container_dict(::Any, ::Any, K::Type{<:NTuple{N,Any}}) where {N}
     return Dict{K,Any}()
 end

--- a/test/Containers/SparseAxisArray.jl
+++ b/test/Containers/SparseAxisArray.jl
@@ -132,14 +132,20 @@ $(SparseAxisArray{Float64,2,Tuple{Symbol,Char}}) with 2 entries:
         @test length(a) == 0
         S = [["a"], [:b]]
         b = Containers.@container([i = 1:2, j = S[i]; i > 3], fill(i, j))
-        @test b isa SparseAxisArray{Any,2,Tuple{Int,Any}}
+        # The compiler doesn't always return the same thing for
+        # `@default_eltype`. It gets Tuple{Int,Any} if run from the REPL, but
+        # `Tuple` if run from within this testset. Just test for either.
+        @test(
+            b isa SparseAxisArray{Any,2,Tuple{Int,Any}} ||
+            b isa SparseAxisArray{Any,2,Tuple{Any,Any}}
+        )
         @test length(b) == 0
         c = Containers.@container(
             [i = 1:0, j = Any[]],
             i,
             container = SparseAxisArray
         )
-        @test c isa SparseAxisArray{Any,2,Tuple{Int,Any}}
+        @test c isa SparseAxisArray{Int,2,Tuple{Int,Any}}
         @test length(c) == 0
         d = Containers.@container([i = Any[], j = Any[]; isodd(i)], i)
         @test d isa SparseAxisArray{Any,2,Tuple{Any,Any}}

--- a/test/Containers/SparseAxisArray.jl
+++ b/test/Containers/SparseAxisArray.jl
@@ -127,11 +127,11 @@ $(SparseAxisArray{Float64,2,Tuple{Symbol,Char}}) with 2 entries:
         sparse_test(d, 2.5, d2, d3, dsqr, [da, db, dc])
     end
     @testset "empty-array" begin
-        c = Containers.@container([i=1:3; i > 5], sqrt(i))
+        c = Containers.@container([i = 1:3; i > 5], sqrt(i))
         @test c isa SparseAxisArray{Float64,1,Tuple{Int}}
         @test length(c) == 0
         S = [["a"], [:b]]
-        d = Containers.@container([i=1:2, j=S[i]; i > 3], fill(i, j))
+        d = Containers.@container([i = 1:2, j = S[i]; i > 3], fill(i, j))
         @test d isa SparseAxisArray{Any,2,Tuple{Int,Any}}
         @test length(d) == 0
     end

--- a/test/Containers/SparseAxisArray.jl
+++ b/test/Containers/SparseAxisArray.jl
@@ -127,12 +127,19 @@ $(SparseAxisArray{Float64,2,Tuple{Symbol,Char}}) with 2 entries:
         sparse_test(d, 2.5, d2, d3, dsqr, [da, db, dc])
     end
     @testset "empty-array" begin
-        c = Containers.@container([i = 1:3; i > 5], sqrt(i))
-        @test c isa SparseAxisArray{Float64,1,Tuple{Int}}
-        @test length(c) == 0
+        a = Containers.@container([i = 1:3; i > 5], sqrt(i))
+        @test a isa SparseAxisArray{Float64,1,Tuple{Int}}
+        @test length(a) == 0
         S = [["a"], [:b]]
-        d = Containers.@container([i = 1:2, j = S[i]; i > 3], fill(i, j))
-        @test d isa SparseAxisArray{Any,2,Tuple{Int,Any}}
+        b = Containers.@container([i = 1:2, j = S[i]; i > 3], fill(i, j))
+        @test b isa SparseAxisArray{Any,2,Tuple{Int,Any}}
+        @test length(b) == 0
+        c = Containers.@container([i=1:0, j=Any[]], i, container=SparseAxisArray)
+        @test c isa SparseAxisArray{Any,2,Tuple{Int64,Any}}
+        @test length(c) == 0
+
+        d = Containers.@container([i=Any[], j=Any[]; isodd(i)], i)
+        @test d isa SparseAxisArray{Any,2,Tuple{Any,Any}}
         @test length(d) == 0
     end
 end

--- a/test/Containers/SparseAxisArray.jl
+++ b/test/Containers/SparseAxisArray.jl
@@ -139,9 +139,8 @@ $(SparseAxisArray{Float64,2,Tuple{Symbol,Char}}) with 2 entries:
             i,
             container = SparseAxisArray
         )
-        @test c isa SparseAxisArray{Any,2,Tuple{Int64,Any}}
+        @test c isa SparseAxisArray{Any,2,Tuple{Int,Any}}
         @test length(c) == 0
-
         d = Containers.@container([i = Any[], j = Any[]; isodd(i)], i)
         @test d isa SparseAxisArray{Any,2,Tuple{Any,Any}}
         @test length(d) == 0

--- a/test/Containers/SparseAxisArray.jl
+++ b/test/Containers/SparseAxisArray.jl
@@ -126,4 +126,13 @@ $(SparseAxisArray{Float64,2,Tuple{Symbol,Char}}) with 2 entries:
         )
         sparse_test(d, 2.5, d2, d3, dsqr, [da, db, dc])
     end
+    @testset "empty-array" begin
+        c = Containers.@container([i=1:3; i > 5], sqrt(i))
+        @test c isa SparseAxisArray{Float64,1,Tuple{Int}}
+        @test length(c) == 0
+        S = [["a"], [:b]]
+        d = Containers.@container([i=1:2, j=S[i]; i > 3], fill(i, j))
+        @test d isa SparseAxisArray{Any,2,Tuple{Int,Any}}
+        @test length(d) == 0
+    end
 end

--- a/test/Containers/SparseAxisArray.jl
+++ b/test/Containers/SparseAxisArray.jl
@@ -134,11 +134,15 @@ $(SparseAxisArray{Float64,2,Tuple{Symbol,Char}}) with 2 entries:
         b = Containers.@container([i = 1:2, j = S[i]; i > 3], fill(i, j))
         @test b isa SparseAxisArray{Any,2,Tuple{Int,Any}}
         @test length(b) == 0
-        c = Containers.@container([i=1:0, j=Any[]], i, container=SparseAxisArray)
+        c = Containers.@container(
+            [i = 1:0, j = Any[]],
+            i,
+            container = SparseAxisArray
+        )
         @test c isa SparseAxisArray{Any,2,Tuple{Int64,Any}}
         @test length(c) == 0
 
-        d = Containers.@container([i=Any[], j=Any[]; isodd(i)], i)
+        d = Containers.@container([i = Any[], j = Any[]; isodd(i)], i)
         @test d isa SparseAxisArray{Any,2,Tuple{Any,Any}}
         @test length(d) == 0
     end

--- a/test/Containers/macro.jl
+++ b/test/Containers/macro.jl
@@ -62,19 +62,19 @@ using Test
         Containers.@container(x[i = 1:0, j = i:0], i)
         @test x isa SparseAxisArray{Any,2,Tuple{Any,Any}}
         Containers.@container(x[i = 1:2, j = 1:2; false], i)
-        @test x isa SparseAxisArray{Any,2,Tuple{Any,Any}}
+        @test x isa SparseAxisArray{Int,2,Tuple{Int,Int}}
         Containers.@container(
             x[i = 1:0, j = 2:1],
             i,
             container = SparseAxisArray
         )
-        @test x isa SparseAxisArray{Any,2,Tuple{Int,Int}}
+        @test x isa SparseAxisArray{Int,2,Tuple{Int,Int}}
         Containers.@container(
             x[i = 1:0, j = 1:0],
             i,
             container = SparseAxisArray
         )
-        @test x isa SparseAxisArray{Any,2,Tuple{Int,Int}}
+        @test x isa SparseAxisArray{Int,2,Tuple{Int,Int}}
     end
     @testset "duplicate_indices" begin
         expr = :(Containers.@container(x[i = 1:2, i = 1:2], i + i))

--- a/test/Containers/macro.jl
+++ b/test/Containers/macro.jl
@@ -56,19 +56,20 @@ using Test
     end
     @testset "SparseAxisArray" begin
         Containers.@container(x[i = 1:3, j = 1:i], i + j)
-        @test x isa Containers.SparseAxisArray{Int,2}
+        @test x isa Containers.SparseAxisArray{Int,2,Tuple{Int,Int}}
         Containers.@container(x[i = 1:10; iseven(i)], i)
-        @test x isa Containers.SparseAxisArray{Int,1}
-        Containers.@container(x[i = 1:0, j = i:0], i)
+        @test x isa Containers.SparseAxisArray{Int,1,Tuple{Int}}
         # Return types are not the same across Julia versions. Check for a
         # variety of plausible results.
-        @test(
-            x isa SparseAxisArray{Any,2,Tuple{Any,Any}} ||
-            x isa SparseAxisArray{Int,2,Tuple{Int,Int}} ||
-            x isa SparseAxisArray{Int,2,Tuple{Int,Any}}
-        )
+        T = Union{Tuple{Any,Any},Tuple{Int,Any},Tuple{Int,Int}}
+        # Here the iterators are empty, and have a linked dependence, so we
+        # can't infer the key or value types.
+        Containers.@container(x[i = 1:0, j = i:0], i)
+        @test x isa SparseAxisArray{Any,2,<:T}
+        # This one is better, we can infer the value type, but the keys are
+        # difficult to infer, and depend on the Julia version you are running.
         Containers.@container(x[i = 1:2, j = 1:2; false], i)
-        @test x isa SparseAxisArray{Int,2,Tuple{Int,Int}}
+        @test x isa SparseAxisArray{Int,2,<:T}
         Containers.@container(
             x[i = 1:0, j = 2:1],
             i,

--- a/test/Containers/macro.jl
+++ b/test/Containers/macro.jl
@@ -66,7 +66,7 @@ using Test
         # can't always infer the key or value types.
         Containers.@container(x[i = 1:0, j = i:0], i)
         @test(
-            x isa SparseAxisArray{Int,2,<:T} || 
+            x isa SparseAxisArray{Int,2,<:T} ||
             x isa SparseAxisArray{Any,2,<:T}
         )
         # This one is better, we can infer the value type, but the keys are

--- a/test/Containers/macro.jl
+++ b/test/Containers/macro.jl
@@ -60,9 +60,12 @@ using Test
         Containers.@container(x[i = 1:10; iseven(i)], i)
         @test x isa Containers.SparseAxisArray{Int,1}
         Containers.@container(x[i = 1:0, j = i:0], i)
+        # Return types are not the same across Julia versions. Check for a
+        # variety of plausible results.
         @test(
             x isa SparseAxisArray{Any,2,Tuple{Any,Any}} ||
-            x isa SparseAxisArray{Int,2,Tuple{Int,Int}}
+            x isa SparseAxisArray{Int,2,Tuple{Int,Int}} ||
+            x isa SparseAxisArray{Int,2,Tuple{Int,Any}}
         )
         Containers.@container(x[i = 1:2, j = 1:2; false], i)
         @test x isa SparseAxisArray{Int,2,Tuple{Int,Int}}

--- a/test/Containers/macro.jl
+++ b/test/Containers/macro.jl
@@ -65,7 +65,10 @@ using Test
         # Here the iterators are empty, and have a linked dependence, so we
         # can't always infer the key or value types.
         Containers.@container(x[i = 1:0, j = i:0], i)
-        @test(x isa SparseAxisArray{Int,2,<:T} || x isa SparseAxisArray{Any,2,<:T})
+        @test(
+            x isa SparseAxisArray{Int,2,<:T} || 
+            x isa SparseAxisArray{Any,2,<:T}
+        )
         # This one is better, we can infer the value type, but the keys are
         # difficult to infer, and depend on the Julia version you are running.
         Containers.@container(x[i = 1:2, j = 1:2; false], i)

--- a/test/Containers/macro.jl
+++ b/test/Containers/macro.jl
@@ -63,9 +63,9 @@ using Test
         # variety of plausible results.
         T = Union{Tuple{Any,Any},Tuple{Int,Any},Tuple{Int,Int}}
         # Here the iterators are empty, and have a linked dependence, so we
-        # can't infer the key or value types.
+        # can't always infer the key or value types.
         Containers.@container(x[i = 1:0, j = i:0], i)
-        @test x isa SparseAxisArray{Any,2,<:T}
+        @test(x isa SparseAxisArray{Int,2,<:T} || x isa SparseAxisArray{Any,2,<:T})
         # This one is better, we can infer the value type, but the keys are
         # difficult to infer, and depend on the Julia version you are running.
         Containers.@container(x[i = 1:2, j = 1:2; false], i)

--- a/test/Containers/macro.jl
+++ b/test/Containers/macro.jl
@@ -60,7 +60,10 @@ using Test
         Containers.@container(x[i = 1:10; iseven(i)], i)
         @test x isa Containers.SparseAxisArray{Int,1}
         Containers.@container(x[i = 1:0, j = i:0], i)
-        @test x isa SparseAxisArray{Any,2,Tuple{Any,Any}}
+        @test(
+            x isa SparseAxisArray{Any,2,Tuple{Any,Any}} ||
+            x isa SparseAxisArray{Int,2,Tuple{Int,Int}}
+        )
         Containers.@container(x[i = 1:2, j = 1:2; false], i)
         @test x isa SparseAxisArray{Int,2,Tuple{Int,Int}}
         Containers.@container(

--- a/test/Containers/nested_iterator.jl
+++ b/test/Containers/nested_iterator.jl
@@ -3,12 +3,12 @@ using Test
 
 @testset "Nested Iterator" begin
     iterators = (() -> 1:3, i -> 1:i)
-    condition(i, j) = j > i
+    condition = (i, j) -> j > i
     @test isempty(Containers.nested(iterators..., condition = condition))
     @test isempty(
         collect(Containers.nested(iterators..., condition = condition)),
     )
-    condition(i, j) = isodd(i) || isodd(j)
+    condition = (i, j) -> isodd(i) || isodd(j)
     @test collect(Containers.nested(iterators..., condition = condition)) == [
         (1, 1)
         (2, 1)


### PR DESCRIPTION
Closes #2552 

The call to `return_types` happens at runtime and is slow, but that's not a problem for now because things don't infer normally: #2457