### PR TITLE
WIP: bridge backend of Model if needed

### DIFF
--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -165,7 +165,7 @@ DocTestSetup = quote
     @constraint(model, con, x <= 1);
     @objective(model, Max, -2x);
     optimize!(model);
-    mock = backend(model).optimizer.model;
+    mock = unsafe_backend(model);
     MOI.set(mock, MOI.TerminationStatus(), MOI.OPTIMAL)
     MOI.set(mock, MOI.DualStatus(), MOI.FEASIBLE_POINT)
     MOI.set(mock, MOI.ConstraintDual(), optimizer_index(con), -2.0)

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -236,59 +236,61 @@ mutable struct Model <: AbstractModel
 end
 
 """
-    Model(; caching_mode::MOIU.CachingOptimizerMode=MOIU.AUTOMATIC)
+    Model(optimizer_factory = nothing; bridge_constraints::Bool = false,)
 
-Return a new JuMP model without any optimizer; the model is stored the model in
-a cache. The mode of the `CachingOptimizer` storing this cache is
-`caching_mode`. Use [`set_optimizer`](@ref) to set the optimizer before
-calling [`optimize!`](@ref).
-"""
-function Model(;
-    caching_mode::MOIU.CachingOptimizerMode = MOIU.AUTOMATIC,
-    solver = nothing,
-)
-    if solver !== nothing
-        error(
-            "The solver= keyword is no longer available in JuMP 0.19 and " *
-            "later. See the JuMP documentation " *
-            "(https://jump.dev/JuMP.jl/latest/) for latest syntax.",
-        )
-    end
-    universal_fallback = MOIU.UniversalFallback(MOIU.Model{Float64}())
-    caching_opt = MOIU.CachingOptimizer(universal_fallback, caching_mode)
-    return direct_model(caching_opt)
-end
+Construct a JuMP model with a `MOI.Utilities.CachingOptimizer` backend.
 
-"""
-    Model(optimizer_factory;
-          caching_mode::MOIU.CachingOptimizerMode=MOIU.AUTOMATIC,
-          bridge_constraints::Bool=true)
-
-Return a new JuMP model with the provided optimizer and bridge settings. This
-function is equivalent to:
-```julia
-    model = Model()
-    set_optimizer(model, optimizer_factory,
-                  bridge_constraints=bridge_constraints)
-    return model
-```
-See [`set_optimizer`](@ref) for the description of the `optimizer_factory` and
-`bridge_constraints` arguments.
+See [`set_optimizer`](@ref) for a description of the arguments.
 
 ## Examples
 
-The following creates a model with the optimizer set to `Ipopt`:
+Create a model with no backing optimizer. Call [`set_optimizer`](@ref) later to
+add an optimizer prior to calling [`optimize!`](@ref).
 ```julia
-model = Model(Ipopt.Optimizer)
+model = Model()
+```
+
+Pass a `.Optimizer` object from a supported package:
+```julia
+model = Model(GLPK.Optimizer)
+```
+
+Use [`optimizer_with-attributes`](@ref) to initialize the model with the
+provided attributes:
+```julia
+model = Model(
+    optimizer_with_attributes(GLPK.Optimizer, "loglevel" => 0),
+)
+```
+
+Create an anonymous function to pass positional arguments to the optimizer:
+```julia
+model = Model() do
+    AmplNLWriter.Optimizer(Bonmin_jll.amplexe)
+end
+```
+
+Pass `bridge_constraints = true` to intialize the model with bridges. Normally,
+bridges will be added only if necessary. Adding them here can have performance
+benefits if you know that your model will use the bridges.
+```julia
+model = Model(SCS.Optimizer; bridge_constraints = true)
 ```
 """
