### PR TITLE
Fix inference in add_constraint

### DIFF
--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -555,8 +555,7 @@ function add_constraint(
     # The type of backend(model) is unknown so we directly redirect to another
     # function.
     check_belongs_to_model(con, model)
-    func = moi_function(con)
-    set = moi_set(con)
+    func, set = moi_function(con), moi_set(con)
     cindex = moi_add_constraint(
         backend(model),
         func,

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -555,7 +555,13 @@ function add_constraint(
     # The type of backend(model) is unknown so we directly redirect to another
     # function.
     check_belongs_to_model(con, model)
-    cindex = moi_add_constraint(backend(model), moi_function(con), moi_set(con))
+    func = moi_function(con)
+    set = moi_set(con)
+    cindex = moi_add_constraint(
+        backend(model),
+        func,
+        set,
+    )::MOI.ConstraintIndex{typeof(func),typeof(set)}
     cshape = shape(con)
     if !(cshape isa ScalarShape) && !(cshape isa VectorShape)
         model.shapes[cindex] = cshape

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -960,6 +960,16 @@ function test_abstractarray_vector_constraint(ModelType, ::Any)
     @test obj.set == MOI.SOS1([1.0, 2.0, 3.0, 4.0])
 end
 
+function test_constraint_inference(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, x)
+    foo(model, x) = @constraint(model, 2x <= 1)
+    c = @inferred foo(model, x)
+    obj = constraint_object(c)
+    @test obj.func == 2x
+    @test obj.set == MOI.LessThan(1.0)
+end
+
 function runtests()
     for name in names(@__MODULE__; all = true)
         if !startswith("$(name)", "test_")


### PR DESCRIPTION
Closes #2611 

Before:

```Julia
julia> using JuMP

julia> model = Model()
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: NO_OPTIMIZER
Solver name: No optimizer attached.

julia> @variable(model, x)
x

julia> main(model, x) = @constraint(model, 2x <= 1)
main (generic function with 1 method)

julia> @code_warntype main(model, x)
Variables
  #self#::Core.Const(main)
  model::Model
  x::VariableRef
  ##259::AffExpr
  ##260::AffExpr
  ##261::AffExpr
  ##262::MutableArithmetics.Zero

Body::ConstraintRef{Model, _A, ScalarShape} where _A
1 ─       JuMP._valid_model(model, :model)
│   %2  = MutableArithmetics.Zero::Core.Const(MutableArithmetics.Zero)
│         (##262 = (%2)())
│   %4  = MutableArithmetics.operate!::Core.Const(MutableArithmetics.operate!)
│   %5  = MutableArithmetics.add_mul::Core.Const(MutableArithmetics.add_mul)
│   %6  = ##262::Core.Const(MutableArithmetics.Zero())
│         (##261 = (%4)(%5, %6, 2, x))
│   %8  = MutableArithmetics.operate!::Core.Const(MutableArithmetics.operate!)
│   %9  = MutableArithmetics.sub_mul::Core.Const(MutableArithmetics.sub_mul)
│   %10 = ##261::AffExpr
│         (##260 = (%8)(%9, %10, 1))
│         (##259 = ##260)
│   %13 = JuMP._functionize(##259)::AffExpr
│   %14 = JuMP.build_constraint(JuMP.var"#_error#92"{Tuple{Symbol, Expr}, Symbol, LineNumberNode}((:model, :($(Expr(:escape, 2)) * $(Expr(:escape, :x)) <= 1)), :constraint, :(#= REPL[4]:1 =#)), %13, MathOptInterface.LessThan{Float64}(0.0))::ScalarConstraint{AffExpr, MathOptInterface.LessThan{Float64}}
│   %15 = JuMP.add_constraint(model, %14, "")::ConstraintRef{Model, _A, ScalarShape} where _A
└──       return %15
```

After
```Julia
julia> @code_warntype main(model, x)
Variables
  #self#::Core.Const(main)
  model::Model
  x::VariableRef
  ##267::AffExpr
  ##268::AffExpr
  ##269::AffExpr
  ##270::MutableArithmetics.Zero

Body::ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}
1 ─       JuMP._valid_model(model, :model)
│   %2  = MutableArithmetics.Zero::Core.Const(MutableArithmetics.Zero)
│         (##270 = (%2)())
│   %4  = MutableArithmetics.operate!::Core.Const(MutableArithmetics.operate!)
│   %5  = MutableArithmetics.add_mul::Core.Const(MutableArithmetics.add_mul)
│   %6  = ##270::Core.Const(MutableArithmetics.Zero())
│         (##269 = (%4)(%5, %6, 2, x))
│   %8  = MutableArithmetics.operate!::Core.Const(MutableArithmetics.operate!)
│   %9  = MutableArithmetics.sub_mul::Core.Const(MutableArithmetics.sub_mul)
│   %10 = ##269::AffExpr
│         (##268 = (%8)(%9, %10, 1))
│         (##267 = ##268)
│   %13 = JuMP._functionize(##267)::AffExpr
│   %14 = JuMP.build_constraint(JuMP.var"#_error#94"{Tuple{Symbol, Expr}, Symbol, LineNumberNode}((:model, :($(Expr(:escape, 2)) * $(Expr(:escape, :x)) <= 1)), :constraint, :(#= REPL[9]:1 =#)), %13, MathOptInterface.LessThan{Float64}(0.0))::ScalarConstraint{AffExpr, MathOptInterface.LessThan{Float64}}
│   %15 = JuMP.add_constraint(model, %14, "")::ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}
└──       return %15
```