### PR TITLE
Add unsafe_backend

### DIFF
--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -241,8 +241,8 @@ with optimizer MOIB.LazyBridgeOptimizer{GLPK.Optimizer}
 The backend is a `MOIU.CachingOptimizer` in the state `EMPTY_OPTIMIZER` and mode
 `AUTOMATIC`.
 
-Alternatively, use [`unsafe_backend`](@ref) to access the `GLPK.Optimizer`
-object at the bottom of the stack.
+Alternatively, use [`unsafe_backend`](@ref) to access the innermost 
+`GLPK.Optimizer` object:
 ```jldoctest models_backends
 julia> unsafe_backend(model)
 A GLPK model

--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -241,12 +241,17 @@ with optimizer MOIB.LazyBridgeOptimizer{GLPK.Optimizer}
 The backend is a `MOIU.CachingOptimizer` in the state `EMPTY_OPTIMIZER` and mode
 `AUTOMATIC`.
 
-Alternatively, pass `innermost = true` to access the `GLPK.Optimizer` object at 
-the bottom of the stack.
+Alternatively, use [`unsafe_backend`](@ref) to access the `GLPK.Optimizer`
+object at the bottom of the stack.
 ```jldoctest models_backends
-julia> backend(model; innermost = true)
+julia> unsafe_backend(model)
 A GLPK model
 ```
+
+!!! warning
+    [`backend`](@ref) and [`unsafe_backend`](@ref) are advanced routines. Read
+    their docstrings to understand the cavets of their usage. You should only
+    call them if you wish to access low-level solver-specific functions.
 
 ### CachingOptimizer
 

--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -250,7 +250,7 @@ A GLPK model
 
 !!! warning
     [`backend`](@ref) and [`unsafe_backend`](@ref) are advanced routines. Read
-    their docstrings to understand the cavets of their usage. You should only
+    their docstrings to understand the caveats of their usage. You should only
     call them if you wish to access low-level solver-specific functions.
 
 ### CachingOptimizer

--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -241,10 +241,10 @@ with optimizer MOIB.LazyBridgeOptimizer{GLPK.Optimizer}
 The backend is a `MOIU.CachingOptimizer` in the state `EMPTY_OPTIMIZER` and mode
 `AUTOMATIC`.
 
-Pass `innermost = true` to access the `GLPK.Optimizer` object at the bottom of
-the stack.
+Alternatively, pass `innermost = true` to access the `GLPK.Optimizer` object at 
+the bottom of the stack.
 ```jldoctest models_backends
-julia> b = backend(model; innermost = true)
+julia> backend(model; innermost = true)
 A GLPK model
 ```
 

--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -241,6 +241,13 @@ with optimizer MOIB.LazyBridgeOptimizer{GLPK.Optimizer}
 The backend is a `MOIU.CachingOptimizer` in the state `EMPTY_OPTIMIZER` and mode
 `AUTOMATIC`.
 
+Pass `innermost = true` to access the `GLPK.Optimizer` object at the bottom of
+the stack.
+```jldoctest models_backends
+julia> b = backend(model; innermost = true)
+A GLPK model
+```
+
 ### CachingOptimizer
 
 A `MOIU.CachingOptimizer` is an MOI layer that abstracts the difference between

--- a/docs/src/reference/models.md
+++ b/docs/src/reference/models.md
@@ -23,6 +23,7 @@ DIRECT
 
 ```@docs
 backend
