### PR TITLE
[docs] clarify user-defined functions return scalars

### DIFF
--- a/docs/src/manual/nlp.md
+++ b/docs/src/manual/nlp.md
@@ -274,6 +274,10 @@ In addition to this list of functions, it is possible to register custom
     a function is not needed. Two exceptions are if you want to provide custom
     derivatives, or if the function is not available in the scope of the
     nonlinear expression.
+    
+!!! warning
+    User-defined functions must return a scalar output. For a work-around, see
+    [User-defined functions with vector outputs](@ref).
 
 ### Automatic differentiation
 


### PR DESCRIPTION
This came up again on Slack
<img width="732" alt="image" src="https://user-images.githubusercontent.com/8177701/114132065-c9b1a880-9957-11eb-9d1a-76c177cd0c07.png">
