### PR TITLE
Fix map for DenseAxisArray with OneTo axes

### DIFF
--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -201,7 +201,7 @@ function Base.similar(
     ::DenseAxisArray{T, N, Ax},
     ::Type{S},
     axes::Ax,
-) where {T, N, Ax<:Tuple{Base.OneTo, Vararg{Base.OneTo}}, S}
+) where {T,N,Ax<:Tuple{Base.OneTo,Vararg{Base.OneTo}},S}
     return construct_undef_array(S, axes)
 end
 

--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -198,7 +198,7 @@ end
 # Avoid conflict with method defined in Julia Base when the axes of the
 # `DenseAxisArray` are all `Base.OneTo`:
 function Base.similar(
-    ::DenseAxisArray{T, N, Ax},
+    ::DenseAxisArray{T,N,Ax},
     ::Type{S},
     axes::Ax,
 ) where {T,N,Ax<:Tuple{Base.OneTo,Vararg{Base.OneTo}},S}

--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -195,6 +195,15 @@ function Base.similar(
 ) where {T,N,Ax,S}
     return construct_undef_array(S, axes)
 end
+# Avoid conflict with method defined in Julia Base when the axes of the
+# `DenseAxisArray` are all `Base.OneTo`:
+function Base.similar(
+    ::DenseAxisArray{T, N, Ax},
+    ::Type{S},
+    axes::Ax,
+) where {T, N, Ax<:Tuple{Base.OneTo, Vararg{Base.OneTo}}, S}
+    return construct_undef_array(S, axes)
+end
 
 # AbstractArray interface
 

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -283,7 +283,7 @@ And data, a 0-dimensional $(Array{Int,0}):
         @test B isa DenseAxisArray
         @test B.data == [1, 9, 4]
         @test B.axes == (Base.OneTo(3),)
-        C = @inferred DenseAxisArray([1  3; 2 4], Base.OneTo(2), Base.OneTo(2))
+        C = @inferred DenseAxisArray([1 3; 2 4], Base.OneTo(2), Base.OneTo(2))
         D = @inferred map(x -> x - 1, C)
         @test D isa DenseAxisArray
         @test D.data == [0 2; 1 3]

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -107,7 +107,7 @@ And data, a 2-element $(Vector{Float64}):
         @test A[2, :a, 1] == 1
         @test A[2, :a, 1, 1] == 1
         @test A[3, :a, 1, 1, 1] == 3
-        @test @inferred A[:, :a] == DenseAxisArray([1, 3], 2:3)
+        @test DenseAxisArray([1, 3], 2:3) == @inferred A[:, :a]
         @test A[2, :] == DenseAxisArray([1, 2], [:a, :b])
         @test sprint(show, A) == """
 2-dimensional DenseAxisArray{$Int,2,...} with index sets:
@@ -276,5 +276,17 @@ And data, a 0-dimensional $(Array{Int,0}):
         @test_throws ErrorException A .+ B
         b = [5.0 6.0; 7.0 8.0; 9.0 10.0]
         @test_throws DimensionMismatch A .+ b
+    end
+    @testset "DenseAxisArray with Base.OneTo" begin
+        A = @inferred DenseAxisArray([1, 3, 2], Base.OneTo(3))
+        B = @inferred map(x -> x^2, A)
+        @test B isa DenseAxisArray
+        @test B.data == [1, 9, 4]
+        @test B.axes == (Base.OneTo(3),)
+        C = @inferred DenseAxisArray([1  3; 2 4], Base.OneTo(2), Base.OneTo(2))
+        D = @inferred map(x -> x - 1, C)
+        @test D isa DenseAxisArray
+        @test D.data == [0 2; 1 3]
+        @test D.axes == (Base.OneTo(2), Base.OneTo(2))
     end
 end


### PR DESCRIPTION
Reported in https://discourse.julialang.org/t/jump-error-while-fixing-variable-defined-as-denseaxisarray-using-map-function/62461