+unsafe_backend
 solver_name
 Base.empty!(::Model)
 mode

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -383,9 +383,8 @@ inner = unsafe_backend(model)
 ```
 
 Moreover, if you modify the JuMP model, the reference you have to the backend
-(i.e., `inner` in the example above) may be out-dated. Always get a new
-reference by calling `unsafe_backend` before calling any low-level
-functionality.
+(i.e., `inner` in the example above) may be out-dated, and you should call
+[`MOI.Utilities.attach_optimizer`](@ref) again.
 
 This function is also unsafe in the reverse direction: if you modify the unsafe
 backend, e.g., by adding a new constraint to `inner`, the changes may be
@@ -402,20 +401,12 @@ model = Model(GLPK.Optimizer)
 @variable(model, x >= 0)
 MOI.Utilities.attach_optimizer(model)
 glpk = unsafe_backend(model)
-# ... use GLPK ...
-@objective(model, Min, 2x + 1)
-MOI.Utilities.attach_optimizer(model)
-glpk = unsafe_backend(model)
-# ... use GLPK again...
 ```
 Use:
 ```julia
 model = direct_model(GLPK.Optimizer())
 @variable(model, x >= 0)
 glpk = backend(model)  # No need to call `attach_optimizer`.
-# ... use GLPK ...
-@objective(model, Min, 2x + 1)
-# ... use GLPK again. No need to call `backend` twice ...
 ```
 """
 unsafe_backend(model::Model) = unsafe_backend(backend(model))

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -374,9 +374,12 @@ See also: [`backend`](@ref).
 This function is unsafe for two main reasons.
 
 First, the formulation and order of variables and constraints in the unsafe
-backend may be different to the variables and constraints in `model` due to
-bridges. There is no solution to this. Use the alternative suggested below
-instead.
+backend may be different to the variables and constraints in `model`. This 
+can happen because of bridges, or because the solver requires the variables or 
+constraints in a specific order. In addition, the variable or constraint index 
+returned by [`index`](@ref) at the JuMP level may be different to the index of 
+the corresponding variable or constraint in the `unsafe_backed`. There is no 
+solution to this. Use the alternative suggested below instead.
 
 Second, the `unsafe_backend` may be empty, or lack some modifications made to
 the JuMP model. Thus, before calling `unsafe_backend` you should first call

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -371,10 +371,15 @@ See also: [`backend`](@ref).
 
 ## Unsafe behavior
 
-This function is unsafe because the innermost optimizer may not represent the
-same problem as the JuMP `model`.
+This function is unsafe for two main reasons.
 
-Thus, before calling `unsafe_backend` you should first call
+First, the formulation and order of variables and constraints in the unsafe
+backend may be different to the variables and constraints in `model` due to
+bridges. There is no solution to this. Use the alternative suggested below
+instead.
+
+Second, the `unsafe_backend` may be empty, or lack some modifications made to
+the JuMP model. Thus, before calling `unsafe_backend` you should first call
 [`MOI.Utilities.attach_optimizer`](@ref) to ensure that the backend is
 synchronized with the JuMP model.
 ```julia

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -386,8 +386,8 @@ calling any low-level functionality.
 
 Moreover, if you modify the unsafe backend, e.g., by adding a new constraint,
 the changes may be silently discarded by JuMP when the model is modified or
-solved. Don't to this unless you understand when and how JuMP attaches and
-detaches optimizers! Use the alternative suggested below.
+solved. So don't modify the unsafe backend unless you understand when and how
+JuMP attaches and detaches optimizers! Use the alternative suggested below.
 
 If you pass `attach_caching_optimizers = false`, you should assume that any
 `CachingOptimizer`s may be in the `EMPTY_OPTIMIZER` state.

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -378,7 +378,7 @@ backend may be different to the variables and constraints in `model`. This
 can happen because of bridges, or because the solver requires the variables or 
 constraints in a specific order. In addition, the variable or constraint index 
 returned by [`index`](@ref) at the JuMP level may be different to the index of 
-the corresponding variable or constraint in the `unsafe_backed`. There is no 
+the corresponding variable or constraint in the `unsafe_backend`. There is no 
 solution to this. Use the alternative suggested below instead.
 
 Second, the `unsafe_backend` may be empty, or lack some modifications made to

--- a/test/model.jl
+++ b/test/model.jl
@@ -114,7 +114,8 @@ end
 
 function test_innermost()
     model = Model(() -> MOIU.MockOptimizer(MOIU.Model{Float64}()))
-    @test isa(unsafe_backend(model), MOIU.MockOptimizer{MOIU.Model{Float64}})
+    MOI.Utilities.attach_optimizer(model)
+    @test unsafe_backend(model) isa MOIU.MockOptimizer{MOIU.Model{Float64}}
 end
 
 function test_hygiene_variable()

--- a/test/model.jl
+++ b/test/model.jl
@@ -107,6 +107,19 @@ function test_empty!_model()
     @test fill_small_test_model!(model) === model
 end
 
+function test_innermost_error()
+    model = Model()
+    @test_throws ErrorException backend(model; innermost = true)
+end
+
+function test_innermost()
+    model = Model(() -> MOIU.MockOptimizer(MOIU.Model{Float64}()))
+    @test isa(
+        backend(model; innermost = true),
+        MOIU.MockOptimizer{MOIU.Model{Float64}},
+    )
+end
+
 function test_hygiene_variable()
     model_x = Model()
     @variable(model_x, x)

--- a/test/model.jl
+++ b/test/model.jl
@@ -109,13 +109,13 @@ end
 
 function test_innermost_error()
     model = Model()
-    @test_throws ErrorException backend(model; innermost = true)
+    @test_throws ErrorException unsafe_backend(model)
 end
 
 function test_innermost()
     model = Model(() -> MOIU.MockOptimizer(MOIU.Model{Float64}()))
     @test isa(
-        backend(model; innermost = true),
+        unsafe_backend(model),
         MOIU.MockOptimizer{MOIU.Model{Float64}},
     )
 end

--- a/test/model.jl
+++ b/test/model.jl
@@ -114,10 +114,7 @@ end
 
 function test_innermost()
     model = Model(() -> MOIU.MockOptimizer(MOIU.Model{Float64}()))
-    @test isa(
-        unsafe_backend(model),
-        MOIU.MockOptimizer{MOIU.Model{Float64}},
-    )
+    @test isa(unsafe_backend(model), MOIU.MockOptimizer{MOIU.Model{Float64}})
 end
 
 function test_hygiene_variable()


### PR DESCRIPTION
Closes #2565 

This solves two pain points for users:
 * No longer need things like `backend(model).optimizer.model.optimizer` or `backend(model).optimizer.model`, and knowing which to use depends on the solver.
 * No longer have issues where they go `backend(model).optimizer.model.optimizer` and the solver isn't initialized because `attach_optimizer` hasn't been called yet.