-function Model(optimizer_factory; bridge_constraints::Bool = true, kwargs...)
-    model = Model(; kwargs...)
-    set_optimizer(
-        model,
-        optimizer_factory,
-        bridge_constraints = bridge_constraints,
+function Model(optimizer_factory = nothing; bridge_constraints::Bool = false)
+    model = direct_model(
+        MOI.Utilities.CachingOptimizer(
+            MOIU.UniversalFallback(MOIU.Model{Float64}()),
+            MOI.Utilities.AUTOMATIC,
+        ),
     )
+    if optimizer_factory !== nothing
+        set_optimizer(
+            model,
+            optimizer_factory;
+            bridge_constraints = bridge_constraints,
+        )
+    end
     return model
 end
 
@@ -432,6 +434,66 @@ end
 unsafe_backend(model::MOIB.LazyBridgeOptimizer) = unsafe_backend(model.model)
 unsafe_backend(model::MOI.ModelLike) = model
 
+_needs_bridges(::MOI.ModelLike) = true
+_needs_bridges(::MOI.Bridges.LazyBridgeOptimizer) = false
+_needs_bridges(::Nothing) = false
+
+"""
+TODO(odow): replace with `MOI.Utilities.CachingOptimizer` when updating to
+MOI@0.10.
+
+This function works around an unnecessary `@assert MOI.is_valid(model_cache)`
+check when creating a CachingOptimizer.
+"""
+function _CachingOptimizer(
+    model_cache::A,
+    optimizer::B,
+) where {A<:MOI.ModelLike,B<:MOI.AbstractOptimizer}
+    return MOI.Utilities.CachingOptimizer{B,A}(
+        optimizer,
+        model_cache,
+        MOI.Utilities.EMPTY_OPTIMIZER,
+        MOI.Utilities.AUTOMATIC,
+        MOI.Utilities.IndexMap(),
+        MOI.Utilities.IndexMap(),
+    )
+end
+
+function _add_bridges_if_needed(
+    model::Model,
+    backend::MOI.Utilities.CachingOptimizer,
+)
+    if !_needs_bridges(backend.optimizer)
+        return false
+    end
+    optimizer = backend.optimizer
+    if !MOI.Utilities.supports_default_copy_to(backend.optimizer, false)
+        optimizer = Utilities.CachingOptimizer(
+            Utilities.UniversalFallback(Utilities.Model{Float64}()),
+            backend.optimizer,
+        )
+    end
+    bridge = MOI.Bridges.full_bridge_optimizer(optimizer, Float64)
+    # We don't have to worry about adding `model.bridge_types` here, because
+    # calling `add_bridge` will force a `LazyBridgeOptimizer` backend.
+    model.moi_backend = _CachingOptimizer(backend.model_cache, bridge)
+    MOIU.reset_optimizer(model)
+    return true
+end
+
+_add_bridges_if_needed(::Model, ::MOI.ModelLike) = false
+
+"""
+    _add_bridges_if_needed(model::Model)
+
+Add a `MOI.Bridges.LazyBridgeOptimizer` to the backend of `model` if one does
+not already exist. Returns `true` if a new `MOI.Bridges.LazyBridgeOptimizer` is
+added, and `false` otherwise.
+"""
+function _add_bridges_if_needed(model::Model)
+    return _add_bridges_if_needed(model, backend(model))
+end
+
 """
     moi_mode(model::MOI.ModelLike)
 
@@ -456,16 +518,6 @@ function mode(model::Model)
     # The type of `backend(model)` is not type-stable, so we use a function
     # barrier (`moi_mode`) to improve performance.
     return moi_mode(backend(model))
-end
-
-"""
-    moi_bridge_constraints(model::MOI.ModelLike)
-
-Return `true` if `model` will bridge constraints.
-"""
-moi_bridge_constraints(model::MOI.ModelLike) = false
-function moi_bridge_constraints(model::MOIU.CachingOptimizer)
-    return model.optimizer isa MOI.Bridges.LazyBridgeOptimizer
 end
 
 # Internal function.
@@ -500,37 +552,16 @@ function solver_name(model::Model)
     end
 end
 
-"""
-    bridge_constraints(model::Model)
+# No optimizer is attached, the bridge will be added when one is attached
+_moi_add_bridge(::Nothing, ::Type{<:MOI.Bridges.AbstractBridge}) = nothing
 
-When in direct mode, return `false`.
-When in manual or automatic mode, return a `Bool` indicating whether the
-optimizer is set and unsupported constraints are automatically bridged
-to equivalent supported constraints when an appropriate transformation is
-available.
-"""
-function bridge_constraints(model::Model)
-    # The type of `backend(model)` is not type-stable, so we use a function
-    # barrier (`moi_bridge_constraints`) to improve performance.
-    return moi_bridge_constraints(backend(model))
-end
-
-function _moi_add_bridge(
-    model::Nothing,
-    BridgeType::Type{<:MOI.Bridges.AbstractBridge},
-)
-    # No optimizer is attached, the bridge will be added when one is attached
-    return
-end
-function _moi_add_bridge(
-    model::MOI.ModelLike,
-    BridgeType::Type{<:MOI.Bridges.AbstractBridge},
-)
+function _moi_add_bridge(::MOI.ModelLike, ::Type{<:MOI.Bridges.AbstractBridge})
     return error(
-        "Cannot add bridge if `bridge_constraints` was set to `false` in the",
-        " `Model` constructor.",
+        "`In order to add a bridge, you must pass `bridge_constraints=true` " *
+        "to `Model`, i.e., `Model(optimizer; bridge_constraints = true)`.",
     )
 end
+
 function _moi_add_bridge(
     bridge_opt::MOI.Bridges.LazyBridgeOptimizer,
     BridgeType::Type{<:MOI.Bridges.AbstractBridge},
@@ -538,6 +569,7 @@ function _moi_add_bridge(
     MOI.Bridges.add_bridge(bridge_opt, BridgeType{Float64})
     return
 end
+
 function _moi_add_bridge(
     caching_opt::MOIU.CachingOptimizer,
     BridgeType::Type{<:MOI.Bridges.AbstractBridge},
@@ -547,8 +579,10 @@ function _moi_add_bridge(
 end
 
 """
-     add_bridge(model::Model,
-                BridgeType::Type{<:MOI.Bridges.AbstractBridge})
+    add_bridge(
+        model::Model,
+        BridgeType::Type{<:MOI.Bridges.AbstractBridge},
+    )
 
 Add `BridgeType` to the list of bridges that can be used to transform
 unsupported constraints into an equivalent formulation using only constraints
@@ -559,6 +593,8 @@ function add_bridge(
     BridgeType::Type{<:MOI.Bridges.AbstractBridge},
 )
     push!(model.bridge_types, BridgeType)
+    # Make sure we force a `LazyBridgeOptimizer` backend!
+    _add_bridges_if_needed(model)
     # The type of `backend(model)` is not type-stable, so we use a function
     # barrier (`_moi_add_bridge`) to improve performance.
     _moi_add_bridge(JuMP.backend(model), BridgeType)
@@ -606,8 +642,9 @@ end
 
 function _moi_print_bridge_graph(::IO, ::MOI.ModelLike)
     return error(
-        "Cannot print bridge graph if `bridge_constraints` was set to " *
-        "`false` in the `Model` constructor.",
+        "`In order to print the bridge graph, you must pass " *
+        "`bridge_constraints=true` to `Model`, i.e., " *
+        "`Model(optimizer; bridge_constraints = true)`.",
     )
 end
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -513,33 +513,37 @@ function check_belongs_to_model(con::VectorConstraint, model)
 end
 
 function moi_add_constraint(
-    model::MOI.ModelLike,
-    f::MOI.AbstractFunction,
-    s::MOI.AbstractSet,
-)
-    if !MOI.supports_constraint(model, typeof(f), typeof(s))
-        if moi_mode(model) == DIRECT
-            bridge_message = "."
-        elseif moi_bridge_constraints(model)
-            error(
-                sprint(
-                    io -> MOI.Bridges.debug(
-                        model.optimizer,
-                        typeof(f),
-                        typeof(s);
-                        io = io,
-                    ),
-                ),
-            )
-        else
-            bridge_message = ", try using `bridge_constraints=true` in the `JuMP.Model` constructor if you believe the constraint can be reformulated to constraints supported by the solver."
-        end
+    model::JuMP.Model,
+    f::F,
+    s::S,
+) where {F<:MOI.AbstractFunction,S<:MOI.AbstractSet}
+    return moi_add_constraint(model, backend(model), f, s)
+end
+
+function moi_add_constraint(
+    model::JuMP.Model,
+    moi_backend::MOI.ModelLike,
+    f::F,
+    s::S,
+) where {F<:MOI.AbstractFunction,S<:MOI.AbstractSet}
+    if MOI.supports_constraint(moi_backend, F, S)
+        # Our backend supports the constraint. Go ahead and add it.
+        return MOI.add_constraint(moi_backend, f, s)
+    elseif _add_bridges_if_needed(model)
+        # In here, we added some bridges. Call again with the new backend.
+        return moi_add_constraint(model, f, s)
+    end
+    # Our backend doesn't support the constraint, and even after we added
+    # bridges it still didn't!
+    if moi_mode(moi_backend) == DIRECT
+        error("Constraints of type $F-in-$S are not supported by the solver.")
+    else
         error(
-            "Constraints of type $(typeof(f))-in-$(typeof(s)) are not supported by the solver" *
-            bridge_message,
+            sprint() do io
+                return MOI.Bridges.debug(moi_backend.optimizer, F, S; io = io)
+            end,
         )
     end
