### PR TITLE
Enhance extendibility of constraint macros

### DIFF
--- a/docs/src/developers/extensions.md
+++ b/docs/src/developers/extensions.md
@@ -155,7 +155,7 @@ model, i.e. `ScalarConstraint` or `VectorConstraint`, or a custom
 
 Work in progress.
 
-### Adding extra positional arguments
+### Adding an extra positional argument
 
 We can also extend `@constraint` to handle additional positional arguments that 
 effectively "tag" a particular constraint type and/or pass along additional 
@@ -180,6 +180,9 @@ julia> function JuMP.build_constraint(
 julia> @constraint(model, my_con, x == 0, MyConstrType, d = 2)
 my_con : x ≤ 2.0
 ```
+Note that only a single positional argument can be given to a particular 
+constraint. Extensions that seek to pass multiple arguments (e.g., `Foo` and 
+`Bar`) should combine them into one argument type (e.g., `FooBar`). 
 
 ### Shapes
 

--- a/docs/src/developers/extensions.md
+++ b/docs/src/developers/extensions.md
@@ -154,6 +154,33 @@ model, i.e. `ScalarConstraint` or `VectorConstraint`, or a custom
 ### Adding `add_constraint` methods
 
 Work in progress.
+
+### Adding extra positional arguments
+
+We can also extend `@constraint` to handle additional positional arguments that 
+effectively "tag" a particular constraint type and/or pass along additional 
+information that we may want. For example, we can make a `MyConstrType` that 
+modifies affine equalities:
+```jldoctest
+julia> model = Model(); @variable(model, x);
+
+julia> struct MyConstrType end
+
+julia> function JuMP.build_constraint(
+            _error::Function,
+            f::JuMP.GenericAffExpr,
+            set::MOI.EqualTo,
+            extra::Type{MyConstrType};
+            d = 0,
+       )
+            new_set = MOI.LessThan(set.value + d)
+            return JuMP.build_constraint(_error, f, new_set)
+       end
+
+julia> @constraint(model, my_con, x == 0, MyConstrType, d = 2)
+my_con : x ≤ 2.0
+```
+
 ### Shapes
 
 Shapes allow vector constraints, which are represented as flat vectors in MOI,

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -39,8 +39,8 @@ end
     _add_positional_args(call, args)::Nothing
 
 Add the positional arguments `args` to the function call expression `call`, 
-escaping each argument expression. The elements of `args` should should be ones 
-that were extracted via [`Containers._extract_kw_args`](@ref) and had appropriate 
+escaping each argument expression. The elements of `args` should be ones that 
+were extracted via [`Containers._extract_kw_args`](@ref) and had appropriate 
 arguments filtered out (e.g., the model argument). This is able to incorporate 
 additional positional arguments to `call`s that already have keyword arguments.
 
@@ -561,8 +561,8 @@ end
 
 Returns the code for the macro `@constraint_like args...` of syntax
 ```julia
-@constraint_like model con extra_args...     # single constraint
-@constraint_like model ref con extra_args... # group of constraints
+@constraint_like(model, con, extra_arg, kw_args...)      # single constraint
+@constraint_like(model, ref, con, extra_arg, kw_args...) # group of constraints
 ```
 where `@constraint_like` is either `@constraint` or `@SDconstraint`.
 
@@ -570,7 +570,7 @@ The expression `con` is parsed by `parsefun` which returns a `build_constraint`
 call code that, when executed, returns an `AbstractConstraint`. The macro
 keyword arguments (except the `container` keyword argument which is used to
 determine the container type) are added to the `build_constraint` call. The 
-`extra_args` are added as terminal positional arguments to the `build_constraint` 
+`extra_arg` is added as terminal positional argument to the `build_constraint` 
 call along with any keyword arguments (apart from `container` and `base_name`). 
 The returned value of this call is passed to `add_constraint` which returns a 
 constraint reference.
@@ -621,6 +621,11 @@ function _constraint_macro(
         c = gensym()
         x = y
         anonvar = true
+    end
+
+    # Enforce that only one extra positional argument can be given 
+    if length(extra) > 1
+        _error("Cannot specify more than 1 additional positional argument.")
     end
 
     # Prepare the keyword arguments 
@@ -762,12 +767,11 @@ that either `func` or `set` will be some custom type, rather than e.g. a
 set appearing in the constraint.
 
 For extensions that need to create constraints with more information than just 
-`func` and `set`, additional positional arguments can be specified to 
+`func` and `set`, an additional positional argument can be specified to 
 `@constraint` that will then be passed on `build_constraint`. Hence, we can 
 enable this syntax by defining extensions of 
-`build_constraint(_error, func, set, my_args...; kw_args...)` (using explicit 
-typed arguments not splatted ones as shown). This produces the user syntax: 
-`@constraint(model, ref[...], expr, my_args..., kw_args...)`. 
+`build_constraint(_error, func, set, my_arg; kw_args...)`. This produces the 
+user syntax: `@constraint(model, ref[...], expr, my_arg, kw_args...)`. 
 """
 macro constraint(args...)
     return _constraint_macro(

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -397,71 +397,6 @@ function parse_constraint(_error::Function, args...)
     end
 end
 
-"""
-    parse_extra_constraint_args(_error::Function, ::Val{macro_name}, args...)::Vector
-
-Parse the extra positional argument expressions `args` given to a constraint 
-macro with name `macro_name` and return a vector of the parsed argument 
-expressions. By default, this will simply return `[args...]` (i.e., leave the 
-argument expressions unchanged). These extra positional come from the syntax:
-```julia
-@macro_name(model, ref, constr, args...)
-```
-
-JuMP extensions that extend `build_constraint` to use extra positional supports, 
-may also choose to extend this method to parse symbolic input formats. This 
-should only be extended by users that are well experienced with meta programming 
-in Julia.
-
-**Example**
-
-To exemplify how this can be used, consider the following constraint extension 
-Note that it is a little contrived for succintness, relevant extensions will 
-typically be defining a new constraint type.
-```jldoctest constr_ext; setup = :(using JuMP)
-julia> struct MyInfo 
-           var::JuMP.VariableRef
-           value::Float64
-       end
-
-julia> function JuMP.build_constraint(_error::Function, func::JuMP.AffExpr, set::MOI.AbstractScalarSet, info::MyInfo)
-           func.terms[info.var] *= info.value
-           return JuMP.build_constraint(_error, func, set)
-       end
-```
-We can invoke our `build_constraint` extension via [`@constraint`](@ref) by 
-giving an extra argument of type `MyInfo`.
-```jldoctest constr_ext
-julia> model = Model(); @variable(model, x);
-
-julia> @constraint(model, c1, x >= 0, MyInfo(x, 2.3))
-c1 : 2.3 x >= 0.0
-```
-For more complex use cases, these arguments might become complicated and verbose 
-to define explicitly and it may be more convenient to provide a symbolic syntax. 
-This can be accomplished by extending `parse_extra_constraint_args`.
-```jldoctest constr_ext
-julia> using Base.Meta;
-
-julia> function JuMP.parse_extra_constraint_args(_error::Function, ::Val{:constraint}, arg)
-           if isexpr(arg, :*=)
-               return [Expr(:call, :MyInfo, arg.args...)]
-           else
-               [arg] # some other syntax --> pass it on to `build_constraint`
-           end
-       end
-
-julia> @constraint(model, c2, x >= 0, x *= 2.3)
-c2 : 2.3 x >= 0.0
-```
-"""
-function parse_extra_constraint_args end
-
-# Fallback that simply leaves the extra args unchanged.
-function parse_extra_constraint_args(_error::Function, macro_name::Val, args...)
-    return [a for a in args]
-end
-
 # Generic fallback.
 function build_constraint(_error::Function, func, set, args...; kwargs...)
     arg_str = join(args, ", ")
@@ -681,7 +616,7 @@ function _constraint_macro(
         length(extra) >= 1 || _error("No constraint expression was given.")
         c = y
         x = popfirst!(extra)
-        anonvar = isexpr(y, :vect) || isexpr(y, :vcat)
+        anonvar = isexpr(y, (:vect, :vcat))
     else
         c = gensym()
         x = y
@@ -709,9 +644,6 @@ function _constraint_macro(
     (x.head == :block) && _error(
         "Code block passed as constraint. Perhaps you meant to use @constraints instead?",
     )
-
-    # Process the extra positional argument syntax (enables extension parsing)
-    extra = parse_extra_constraint_args(_error, Val(macro_name), extra...)
 
     # Strategy: build up the code for add_constraint, and if needed we will wrap
     # in a function returning `ConstraintRef`s and give it to `Containers.container`.

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -704,11 +704,11 @@ This function needs to be implemented by all `AbstractModel`s
 constraint_type(m::Model) = ConstraintRef{typeof(m)}
 
 """
-    @constraint(m::Model, expr)
+    @constraint(m::Model, expr, kw_args...)
 
 Add a constraint described by the expression `expr`.
 
-    @constraint(m::Model, ref[i=..., j=..., ...], expr)
+    @constraint(m::Model, ref[i=..., j=..., ...], expr, kw_args...)
 
 Add a group of constraints described by the expression `expr` parametrized by
 `i`, `j`, ...
@@ -732,6 +732,14 @@ The expression `expr` can either be
   `@constraint(m, a .sign b .sign c)` which broadcast the constraint creation to
   each element of the vectors.
 
+The recognized keyword arguments in `kw_args` are the following:
+
+* `base_name`: Sets the name prefix used to generate constraint names. It
+  corresponds to the constraint name for scalar constraints, otherwise, the
+  constraint names are set to `base_name[...]` for each index `...` of the axes
+  `axes`.
+* `container`: Specify the container type.
+
 ## Note for extending the constraint macro
 
 Each constraint will be created using
@@ -752,6 +760,14 @@ the corresponding methods to `build_constraint`. Note that this will likely mean
 that either `func` or `set` will be some custom type, rather than e.g. a
 `Symbol`, since we will likely want to dispatch on the type of the function or
 set appearing in the constraint.
+
+For extensions that need to create constraints with more information than just 
+`func` and `set`, additional positional arguments can be specified to 
+`@constraint` that will then be passed on `build_constraint`. Hence, we can 
+enable this syntax by defining extensions of 
+`build_constraint(_error, func, set, my_args...; kw_args...)` (using explicit 
+typed arguments not splatted ones as shown). This produces the user syntax: 
+`@constraint(model, ref[...], expr, my_args..., kw_args...)`. 
 """
 macro constraint(args...)
     return _constraint_macro(

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -269,7 +269,7 @@ function test_syntax_error_constraint(ModelType, ::Any)
     model = ModelType()
     @variable(model, x[1:2])
     err = ErrorException(
-        "In `@constraint(model, [3, x] in SecondOrderCone())`: unable to " *
+        "In `@constraint(model, [3, x] in SecondOrderCone())`: Unable to " *
         "add the constraint because we don't recognize $([3, x]) as a " *
         "valid JuMP function.",
     )

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -213,22 +213,33 @@ function build_constraint_extra_arg_test(ModelType::Type{<:JuMP.AbstractModel})
     end
 end
 
-struct MyInfo 
+struct MyInfo
     var::JuMP.VariableRef
     value::Float64
 end
-function JuMP.build_constraint(_error::Function, func::AffExpr, set::MOI.AbstractScalarSet, info::MyInfo)
+function JuMP.build_constraint(
+    _error::Function,
+    func::AffExpr,
+    set::MOI.AbstractScalarSet,
+    info::MyInfo,
+)
     func.terms[info.var] *= info.value
     return JuMP.build_constraint(_error, func, set)
 end
-function JuMP.parse_extra_constraint_args(_error::Function, ::Val{:constraint}, arg)
+function JuMP.parse_extra_constraint_args(
+    _error::Function,
+    ::Val{:constraint},
+    arg,
+)
     if isexpr(arg, :*=)
         return [Expr(:call, :MyInfo, arg.args...)]
     else
         return [arg]
     end
 end
-function constraint_with_symbolic_extra_args(ModelType::Type{<:JuMP.AbstractModel})
+function constraint_with_symbolic_extra_args(
+    ModelType::Type{<:JuMP.AbstractModel},
+)
     @testset "build constraint with extra symbilic arguments" begin
         model = ModelType()
         @variable(model, x)

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -210,6 +210,12 @@ function build_constraint_extra_arg_test(ModelType::Type{<:JuMP.AbstractModel})
             BadPosArg,
             d = 1
         )
+        @test_throws_strip ErrorException @constraint(
+            model,
+            x == 0,
+            MyConstrType,
+            BadPosArg
+        )
     end
 end
 

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -57,6 +57,12 @@ end
     ]
 end
 
+@testset "Test _add_positional_args" begin
+    call = :(f(1, a=2))
+    @test JuMP._add_positional_args(call, [:(MyObject)]) isa Nothing 
+    @test call == :(f(1, $(Expr(:escape, :MyObject)), a = 2))
+end
+
 @testset "MutableArithmetics.Zero (Issue #2187)" begin
     model = Model()
     c = @constraint(model, sum(1 for _ in 1:0) == sum(1 for _ in 1:0))
@@ -173,6 +179,29 @@ function build_constraint_keyword_test(ModelType::Type{<:JuMP.AbstractModel})
         @test JuMP.constraint_object(cref1).set isa MOI.PowerCone{Float64}
         cref2 = @constraint(model, [1, x, x] in PowerCone(0.5), dual = true)
         @test JuMP.constraint_object(cref2).set isa MOI.DualPowerCone{Float64}
+    end
+end
+
+struct MyConstrType end
+struct BadPosArg end
+function JuMP.build_constraint(
+    _error::Function,
+    f,
+    set,
+    extra::Type{MyConstrType};
+    d = false,
+)
+    return JuMP.build_constraint(_error, f, set)
+end
+function build_constraint_extra_arg_test(ModelType::Type{<:JuMP.AbstractModel})
+    @testset "build_constraint with extra positional arguments" begin
+        model = ModelType()
+        @variable(model, x)
+        cref = @constraint(model, x == 0, MyConstrType)
+        @test JuMP.constraint_object(cref).set isa MOI.EqualTo{Float64}
+        cref = @constraint(model, c1, x == 0, MyConstrType, d = true)
+        @test JuMP.constraint_object(cref).set isa MOI.EqualTo{Float64}
+        @test_macro_throws ErrorException @constraint(model, x == 0, BadPosArg)
     end
 end
 
@@ -328,6 +357,29 @@ function macros_test(
         @test c.func isa JuMP.GenericAffExpr
         @test JuMP.isequal_canonical(c.func, 1 * x)
         @test c.set == MOI.Interval(0.0, 1.0)
+    end
+
+    @testset "Constraint Naming" begin 
+        model = ModelType()
+        @variable(model, x)
+
+        cref = @constraint(model, x == 0)
+        @test name(cref) == ""
+
+        cref = @constraint(model, x == 0, base_name = "cat")
+        @test name(cref) == "cat"
+
+        cref = @constraint(model, c1, x == 0)
+        @test name(cref) == "c1"
+
+        cref = @constraint(model, c2, x == 0, base_name = "cat")
+        @test name(cref) == "cat"
+
+        crefs = @constraint(model, [1:2], x == 0, base_name = "cat")
+        @test name.(crefs) == ["cat[1]", "cat[2]"]
+
+        @test_macro_throws ErrorException @constraint(model, c3[1:2])
+        @test_macro_throws ErrorException @constraint(model, "c"[1:2])
     end
 
     @testset "@build_constraint (scalar inequality)" begin

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -187,7 +187,7 @@ struct MyConstrType end
 struct BadPosArg end
 function JuMP.build_constraint(
     _error::Function,
-    f::AffExpr,
+    f::GenericAffExpr,
     set::MOI.EqualTo,
     extra::Type{MyConstrType};
     d = 0,
@@ -200,55 +200,16 @@ function build_constraint_extra_arg_test(ModelType::Type{<:JuMP.AbstractModel})
         model = ModelType()
         @variable(model, x)
         cref = @constraint(model, x == 0, MyConstrType)
-        @test JuMP.constraint_object(cref).set isa MOI.EqualTo{Float64}
+        @test JuMP.constraint_object(cref).set isa MOI.LessThan{Float64}
         cref = @constraint(model, c1, x == 0, MyConstrType, d = 1)
         @test JuMP.constraint_object(cref).set == MOI.LessThan{Float64}(1)
-        @test_macro_throws ErrorException @constraint(model, x == 0, BadPosArg)
-        @test_macro_throws ErrorException @constraint(
+        @test_throws_strip ErrorException @constraint(model, x == 0, BadPosArg)
+        @test_throws_strip ErrorException @constraint(
             model,
             x == 0,
             BadPosArg,
             d = 1
         )
-    end
-end
-
-struct MyInfo
-    var::JuMP.VariableRef
-    value::Float64
-end
-function JuMP.build_constraint(
-    _error::Function,
-    func::AffExpr,
-    set::MOI.AbstractScalarSet,
-    info::MyInfo,
-)
-    func.terms[info.var] *= info.value
-    return JuMP.build_constraint(_error, func, set)
-end
-function JuMP.parse_extra_constraint_args(
-    _error::Function,
-    ::Val{:constraint},
-    arg,
-)
-    if isexpr(arg, :*=)
-        return [Expr(:call, :MyInfo, arg.args...)]
-    else
-        return [arg]
-    end
-end
-function constraint_with_symbolic_extra_args(
-    ModelType::Type{<:JuMP.AbstractModel},
-)
-    @testset "build constraint with extra symbilic arguments" begin
-        model = ModelType()
-        @variable(model, x)
-        cref = @constraint(model, x == 0, MyInfo(x, 2.3))
-        @test JuMP.constraint_object(cref).set == MOI.EqualTo{Float64}(0)
-        @test JuMP.constraint_object(cref).func = 2.3x
-        cref = @constraint(model, c1, x == 0, x *= 2.3)
-        @test JuMP.constraint_object(cref).set == MOI.EqualTo{Float64}(0)
-        @test JuMP.constraint_object(cref).func = 2.3x
     end
 end
 
@@ -510,6 +471,7 @@ function macros_test(
 
     build_constraint_keyword_test(ModelType)
     custom_expression_test(ModelType)
+    build_constraint_extra_arg_test(ModelType)
     return custom_function_test(ModelType)
 end
 

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -210,7 +210,7 @@ function build_constraint_extra_arg_test(ModelType::Type{<:JuMP.AbstractModel})
             BadPosArg,
             d = 1
         )
-        @test_throws_strip ErrorException @constraint(
+        @test_macro_throws ErrorException @constraint(
             model,
             x == 0,
             MyConstrType,


### PR DESCRIPTION
This restructures `_constraint_macro` to handle extra positional arguments (closes #2573) and enables the use of `base_name` in like manner to `@variable`. 

For supporting `base_name` the syntax is:
```julia
julia> using JuMP; model = Model(); @variable(model, x);

julia> @constraint(model, x == 0, base_name = "name")
name : x = 0

julia> @constraint(model, c1, x == 0)
c1 : x = 0

julia> @constraint(model, c2, x == 0, base_name = "name")
name : x = 0
```

For supporting extra arguments to be passed on to `build_constraint` we have:
```julia
julia> using JuMP; model = Model(); @variable(model, x);

julia> struct MyConstrType end

julia> function JuMP.build_constraint(
    _error::Function,
    f::JuMP.AffExpr,
    set::MOI.EqualTo,
    extra::Type{MyConstrType};
    d = 0,
)
    new_set = MOI.EqualTo(set.value + d)
    return JuMP.build_constraint(_error, f, new_set)
end

julia> @constraint(model, x == 0, MyConstrType, d = 2, base_name = "test")
test : x == 2.0
```

Update:
This also fixes a bug with constraint macro error messages. Previously, error messages always erroneously excluded keyword arguments in the error message, but this behavior has been corrected.
```julia
julia> using JuMP; model = Model(); @variable(model, x);

julia> @constraint(model, kwarg = 2) # previous behavior
ERROR: LoadError: At REPL[2]:1: `@constraint(model)`: Not enough positional arguments

julia> @constraint(model, kwarg = 2) # new behavior
ERROR: LoadError: At REPL[2]:1: `@constraint(model, kwarg = 2)`: Not enough positional arguments
```

~~Update 2:
This adds `parse_extra_constraint_args` as an extendable function to allow extra positional arguments to be parsed prior to adding them to the call expression of `build_constraint`. This allows extensions to define symbolic parsing of arguments when these arguments can be quite cumbersome to define otherwise (i.e., take advantage of the macro to enable symbolic extension syntax).~~