### PR TITLE
OptimizerWithAttributes direct model constructor

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -335,17 +335,9 @@ end
 Return a new JuMP model that instantiates a [`OptimizerWithAttributes`](@ref) to store the
 model and solve it.
 """
-function direct_model(optimizer::MOI.OptimizerWithAttributes)
-    return Model(
-        MOI._instantiate_and_check(optimizer),
-        Dict{_MOICON,AbstractShape}(),
-        Set{Any}(),
-        nothing,
-        nothing,
-        Dict{Symbol,Any}(),
-        0,
-        Dict{Symbol,Any}(),
-    )
+function direct_model(factory::MOI.OptimizerWithAttributes)
+    optimizer = MOI.instantiate(factory)
+    return direct_model(optimizer)
 end
 
 Base.broadcastable(model::Model) = Ref(model)

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -348,8 +348,6 @@ function direct_model(optimizer::MOI.OptimizerWithAttributes)
     )
 end
 
-
-
 Base.broadcastable(model::Model) = Ref(model)
 
 """

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -330,10 +330,28 @@ function direct_model(backend::MOI.ModelLike)
 end
 
 """
-    direct_model(optimizer::MOI.OptimizerWithAttributes)
+    direct_model(factory::MOI.OptimizerWithAttributes)
 
-Return a new JuMP model that instantiates a [`OptimizerWithAttributes`](@ref) to store the
-model and solve it.
+Create a [`direct_model`](@ref) using `factory`, a `MOI.OptimizerWithAttributes`
+object created by [`optimizer_with_attributes`](@ref).
+
+## Example
+
+```julia
+model = direct_model(
+    optimizer_with_attributes(
+        Gurobi.Optimizer,
+        "Presolve" => 0,
+        "OutputFlag" => 1,
+    )
+)
+```
+is equivalent to:
+```julia
+model = direct_model(Gurobi.Optimizer())
+set_optimizer_attribute(model, "Presolve", 0)
+set_optimizer_attribute(model, "OutputFlag", 1)
+```
 """
 function direct_model(factory::MOI.OptimizerWithAttributes)
     optimizer = MOI.instantiate(factory)

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -329,6 +329,27 @@ function direct_model(backend::MOI.ModelLike)
     )
 end
 
+"""
+    direct_model(optimizer::MOI.OptimizerWithAttributes)
+
+Return a new JuMP model that instantiates a [`OptimizerWithAttributes`](@ref) to store the
+model and solve it.
+"""
+function direct_model(optimizer::MOI.OptimizerWithAttributes)
+    return Model(
+        MOI._instantiate_and_check(optimizer),
+        Dict{_MOICON,AbstractShape}(),
+        Set{Any}(),
+        nothing,
+        nothing,
+        Dict{Symbol,Any}(),
+        0,
+        Dict{Symbol,Any}(),
+    )
+end
+
+
+
 Base.broadcastable(model::Model) = Ref(model)
 
 """

--- a/test/model.jl
+++ b/test/model.jl
@@ -619,8 +619,8 @@ function test_direct_mode_using_OptimizerWithAttributes()
     optimizer = optimizer_with_attributes(fake_optimizer, "a" => 1, "b" => 2)
     model = JuMP.direct_model(optimizer)
     @test model.moi_backend isa MOIU.MockOptimizer
-    @test MOI.get(model.moi_backend, MOI.RawOptimizerAttribute("a")) == 1
-    @test MOI.get(model.moi_backend, MOI.RawOptimizerAttribute("b")) == 2
+    @test MOI.get(model.moi_backend, MOI.RawParameter("a")) == 1
+    @test MOI.get(model.moi_backend, MOI.RawParameter("b")) == 2
 end
 
 function test_copy_expr_aff()

--- a/test/model.jl
+++ b/test/model.jl
@@ -609,6 +609,20 @@ function test_copy_direct_mode()
     @test_throws ErrorException JuMP.copy(model)
 end
 
+function test_direct_mode_using_OptimizerWithAttributes()
+    function fake_optimizer()
+        return MOIU.MockOptimizer(
+            MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+        )
+    end
+
+    optimizer = optimizer_with_attributes(fake_optimizer, "a" => 1, "b" => 2)
+    model = JuMP.direct_model(optimizer)
+    @test model.moi_backend isa MOIU.MockOptimizer
+    @test MOI.get(model.moi_backend, MOI.RawOptimizerAttribute("a")) == 1
+    @test MOI.get(model.moi_backend, MOI.RawOptimizerAttribute("b")) == 2
+end
+
 function test_copy_expr_aff()
     model = Model()
     @variable(model, x)


### PR DESCRIPTION
Adds a way to create a direct model when the user passes an `OptimizerWithAttributes`. The rationale is to reuse solver definitions for different model options. 