-    return MOI.add_constraint(model, f, s)
 end
 
 """
@@ -555,7 +559,11 @@ function add_constraint(
     # The type of backend(model) is unknown so we directly redirect to another
     # function.
     check_belongs_to_model(con, model)
-    cindex = moi_add_constraint(backend(model), moi_function(con), moi_set(con))
+    cindex = moi_add_constraint(
+        model,
+        moi_function(con),
+        moi_set(con),
+    )
     cshape = shape(con)
     if !(cshape isa ScalarShape) && !(cshape isa VectorShape)
         model.shapes[cindex] = cshape

--- a/src/copy.jl
+++ b/src/copy.jl
@@ -115,8 +115,7 @@ function copy_model(
             "able to copy the constructed model.",
         )
     end
-    caching_mode = backend(model).mode
-    new_model = Model(caching_mode = caching_mode)
+    new_model = Model()
 
     # At JuMP's level, filter_constraints should work with JuMP.ConstraintRef,
     # whereas MOI.copy_to's filter_constraints works with MOI.ConstraintIndex.

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -90,22 +90,26 @@ functions; the recommended way to set the objective is with the
 """
 function set_objective_function end
 
-function set_objective_function(model::Model, func::MOI.AbstractScalarFunction)
-    attr = MOI.ObjectiveFunction{typeof(func)}()
-    if !MOI.supports(backend(model), attr)
-        error(
-            "The solver does not support an objective function of type ",
-            typeof(func),
-            ".",
-        )
+function set_objective_function(
+    model::Model,
+    f::F,
+) where {F<:MOI.AbstractScalarFunction}
+    attr = MOI.ObjectiveFunction{F}()
+    if MOI.supports(backend(model), attr)
+        MOI.set(model, attr, f)
+        # Nonlinear objectives override regular objectives, so if there was a
+        # nonlinear objective set, we must clear it.
+        if model.nlp_data !== nothing
+            model.nlp_data.nlobj = nothing
+        end
+        return
+    else
+        _add_bridges_if_needed(model)
+        return set_objective_function(model, f)
     end
