### PR TITLE
Update printing of SparseAxisArray

### DIFF
--- a/docs/src/manual/containers.md
+++ b/docs/src/manual/containers.md
@@ -182,9 +182,9 @@ An index depends on a prior index:
 ```jldoctest containers_sparse
 julia> Containers.@container([i = 1:2, j = i:2], (i, j))
 JuMP.Containers.SparseAxisArray{Tuple{Int64,Int64},2,Tuple{Int64,Int64}} with 3 entries:
+  [1, 1]  =  (1, 1)
   [1, 2]  =  (1, 2)
   [2, 2]  =  (2, 2)
-  [1, 1]  =  (1, 1)
 ```
 
 The `[indices; condition]` syntax is used:
@@ -341,20 +341,20 @@ This occurs when some indices depend on a previous one:
 ```jldoctest
 julia> Containers.@container([i=1:3, j=1:i], i + j)
 JuMP.Containers.SparseAxisArray{Int64,2,Tuple{Int64,Int64}} with 6 entries:
+  [1, 1]  =  2
+  [2, 1]  =  3
+  [2, 2]  =  4
   [3, 1]  =  4
   [3, 2]  =  5
   [3, 3]  =  6
-  [2, 2]  =  4
-  [1, 1]  =  2
-  [2, 1]  =  3
 ```
 or if there is a condition on the index sets:
 ```jldoctest
 julia> Containers.@container([i = 1:5; isodd(i)], i^2)
 JuMP.Containers.SparseAxisArray{Int64,1,Tuple{Int64}} with 3 entries:
+  [1]  =  1
   [3]  =  9
   [5]  =  25
-  [1]  =  1
 ```
 
 The condition can depend on multiple indices; it just needs to be a function

--- a/docs/src/manual/variables.md
+++ b/docs/src/manual/variables.md
@@ -379,9 +379,9 @@ indices (called *triangular indexing*). JuMP supports this as follows:
 ```jldoctest; setup=:(model=Model())
 julia> @variable(model, x[i=1:2, j=i:2])
 JuMP.Containers.SparseAxisArray{VariableRef,2,Tuple{Int64,Int64}} with 3 entries:
+  [1, 1]  =  x[1,1]
   [1, 2]  =  x[1,2]
   [2, 2]  =  x[2,2]
-  [1, 1]  =  x[1,1]
 ```
 
 We can also conditionally create variables via a JuMP-specific syntax. This
@@ -390,8 +390,8 @@ separated from the indices by a semi-colon (`;`). For example:
 ```jldoctest; setup=:(model=Model())
 julia> @variable(model, x[i=1:4; mod(i, 2)==0])
 JuMP.Containers.SparseAxisArray{VariableRef,1,Tuple{Int64}} with 2 entries:
-  [4]  =  x[4]
   [2]  =  x[2]
+  [4]  =  x[4]
 ```
 
 Note that with many index dimensions and a large amount of sparsity,

--- a/src/Containers/SparseAxisArray.jl
+++ b/src/Containers/SparseAxisArray.jl
@@ -280,9 +280,9 @@ function Base.show(io::IOContext, x::SparseAxisArray)
     if isempty(x)
         return show(io, MIME("text/plain"), x)
     end
-    limit::Bool = get(io, :limit, false)
+    limit = get(io, :limit, false)::Bool
     half_screen_rows = limit ? div(displaysize(io)[1] - 8, 2) : typemax(Int)
-    print_entry(i) = i < half_screen_rows || i > length(x) - half_screen_row
+    print_entry(i) = i < half_screen_rows || i > length(x) - half_screen_rows
     # For stable printing, sort by the string value of the key.
     key_strings = [(join(key, ", "), value) for (key, value) in x.data]
     sort!(key_strings; by = x -> x[1])

--- a/test/Containers/SparseAxisArray.jl
+++ b/test/Containers/SparseAxisArray.jl
@@ -151,4 +151,11 @@ $(SparseAxisArray{Float64,2,Tuple{Symbol,Char}}) with 2 entries"""
         @test d isa SparseAxisArray{Any,2,Tuple{Any,Any}}
         @test length(d) == 0
     end
+    @testset "half-screen" begin
+        d = SparseAxisArray(Dict((i,) => 2 * i for i in 1:100))
+        io = IOBuffer()
+        show(IOContext(io, :limit => true, :compact => true), "text/plain", d)
+        seekstart(io)
+        @test occursin("\u22ee", read(io, String))
+    end
 end

--- a/test/Containers/SparseAxisArray.jl
+++ b/test/Containers/SparseAxisArray.jl
@@ -95,16 +95,10 @@ $(SparseAxisArray{Int,1,Tuple{Symbol}}) with 2 entries:
         @testset "Printing" begin
             @test sprint(summary, d) == """
 $(SparseAxisArray{Float64,2,Tuple{Symbol,Char}}) with 2 entries"""
-            have = sprint(show, "text/plain", d)
-            want_A = """
-            $(SparseAxisArray{Float64,2,Tuple{Symbol,Char}}) with 2 entries:
-              [b, v]  =  0.5
-              [a, u]  =  2.0"""
-            want_B = """
+            @test sprint(show, "text/plain", d) == """
             $(SparseAxisArray{Float64,2,Tuple{Symbol,Char}}) with 2 entries:
               [a, u]  =  2.0
               [b, v]  =  0.5"""
-            @test have == want_A || have == want_B
         end
         d2 = @inferred SA(Dict((:b, 'v') => 1.0, (:a, 'u') => 4.0))
         d3 = @inferred SA(Dict((:a, 'u') => 6.0, (:b, 'v') => 1.5))


### PR DESCRIPTION
Closes #2624 

This PR simplifies the printing, makes it stable across Julia versions (now ordered alphabetically), and adds tests for the case where some rows are omitted.