### PR TITLE
[breaking] Ignore infinite variable bounds

### DIFF
--- a/src/variables.jl
+++ b/src/variables.jl
@@ -121,15 +121,15 @@ struct VariableInfo{S,T,U,V}
         binary::Bool,
         integer::Bool,
     ) where {S,T,U,V}
-        if has_lb && lower_bound === -Inf
+        if has_lb && !isfinite(lower_bound)
             has_lb = false
             lower_bound = NaN
         end
-        if has_ub && upper_bound === Inf
+        if has_ub && !isfinite(upper_bound)
             has_ub = false
             upper_bound = NaN
         end
-        if has_fix && (fixed_value === -Inf || fixed_value === Inf)
+        if has_fix && !isfinite(fixed_value)
             error("Unable to fix variable to $(fixed_value)")
         end
         return new{S,T,U,V}(
@@ -486,7 +486,7 @@ See also [`LowerBoundRef`](@ref), [`has_lower_bound`](@ref),
 [`lower_bound`](@ref), [`delete_lower_bound`](@ref).
 """
 function set_lower_bound(v::VariableRef, lower::Number)
-    if lower === -Inf
+    if !isfinite(lower)
         error(
             "Unable to set lower bound to $(lower). To remove the bound, use " *
             "`delete_lower_bound`.",
@@ -591,7 +591,7 @@ See also [`UpperBoundRef`](@ref), [`has_upper_bound`](@ref),
 [`upper_bound`](@ref), [`delete_upper_bound`](@ref).
 """
 function set_upper_bound(v::VariableRef, upper::Number)
-    if upper === Inf
+    if !isfinite(upper)
         error(
             "Unable to set upper bound to $(upper). To remove the bound, use " *
             "`delete_upper_bound`.",
@@ -700,7 +700,7 @@ See also [`FixRef`](@ref), [`is_fixed`](@ref), [`fix_value`](@ref),
 [`unfix`](@ref).
 """
 function fix(variable::VariableRef, value::Number; force::Bool = false)
-    if value === -Inf || value === Inf
+    if !isfinite(value)
         error("Unable to fix variable to $(value)")
     end
     return _moi_fix(backend(owner_model(variable)), variable, value, force)

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -90,6 +90,12 @@ function _VariableInfoExpr(;
     )
 end
 
+# It isn't sufficient to use `isfinite` below, because some bounds are given as
+# matrices. As a fallback, we define `_isfinite`, because overloading `isfinite`
+# would be type piracy.
+_isfinite(x::Number) = isfinite(x)
+_isfinite(x) = true
+
 """
     VariableInfo{S,T,U,V}
 
@@ -121,15 +127,15 @@ struct VariableInfo{S,T,U,V}
         binary::Bool,
         integer::Bool,
     ) where {S,T,U,V}
-        if has_lb && !isfinite(lower_bound)
+        if has_lb && !_isfinite(lower_bound)
             has_lb = false
             lower_bound = NaN
         end
-        if has_ub && !isfinite(upper_bound)
+        if has_ub && !_isfinite(upper_bound)
             has_ub = false
             upper_bound = NaN
         end
-        if has_fix && !isfinite(fixed_value)
+        if has_fix && !_isfinite(fixed_value)
             error("Unable to fix variable to $(fixed_value)")
         end
         return new{S,T,U,V}(

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -109,6 +109,42 @@ struct VariableInfo{S,T,U,V}
     start::V
     binary::Bool
     integer::Bool
+    function VariableInfo(
+        has_lb::Bool,
+        lower_bound::S,
+        has_ub::Bool,
+        upper_bound::T,
+        has_fix::Bool,
+        fixed_value::U,
+        has_start::Bool,
+        start::V,
+        binary::Bool,
+        integer::Bool,
+    ) where {S,T,U,V}
+        if has_lb && lower_bound === -Inf
+            has_lb = false
+            lower_bound = NaN
+        end
+        if has_ub && upper_bound === Inf
+            has_ub = false
+            upper_bound = NaN
+        end
+        if has_fix && (fixed_value === -Inf || fixed_value === Inf)
+            error("Unable to fix variable to $(fixed_value)")
+        end
+        return new{S,T,U,V}(
+            has_lb,
+            lower_bound,
+            has_ub,
+            upper_bound,
+            has_fix,
+            fixed_value,
+            has_start,
+            start,
+            binary,
+            integer,
+        )
+    end
 end
 
 function _constructor_expr(info::_VariableInfoExpr)
@@ -450,6 +486,12 @@ See also [`LowerBoundRef`](@ref), [`has_lower_bound`](@ref),
 [`lower_bound`](@ref), [`delete_lower_bound`](@ref).
 """
 function set_lower_bound(v::VariableRef, lower::Number)
+    if lower === -Inf
+        error(
+            "Unable to set lower bound to $(lower). To remove the bound, use " *
+            "`delete_lower_bound`.",
+        )
+    end
     return _moi_set_lower_bound(backend(owner_model(v)), v, lower)
 end
 
@@ -549,6 +591,12 @@ See also [`UpperBoundRef`](@ref), [`has_upper_bound`](@ref),
 [`upper_bound`](@ref), [`delete_upper_bound`](@ref).
 """
 function set_upper_bound(v::VariableRef, upper::Number)
+    if upper === Inf
+        error(
+            "Unable to set upper bound to $(upper). To remove the bound, use " *
+            "`delete_upper_bound`.",
+        )
+    end
     return _moi_set_upper_bound(backend(owner_model(v)), v, upper)
 end
 
@@ -652,6 +700,9 @@ See also [`FixRef`](@ref), [`is_fixed`](@ref), [`fix_value`](@ref),
 [`unfix`](@ref).
 """
 function fix(variable::VariableRef, value::Number; force::Bool = false)
+    if value === -Inf || value === Inf
+        error("Unable to fix variable to $(value)")
+    end
     return _moi_fix(backend(owner_model(variable)), variable, value, force)
 end
 

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -948,6 +948,53 @@ function test_start_value(::Any, ::Any)
     @test start_value(x) == 1.0
 end
 
+function test_Model_inf_lower_bound(::Any, ::Any)
+    model = Model()
+    @variable(model, x >= -Inf)
+    @test !has_lower_bound(x)
+    @test_throws(
+        ErrorException(
+            "Unable to set lower bound to -Inf. To remove the bound, use " *
+            "`delete_lower_bound`.",
+        ),
+        set_lower_bound(x, -Inf),
+    )
+end
+
+function test_Model_inf_upper_bound(::Any, ::Any)
+    model = Model()
+    @variable(model, x <= Inf)
+    @test !has_upper_bound(x)
+    @test_throws(
+        ErrorException(
+            "Unable to set upper bound to Inf. To remove the bound, use " *
+            "`delete_upper_bound`.",
+        ),
+        set_upper_bound(x, Inf),
+    )
+end
+
+function test_Model_inf_fixed(::Any, ::Any)
+    model = Model()
+    @test_throws(
+        ErrorException("Unable to fix variable to $(Inf)"),
+        @variable(model, x == Inf),
+    )
+    @test_throws(
+        ErrorException("Unable to fix variable to $(-Inf)"),
+        @variable(model, x == -Inf),
+    )
+    @variable(model, x)
+    @test_throws(
+        ErrorException("Unable to fix variable to $(-Inf)"),
+        fix(x, -Inf),
+    )
+    @test_throws(
+        ErrorException("Unable to fix variable to $(Inf)"),
+        fix(x, Inf),
+    )
+end
+
 function runtests()
     for name in names(@__MODULE__; all = true)
         if !startswith("$(name)", "test_")

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -949,50 +949,45 @@ function test_start_value(::Any, ::Any)
 end
 
 function test_Model_inf_lower_bound(::Any, ::Any)
-    model = Model()
-    @variable(model, x >= -Inf)
-    @test !has_lower_bound(x)
-    @test_throws(
-        ErrorException(
-            "Unable to set lower bound to -Inf. To remove the bound, use " *
-            "`delete_lower_bound`.",
-        ),
-        set_lower_bound(x, -Inf),
-    )
+    for y in [-Inf, Inf, NaN]
+        model = Model()
+        @variable(model, x >= y)
+        @test !has_lower_bound(x)
+        @test_throws(
+            ErrorException(
+                "Unable to set lower bound to $y. To remove the bound, use " *
+                "`delete_lower_bound`.",
+            ),
+            set_lower_bound(x, y),
+        )
+    end
 end
 
 function test_Model_inf_upper_bound(::Any, ::Any)
-    model = Model()
-    @variable(model, x <= Inf)
-    @test !has_upper_bound(x)
-    @test_throws(
-        ErrorException(
-            "Unable to set upper bound to Inf. To remove the bound, use " *
-            "`delete_upper_bound`.",
-        ),
-        set_upper_bound(x, Inf),
-    )
+    for y in [-Inf, Inf, NaN]
+        model = Model()
+        @variable(model, x <= y)
+        @test !has_upper_bound(x)
+        @test_throws(
+            ErrorException(
+                "Unable to set upper bound to $y. To remove the bound, use " *
+                "`delete_upper_bound`.",
+            ),
+            set_upper_bound(x, y),
+        )
+    end
 end
 
 function test_Model_inf_fixed(::Any, ::Any)
-    model = Model()
-    @test_throws(
-        ErrorException("Unable to fix variable to $(Inf)"),
-        @variable(model, x == Inf),
-    )
-    @test_throws(
-        ErrorException("Unable to fix variable to $(-Inf)"),
-        @variable(model, x == -Inf),
-    )
-    @variable(model, x)
-    @test_throws(
-        ErrorException("Unable to fix variable to $(-Inf)"),
-        fix(x, -Inf),
-    )
-    @test_throws(
-        ErrorException("Unable to fix variable to $(Inf)"),
-        fix(x, Inf),
-    )
+    for y in [-Inf, Inf, NaN]
+        model = Model()
+        @test_throws(
+            ErrorException("Unable to fix variable to $y"),
+            @variable(model, x == y),
+        )
+        @variable(model, x)
+        @test_throws(ErrorException("Unable to fix variable to $y"), fix(x, y))
+    end
 end
 
 function runtests()


### PR DESCRIPTION
Introducing non-finite variable bounds is just a cause of trouble: https://github.com/jump-dev/MathOptInterface.jl/issues/1270

Setting a bound to `-Inf` or `Inf` after creation is just a sign that the user wants to delete the bound. So we should make them do it explicitly.

This is breaking because people may be relying on `has_lower_bound` returning `true` if the bound is `-Inf`.

Closes https://github.com/jump-dev/MathOptInterface.jl/issues/1270