-    MOI.set(model, attr, func)
-    # Nonlinear objectives override regular objectives, so if there was a
-    # nonlinear objective set, we must clear it.
-    if model.nlp_data !== nothing
-        model.nlp_data.nlobj = nothing
-    end
-    return
+    return error(
+        "The solver does not support an objective function of type $F.",
+    )
 end
 
 function set_objective_function(model::Model, func::AbstractJuMPScalar)

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -73,51 +73,58 @@ function MOIU.attach_optimizer(model::Model)
 end
 
 """
-    set_optimizer(model::Model, optimizer_factory;
-                  bridge_constraints::Bool=true)
-
+    set_optimizer(
+        model::Model,
+        optimizer_factory;
+        bridge_constraints::Bool = false,
+    )
 
 Creates an empty `MathOptInterface.AbstractOptimizer` instance by calling
-`optimizer_factory()` and sets it as the optimizer of `model`. Specifically,
-`optimizer_factory` must be callable with zero arguments and return an empty
-`MathOptInterface.AbstractOptimizer`.
+`MOI.instantiate(optimizer_factory)` and sets it as the optimizer of `model`.
 
-If `bridge_constraints` is true, constraints that are not supported by the
-optimizer are automatically bridged to equivalent supported constraints when
-an appropriate transformation is defined in the `MathOptInterface.Bridges`
-module or is defined in another module and is explicitly added.
+If `bridge_constraints`, adds a `MOI.Bridges.LazyBridgeOptimizer` layer around
+the constructed optimizer.
 
-See [`set_optimizer_attributes`](@ref) and [`set_optimizer_attribute`](@ref) for setting
-solver-specific parameters of the optimizer.
+See [`set_optimizer_attributes`](@ref) and [`set_optimizer_attribute`](@ref) for
+setting solver-specific parameters of the optimizer.
 
 ## Examples
+
 ```julia
 model = Model()
+
 set_optimizer(model, GLPK.Optimizer)
+
+set_optimizer(model, () -> Gurobi.Optimizer(); bridge_constraints = true)
+
+factory = optimizer_with_attributes(Gurobi.Optimizer, "OutputFlag" => 0)
+set_optimizer(model, factory)
 ```
 """
 function set_optimizer(
     model::Model,
     optimizer_constructor;
-    bridge_constraints::Bool = true,
+    bridge_constraints::Bool = false,
 )
     error_if_direct_mode(model, :set_optimizer)
-    if bridge_constraints
-        # We set `with_names=false` because the names are handled by the first
-        # caching optimizer. If `default_copy_to` without names is supported,
-        # no need for a second cache.
-        optimizer = MOI.instantiate(
-            optimizer_constructor,
-            with_bridge_type = Float64,
-            with_names = false,
-        )
-        for bridge_type in model.bridge_types
-            _moi_add_bridge(optimizer, bridge_type)
-        end
-    else
-        optimizer = MOI.instantiate(optimizer_constructor)
+    if length(model.bridge_types) > 0
+        bridge_constraints = true  # If the user added bridges, add them.
     end
-    return MOIU.reset_optimizer(model, optimizer)
+    optimizer = if bridge_constraints
+        optimizer = MOI.instantiate(
+            optimizer_constructor;
+            with_bridge_type = Float64,
+        )
+        # Make sure to add the bridges in `model.bridge_types`! These may have
+        # been added when no optimizer was present.
+        _moi_add_bridge.(Ref(optimizer), model.bridge_types)
+        optimizer
+    else
+        MOI.instantiate(optimizer_constructor)
+    end
+    model.moi_backend = _CachingOptimizer(backend(model).model_cache, optimizer)
+    MOIU.reset_optimizer(model)
+    return
 end
 
 # Deprecation for JuMP v0.18 -> JuMP v0.19 transition

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -876,7 +876,7 @@ function _test_shadow_price_util(
         ),
     )
     JuMP.optimize!(model)
-    mock_optimizer = JuMP.backend(model).optimizer.model
+    mock_optimizer = JuMP.unsafe_backend(model)
     MOI.set(mock_optimizer, MOI.TerminationStatus(), MOI.OPTIMAL)
     MOI.set(mock_optimizer, MOI.DualStatus(), MOI.FEASIBLE_POINT)
     JuMP.optimize!(model)

--- a/test/feasibility_checker.jl
+++ b/test/feasibility_checker.jl
@@ -109,7 +109,7 @@ function test_primal_solution()
     model = Model(() -> MOIU.MockOptimizer(MOIU.Model{Float64}()))
     @variable(model, x, Bin)
     optimize!(model)
-    mock = backend(model).optimizer.model
+    mock = unsafe_backend(model)
     MOI.set(mock, MOI.TerminationStatus(), MOI.OPTIMAL)
     MOI.set(mock, MOI.PrimalStatus(), MOI.FEASIBLE_POINT)
     MOI.set(mock, MOI.VariablePrimal(), optimizer_index(x), 1.0)

--- a/test/generate_and_solve.jl
+++ b/test/generate_and_solve.jl
@@ -56,7 +56,7 @@ using JuMP
         )
         JuMP.optimize!(m)
 
-        mockoptimizer = JuMP.backend(m).optimizer.model
+        mockoptimizer = JuMP.unsafe_backend(m)
         MOI.set(mockoptimizer, MOI.TerminationStatus(), MOI.OPTIMAL)
         MOI.set(mockoptimizer, MOI.RawStatusString(), "solver specific string")
         MOI.set(mockoptimizer, MOI.ObjectiveValue(), -1.0)
@@ -204,7 +204,6 @@ using JuMP
                 MOIU.Model{Float64}(),
                 eval_objective_value = false,
             ),
-            caching_mode = MOIU.AUTOMATIC,
         )
         @variable(m, x == 1.0, Int)
         @variable(m, y, Bin)
