### PR TITLE
Allow AffExpr and QuadExpr in NL expressions

### DIFF
--- a/docs/src/manual/nlp.md
+++ b/docs/src/manual/nlp.md
@@ -204,15 +204,24 @@ julia> expr = @NLexpression(model, sin(x) + 1)
 
 With the exception of the splatting syntax discussed below, all expressions
 must be simple scalar operations. You cannot use `dot`, matrix-vector products,
-vector slices, etc. Translate vector operations into explicit `sum()` operations
-or use the `AffExpr` plus the [auxiliary variable trick](@ref aux_trick).
-
-```jldoctest; setup=:(model = Model(); @variable(model, x[1:2]); @variable(model, y); c = [1, 2])
+vector slices, etc. 
+```jldoctest nlp_scalar_only; setup=:(model = Model(); @variable(model, x[1:2]); @variable(model, y); c = [1, 2])
 julia> @NLobjective(model, Min, c' * x + 3y)
 ERROR: Unexpected array [1 2] in nonlinear expression. Nonlinear expressions may contain only scalar expressions.
 [...]
+```
 
+Translate vector operations into explicit `sum()` operations:
+```jldoctest nlp_scalar_only
 julia> @NLobjective(model, Min, sum(c[i] * x[i] for i = 1:2) + 3y)
+```
+
+Or use an [`@expression`](@ref):
+```jldoctest nlp_scalar_only
+julia> @expression(model, expr, c' * x)
+x[1] + 2 x[2]
+
+julia> @NLobjective(model, Min, expr + 3y)
 ```
 
 ### Splatting

--- a/docs/src/manual/nlp.md
+++ b/docs/src/manual/nlp.md
@@ -200,28 +200,6 @@ julia> expr = @NLexpression(model, sin(x) + 1)
 "Reference to nonlinear expression #1"
 ```
 
-### [`AffExpr` and `QuadExpr` cannot be used](@id aux_trick)
-
-`AffExpr` and `QuadExpr` objects cannot currently be used inside nonlinear
- expressions. Instead, introduce auxiliary variables, e.g.:
-
-```jldoctest; setup=:(model = Model(); @variable(model, x[1:2]); @variable(model, y); c = [1, 2])
-julia> @expression(model, my_expr, c' * x + 3y)
-x[1] + 2 x[2] + 3 y
-
-julia> @NLobjective(model, Min, sin(my_expr))
-ERROR: Unexpected affine expression x[1] + 2 x[2] + 3 y in nonlinear expression. Affine expressions (e.g., created using @expression) and nonlinear expressions cannot be mixed.
-[...]
-
-julia> aux = @variable(model)
-noname
-
-julia> @constraint(model, aux == my_expr)
--x[1] - 2 x[2] - 3 y + noname = 0.0
-
-julia> @NLobjective(model, Min, sin(aux))
-```
-
 ### Scalar operations only
 
 With the exception of the splatting syntax discussed below, all expressions

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -944,31 +944,32 @@ end
         @test !(:Hess in MOI.features_available(evaluator))
     end
 
-    @testset "Error on using AffExpr in NLexpression" begin
+    @testset "AffExpr in nonlinear" begin
         model = Model()
-        @variable(model, x)
-        @variable(model, y)
-        A = x + y
-        expected_exception = ErrorException(
-            "Unexpected affine expression x + y in nonlinear expression. " *
-            "Affine expressions (e.g., created using @expression) and " *
-            "nonlinear expressions cannot be mixed.",
+        @variable(model, x, start = 1.1)
+        @variable(model, y, start = 1.2)
+        @expression(model, ex, 2 * x + y + 1)
+        nl_ex = @NLexpression(model, ex^2)
+        @test isapprox(
+            value(nl_ex, start_value),
+            (2 * 1.1 + 1.2 + 1)^2,
+            atol = 1e-4,
         )
-        @test_throws expected_exception @NLexpression(model, A)
     end
 
-    @testset "Error on using QuadExpr in NLexpression" begin
+    @testset "QuadExpr in nonlinear" begin
         model = Model()
-        @variable(model, x)
-        @variable(model, y)
-        A = x * y
-        expected_exception = ErrorException(
-            "Unexpected quadratic expression x*y in nonlinear expression. " *
-            "Quadratic expressions (e.g., created using @expression) and " *
-            "nonlinear expressions cannot be mixed.",
+        @variable(model, x, start = 1.1)
+        @variable(model, y, start = 1.2)
+        @expression(model, ex, 0.5 * x^2 + y^2 + 2 * x + 1)
+        nl_ex = @NLexpression(model, sqrt(ex))
+        @test isapprox(
+            value(nl_ex, start_value),
+            sqrt(0.5 * 1.1^2 + 1.2^2 + 2 * 1.1 + 1),
+            atol = 1e-4,
         )
-        @test_throws expected_exception @NLexpression(model, A)
     end
+
     @testset "Error on complex values" begin
         model = Model()
         @variable(model, x)


### PR DESCRIPTION
Closes #2097

@mlubin I didn't see any technical reason not to do this? I guess the error message was just a stop-gap?