### PR TITLE
Added ∈ for @variable set notation

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1325,7 +1325,7 @@ function parse_one_operator_variable end
 function parse_one_operator_variable(
     _error::Function,
     infoexpr::_VariableInfoExpr,
-    ::Val{:in},
+    ::Union{Val{:in},Val{:∈}},
     set,
 )
     return set
@@ -1491,7 +1491,8 @@ arguments `kw_args` and returns the variable.
 Add a variable to the model `model` described by the expression `expr`, the
 positional arguments `args` and the keyword arguments `kw_args`. The expression
 `expr` can either be (note that in the following the symbol `<=` can be used
-instead of `≤` and the symbol `>=`can be used instead of `≥`)
+instead of `≤`, the symbol `>=`can be used instead of `≥`, the symbol `in` can be 
+used instead of `∈`)
 
 * of the form `varexpr` creating variables described by `varexpr`;
 * of the form `varexpr ≤ ub` (resp. `varexpr ≥ lb`) creating variables described by
@@ -1501,7 +1502,7 @@ instead of `≤` and the symbol `>=`can be used instead of `≥`)
 * of the form `lb ≤ varexpr ≤ ub` or `ub ≥ varexpr ≥ lb` creating variables
   described by `varexpr` with lower bounds given by `lb` and upper bounds given
   by `ub`.
-* of the form `varexpr in set` creating variables described by
+* of the form `varexpr ∈ set` creating variables described by
   `varexpr` constrained to belong to `set`, see [Variables constrained on creation](@ref).
 
 The expression `varexpr` can either be

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -547,10 +547,10 @@ function test_variables_constrained_on_creation(ModelType, ::Any)
     @variable(model, [1:2] in SecondOrderCone())
     @test num_constraints(model, typeof(x), MOI.SecondOrderCone) == 2
 
-    @variable(model, [1:3] in MOI.SecondOrderCone(3))
+    @variable(model, [1:3] ∈ MOI.SecondOrderCone(3))
     @test num_constraints(model, typeof(x), MOI.SecondOrderCone) == 3
 
-    z = @variable(model, z in MOI.Semiinteger(1.0, 2.0))
+    z = @variable(model, z ∈ MOI.Semiinteger(1.0, 2.0))
     @test num_constraints(model, typeof(z), MOI.Semiinteger{Float64}) == 1
 
     @variable(model, set = MOI.Semiinteger(1.0, 2.0))


### PR DESCRIPTION
This simply adds support for `∈` with `parse_one_operator_variable` instead of only allowing `in`. Hence, we can now have:
```julia
julia> using JuMP; model = Model();

julia> @variable(model, [1:2] in SecondOrderCone())
2-element Vector{VariableRef}:
 noname
 noname

julia> @variable(model, [1:2] ∈ SecondOrderCone())
2-element Vector{VariableRef}:
 noname
 noname
```