@@ -233,7 +232,7 @@ using JuMP
 
         MOIU.attach_optimizer(m)
 
-        mockoptimizer = JuMP.backend(m).optimizer.model
+        mockoptimizer = JuMP.unsafe_backend(m)
         MOI.set(mockoptimizer, MOI.TerminationStatus(), MOI.OPTIMAL)
         MOI.set(mockoptimizer, MOI.RawStatusString(), "solver specific string")
         MOI.set(mockoptimizer, MOI.ObjectiveValue(), 1.0)
@@ -314,7 +313,7 @@ using JuMP
         )
         JuMP.optimize!(m)
 
-        mockoptimizer = JuMP.backend(m).optimizer.model
+        mockoptimizer = JuMP.unsafe_backend(m)
         MOI.set(mockoptimizer, MOI.TerminationStatus(), MOI.OPTIMAL)
         MOI.set(mockoptimizer, MOI.RawStatusString(), "solver specific string")
         MOI.set(mockoptimizer, MOI.ObjectiveValue(), -1.0)
@@ -627,7 +626,7 @@ c2: x + y <= 1.0
         )
         JuMP.optimize!(m)
 
-        mock = JuMP.backend(m).optimizer.model
+        mock = JuMP.unsafe_backend(m)
         MOI.set(mock, MOI.TerminationStatus(), MOI.OPTIMAL)
         MOI.set(mock, MOI.ResultCount(), 2)
 

--- a/test/lp_sensitivity.jl
+++ b/test/lp_sensitivity.jl
@@ -27,7 +27,7 @@ function test_lp_rhs_perturbation_range(
         ),
     )
     JuMP.optimize!(model)
-    mock_optimizer = JuMP.backend(model).optimizer.model
+    mock_optimizer = JuMP.unsafe_backend(model)
     MOI.set(mock_optimizer, MOI.TerminationStatus(), MOI.OPTIMAL)
 
     JuMP.optimize!(model)
@@ -188,7 +188,7 @@ function test_lp_objective_perturbation_range(
         ),
     )
     JuMP.optimize!(model)
-    mock_optimizer = JuMP.backend(model).optimizer.model
+    mock_optimizer = JuMP.unsafe_backend(model)
     MOI.set(mock_optimizer, MOI.TerminationStatus(), MOI.OPTIMAL)
     MOI.set(mock_optimizer, MOI.DualStatus(), MOI.FEASIBLE_POINT)
 

--- a/test/model.jl
+++ b/test/model.jl
@@ -203,11 +203,13 @@ end
 
 function test_bridges_automatic()
     # optimizer not supporting Interval
-    model = Model(() -> MOIU.MockOptimizer(SimpleLPModel{Float64}()))
-    @test JuMP.bridge_constraints(model)
+    model = Model(
+        () -> MOIU.MockOptimizer(SimpleLPModel{Float64}());
+        bridge_constraints = true,
+    )
     @test JuMP.backend(model) isa MOIU.CachingOptimizer
     @test JuMP.backend(model).optimizer isa MOI.Bridges.LazyBridgeOptimizer
-    @test JuMP.backend(model).optimizer.model isa MOIU.MockOptimizer
+    @test JuMP.unsafe_backend(model) isa MOIU.MockOptimizer
     @variable model x
     cref = @constraint model 0 <= x + 1 <= 1
     @test cref isa JuMP.ConstraintRef{
@@ -228,12 +230,12 @@ function test_bridges_automatic_with_cache()
             SimpleLPModel{Float64}(),
             needs_allocate_load = true,
         ),
+        bridge_constraints = true,
     )
-    @test JuMP.bridge_constraints(model)
     @test JuMP.backend(model) isa MOIU.CachingOptimizer
     @test JuMP.backend(model).optimizer isa MOI.Bridges.LazyBridgeOptimizer
     @test JuMP.backend(model).optimizer.model isa MOIU.CachingOptimizer
-    @test JuMP.backend(model).optimizer.model.optimizer isa MOIU.MockOptimizer
+    @test JuMP.unsafe_backend(model) isa MOIU.MockOptimizer
     @variable model x
     err = ErrorException(
         "There is no `optimizer_index` as the optimizer is not " *
@@ -258,27 +260,10 @@ function test_bridges_automatic_with_cache()
     @test_throws err optimizer_index(cref)
 end
 
-function test_bridges_automatic_disabled()
-    # Automatic bridging disabled with `bridge_constraints` keyword
-    model = Model(
-        () -> MOIU.MockOptimizer(SimpleLPModel{Float64}()),
-        bridge_constraints = false,
-    )
-    @test !JuMP.bridge_constraints(model)
-    @test JuMP.backend(model) isa MOIU.CachingOptimizer
-    @test !(JuMP.backend(model).optimizer isa MOI.Bridges.LazyBridgeOptimizer)
-    @variable model x
-    err = ErrorException(
-        "Constraints of type MathOptInterface.ScalarAffineFunction{Float64}-in-MathOptInterface.Interval{Float64} are not supported by the solver, try using `bridge_constraints=true` in the `JuMP.Model` constructor if you believe the constraint can be reformulated to constraints supported by the solver.",
-    )
-    @test_throws err @constraint model 0 <= x + 1 <= 1
-end
-
 function test_bridges_direct()
     # No bridge automatically added in Direct mode
     optimizer = MOIU.MockOptimizer(SimpleLPModel{Float64}())
     model = JuMP.direct_model(optimizer)
-    @test !JuMP.bridge_constraints(model)
     @variable model x
     err = ErrorException(
         "Constraints of type MathOptInterface.ScalarAffineFunction{Float64}-in-MathOptInterface.Interval{Float64} are not supported by the solver.",
@@ -303,7 +288,7 @@ function mock_factory()
 end
 
 function test_bridges_add_before_con_model_optimizer()
-    model = Model(mock_factory)
+    model = Model(mock_factory; bridge_constraints = true)
     @variable(model, x)
     JuMP.add_bridge(model, NonnegativeBridge)
     c = @constraint(model, x in Nonnegative())
@@ -318,7 +303,7 @@ function test_bridges_add_before_con_set_optimizer()
     @variable(model, x)
     c = @constraint(model, x in Nonnegative())
     JuMP.add_bridge(model, NonnegativeBridge)
-    set_optimizer(model, mock_factory)
+    set_optimizer(model, mock_factory; bridge_constraints = true)
     JuMP.optimize!(model)
     @test 1.0 == @inferred JuMP.value(x)
     @test 1.0 == @inferred JuMP.value(c)
@@ -326,7 +311,7 @@ function test_bridges_add_before_con_set_optimizer()
 end
 
 function test_bridges_add_after_con_model_optimizer()
-    model = Model(mock_factory)
+    model = Model(mock_factory; bridge_constraints = true)
     @variable(model, x)
     flag = true
     try
@@ -381,7 +366,7 @@ function test_bridges_add_bridgeable_con_set_optimizer()
     constraint = ScalarConstraint(x, Nonnegative())
     bc = BridgeableConstraint(constraint, NonnegativeBridge)
     c = add_constraint(model, bc)
-    set_optimizer(model, mock_factory)
+    set_optimizer(model, mock_factory; bridge_constraints = true)
     JuMP.optimize!(model)
     @test 1.0 == @inferred JuMP.value(x)
     @test 1.0 == @inferred JuMP.value(c)
@@ -389,19 +374,13 @@ function test_bridges_add_bridgeable_con_set_optimizer()
 end
 
 function test_bridge_graph_false()
-    model = Model(mock_factory, bridge_constraints = false)
+    model = Model(mock_factory)
     @variable(model, x)
     @test_throws(
         ErrorException(
-            "Cannot add bridge if `bridge_constraints` was set to `false` in " *
-            "the `Model` constructor.",
-        ),
-        add_bridge(model, NonnegativeBridge)
-    )
-    @test_throws(
-        ErrorException(
-            "Cannot print bridge graph if `bridge_constraints` was set to " *
-            "`false` in the `Model` constructor.",
+            "`In order to print the bridge graph, you must pass " *
+            "`bridge_constraints=true` to `Model`, i.e., " *
+            "`Model(optimizer; bridge_constraints = true)`.",
         ),
         print_bridge_graph(model)
     )
@@ -509,7 +488,7 @@ end
 function dummy_optimizer_hook(::JuMP.AbstractModel) end
 
 function copy_model_style_mode(use_copy_model, caching_mode, filter_mode)
-    model = Model(caching_mode = caching_mode)
+    model = Model()
     model.optimize_hook = dummy_optimizer_hook
     data = DummyExtensionData(model)
     model.ext[:dummy] = data
@@ -595,12 +574,6 @@ end
 
 function test_copy_model_base_auto()
     return copy_model_style_mode(false, MOIU.AUTOMATIC, false)
-end
-function test_copy_model_jump_manual()
-    return copy_model_style_mode(true, MOIU.MANUAL, false)
-end
-function test_copy_model_base_manual()
-    return copy_model_style_mode(false, MOIU.MANUAL, false)
 end
 
 function test_copy_direct_mode()
@@ -782,7 +755,7 @@ function test_copy_conflict()
     )
     JuMP.optimize!(model)
 
-    mockoptimizer = JuMP.backend(model).optimizer.model
+    mockoptimizer = JuMP.unsafe_backend(model)
     MOI.set(mockoptimizer, MOI.TerminationStatus(), MOI.INFEASIBLE)
     MOI.set(mockoptimizer, MOI.ConflictStatus(), MOI.CONFLICT_FOUND)
     MOI.set(

--- a/test/print.jl
+++ b/test/print.jl
@@ -902,7 +902,7 @@ end
     )
     optimize!(model)
 
-    mockoptimizer = JuMP.backend(model).optimizer.model
+    mockoptimizer = JuMP.unsafe_backend(model)
     MOI.set(mockoptimizer, MOI.TerminationStatus(), MOI.OPTIMAL)
     MOI.set(mockoptimizer, MOI.RawStatusString(), "solver specific string")
     MOI.set(mockoptimizer, MOI.ObjectiveValue(), -1.0)


### PR DESCRIPTION
This is just a proof-of-concept to look at what changes we can make to JuMP to address the "time-to-first-solve" issue (https://github.com/jump-dev/MathOptInterface.jl/issues/1313). It is essentially a repeat of https://github.com/jump-dev/MathOptInterface.jl/pull/1252, but at the JuMP level instead of MOI. 

## Background 

The main issues are:
 * Bridges are good, and have a small run-time cost if un-used
 * Due to the design, bridges are not type stable. The main reasons are:
   * New bridges can be added by the user
   * Variable bridges can return a function of a variable, instead of just a variable
   * Determining whether a variable is bridged requires a run-time lookup.
 * Because of the type instability, bridges don't precompile well, and they have a large compile-time cost.
 * This compile time-cost happens even if the bridges are not used. As one example:
   * To set the objective, we must first delete the current objective. Because we can only tell at runtime if the current objective is bridged, inference starts exploring the branch that deals with the bridges. Objective bridges lead to the graph, which leads to other bridges, and so inference continues until we hit the type-instabilities and it gives up.
 * One attempt at solving this was https://github.com/jump-dev/MathOptInterface.jl/pull/1252. But this tried to squeeze the logic into CachingOptimizer, and tied CachingOptimizer and LazyBridgeOptimizer together too much.
 * A related PR is https://github.com/jump-dev/JuMP.jl/pull/2520. If JuMP's backend is not a concrete type, we don't need the CachingOptimizer to also be non-concrete.

## Demo

By default, the `LazyBridgeOptimizer` is omitted. But, if you do something that requires bridges, they are added:
```Julia
julia> model = Model(Clp.Optimizer)
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: EMPTY_OPTIMIZER
Solver name: Clp

julia> backend(model)
MOIU.CachingOptimizer{Clp.Optimizer, MOIU.UniversalFallback{MOIU.GenericModel{Float64, MOIU.ModelFunctionConstraints{Float64}}}}
in state EMPTY_OPTIMIZER
in mode AUTOMATIC
with model cache MOIU.UniversalFallback{MOIU.GenericModel{Float64, MOIU.ModelFunctionConstraints{Float64}}}
  fallback for MOIU.GenericModel{Float64, MOIU.ModelFunctionConstraints{Float64}}
with optimizer Clp.Optimizer

julia> @variable(model, x[1:4] in MOI.Nonnegatives(4))
4-element Vector{VariableRef}:
 x[1]
 x[2]
 x[3]
 x[4]

julia> backend(model)
MOIU.CachingOptimizer{MOIB.LazyBridgeOptimizer{MOIU.CachingOptimizer{Clp.Optimizer, MOIU.UniversalFallback{MOIU.GenericModel{Float64, MOIU.ModelFunctionConstraints{Float64}}}}}, MOIU.UniversalFallback{MOIU.GenericModel{Float64, MOIU.ModelFunctionConstraints{Float64}}}}
in state EMPTY_OPTIMIZER
in mode AUTOMATIC
with model cache MOIU.UniversalFallback{MOIU.GenericModel{Float64, MOIU.ModelFunctionConstraints{Float64}}}
  fallback for MOIU.GenericModel{Float64, MOIU.ModelFunctionConstraints{Float64}}
with optimizer MOIB.LazyBridgeOptimizer{MOIU.CachingOptimizer{Clp.Optimizer, MOIU.UniversalFallback{MOIU.GenericModel{Float64, MOIU.ModelFunctionConstraints{Float64}}}}}
  with 0 variable bridges
  with 0 constraint bridges
  with 0 objective bridges
  with inner model MOIU.CachingOptimizer{Clp.Optimizer, MOIU.UniversalFallback{MOIU.GenericModel{Float64, MOIU.ModelFunctionConstraints{Float64}}}}
    in state ATTACHED_OPTIMIZER
    in mode AUTOMATIC
    with model cache MOIU.UniversalFallback{MOIU.GenericModel{Float64, MOIU.ModelFunctionConstraints{Float64}}}
      fallback for MOIU.GenericModel{Float64, MOIU.ModelFunctionConstraints{Float64}}
    with optimizer Clp.Optimizer
```

You can also pass `bridge_constraints = true` to force-add the bridges:
```julia
julia> model = Model(Clp.Optimizer; bridge_constraints = true)
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: EMPTY_OPTIMIZER
Solver name: Clp

julia> backend(model)
MOIU.CachingOptimizer{MOIB.LazyBridgeOptimizer{MOIU.CachingOptimizer{Clp.Optimizer, MOIU.UniversalFallback{MOIU.GenericModel{Float64, MOIU.ModelFunctionConstraints{Float64}}}}}, MOIU.UniversalFallback{MOIU.GenericModel{Float64, MOIU.ModelFunctionConstraints{Float64}}}}
in state EMPTY_OPTIMIZER
in mode AUTOMATIC
with model cache MOIU.UniversalFallback{MOIU.GenericModel{Float64, MOIU.ModelFunctionConstraints{Float64}}}
  fallback for MOIU.GenericModel{Float64, MOIU.ModelFunctionConstraints{Float64}}
with optimizer MOIB.LazyBridgeOptimizer{MOIU.CachingOptimizer{Clp.Optimizer, MOIU.UniversalFallback{MOIU.GenericModel{Float64, MOIU.ModelFunctionConstraints{Float64}}}}}
  with 0 variable bridges
  with 0 constraint bridges
  with 0 objective bridges
  with inner model MOIU.CachingOptimizer{Clp.Optimizer, MOIU.UniversalFallback{MOIU.GenericModel{Float64, MOIU.ModelFunctionConstraints{Float64}}}}
    in state ATTACHED_OPTIMIZER
    in mode AUTOMATIC
    with model cache MOIU.UniversalFallback{MOIU.GenericModel{Float64, MOIU.ModelFunctionConstraints{Float64}}}
      fallback for MOIU.GenericModel{Float64, MOIU.ModelFunctionConstraints{Float64}}
    with optimizer Clp.Optimizer
```

## Alternative

The alternative is to change the default of `bridge_constraints` to `false`, and also fix the double abstract-type issue. 

This would give everyone a speed-up if they don't use bridges, and for models which use bridges, they can just go
```Julia
Model(GLPK.Optimizer, bridge_constraints = true)
```
This would have the added benefit of giving people greater insight into when bridges get used.

## Benchmark

```Julia
using JuMP, Clp

### No bridging

function foo()
    model = Model(Clp.Optimizer)
    set_silent(model)
    @variable(model, x >= 0)
    @constraint(model, 2x + 1 <= 1)
    @objective(model, Max, 1.0 * x)
    optimize!(model)
end

### ObjectiveFunction bridging

function foo_obj()
    model = Model(Clp.Optimizer)
    set_silent(model)
    @variable(model, x >= 0)
    @constraint(model, 2x + 1 <= 1)
    @objective(model, Max, x)
    optimize!(model)
end

### variable bridging

function foo_var()
    model = Model(Clp.Optimizer)
    set_silent(model)
    @variable(model, x[1:1] in MOI.Nonnegatives(1))
    @constraint(model, 2x[1] + 1 <= 1)
    @objective(model, Max, 1.0 * x[1])
    optimize!(model)
end

### constraint bridging

function foo_con()
    model = Model(Clp.Optimizer)
    set_silent(model)
    @variable(model, x[1:2])
    @constraint(model, x in MOI.Nonpositives(2))
    @objective(model, Max, 1.0 * x[1])
    optimize!(model)
end

if get(ARGS, 1, "") == "--var"
    @time foo_var()
    @time foo_var()
elseif get(ARGS, 1, "") == "--con"
    @time foo_con()
    @time foo_con()
elseif get(ARGS, 1, "") == "--obj"
    @time foo_obj()
    @time foo_obj()
else
    @time foo()
    @time foo()
end
```

Current `master`
```
(base) oscar@Oscars-MBP JuMP % ~/julia --project=. ~/Documents/JuMP/performance/auto-cache/new_auto.jl
 15.042563 seconds (19.82 M allocations: 1.149 GiB, 2.70% gc time, 36.00% compilation time)
  0.001562 seconds (4.42 k allocations: 327.695 KiB)
(base) oscar@Oscars-MBP JuMP % ~/julia --project=. ~/Documents/JuMP/performance/auto-cache/new_auto.jl --var
 17.091837 seconds (21.71 M allocations: 1.264 GiB, 2.83% gc time, 33.98% compilation time)
  0.001261 seconds (4.74 k allocations: 365.414 KiB)
(base) oscar@Oscars-MBP JuMP % ~/julia --project=. ~/Documents/JuMP/performance/auto-cache/new_auto.jl --con
 15.977032 seconds (20.92 M allocations: 1.219 GiB, 2.91% gc time, 39.28% compilation time)
  0.001164 seconds (4.42 k allocations: 325.242 KiB)
(base) oscar@Oscars-MBP JuMP % ~/julia --project=. ~/Documents/JuMP/performance/auto-cache/new_auto.jl --obj
 15.682321 seconds (20.06 M allocations: 1.164 GiB, 3.10% gc time, 35.60% compilation time)
  0.001150 seconds (4.43 k allocations: 328.055 KiB)
```

This PR

```
(base) oscar@Oscars-MBP JuMP % ~/julia --project=. ~/Documents/JuMP/performance/auto-cache/new_auto.jl 
  7.989580 seconds (4.24 M allocations: 250.037 MiB, 0.85% gc time, 99.96% compilation time)
  0.000485 seconds (1.87 k allocations: 154.148 KiB)
(base) oscar@Oscars-MBP JuMP % ~/julia --project=. ~/Documents/JuMP/performance/auto-cache/new_auto.jl --var
 16.764737 seconds (23.05 M allocations: 1.349 GiB, 2.82% gc time, 29.02% compilation time)
  0.001286 seconds (4.88 k allocations: 377.680 KiB)
(base) oscar@Oscars-MBP JuMP % ~/julia --project=. ~/Documents/JuMP/performance/auto-cache/new_auto.jl --con
 15.583102 seconds (22.05 M allocations: 1.290 GiB, 3.06% gc time, 31.92% compilation time)
  0.001189 seconds (4.53 k allocations: 334.664 KiB)
(base) oscar@Oscars-MBP JuMP % ~/julia --project=. ~/Documents/JuMP/performance/auto-cache/new_auto.jl --obj
 14.417599 seconds (19.37 M allocations: 1.130 GiB, 3.01% gc time, 38.62% compilation time)
  0.001061 seconds (4.56 k allocations: 339.273 KiB)
```

The big change is really that its 2x as fast when bridges are not needed. Note that this uses MOI 0.9.21, so it doesn't account for all the recent changes I've been making. We should re-do this benchmark after MOI is released.

## TODO

TODOs before merging
 - [ ] Update to MOI 0.10
 - [ ] Better tests
 - [ ] Update documentation