### PR TITLE
Add vector of scalar variables with `in` syntax

### DIFF
--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -377,8 +377,8 @@ end
 # https://docs.julialang.org/en/v1/manual/interfaces/#man-interfaces-broadcasting
 # for implementing broadcast.
 
-function Base.BroadcastStyle(::Type{T}) where {T<:DenseAxisArray}
-    return Broadcast.ArrayStyle{T}()
+function Base.BroadcastStyle(::Type{<:DenseAxisArray})
+    return Broadcast.ArrayStyle{DenseAxisArray}()
 end
 
 function _broadcast_axes_check(x::NTuple{N}) where {N}
@@ -406,7 +406,7 @@ _broadcast_args(x::Any, tail) = (x, _broadcast_args(tail)...)
 _broadcast_args(x::DenseAxisArray, tail) = (x.data, _broadcast_args(tail)...)
 
 function Base.Broadcast.broadcasted(
-    ::Broadcast.ArrayStyle{<:DenseAxisArray},
+    ::Broadcast.ArrayStyle{DenseAxisArray},
     f,
     args...,
 )

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1497,8 +1497,9 @@ function build_variable(
 )
     if length(variables) != length(sets)
         return _error(
-            "Dimensions of the vector of scalar variables and the vector of " *
-            "scalar sets don't match.",
+            "Dimensions must match. Got a vector of scalar variables with" *
+            "$(length(variables)) elements and a vector of " *
+            "scalar sets with $(length(sets)).",
         )
     end
     return VariableConstrainedOnCreation.(variables, sets)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1491,9 +1491,9 @@ function build_variable(
 end
 
 function build_variable(
-    ::Function,
-    variables::Vector{<:ScalarVariable},
-    sets::Vector{<:MOI.AbstractScalarSet},
+    _error::Function,
+    variables::AbstractArray{<:ScalarVariable},
+    sets::AbstractArray{<:MOI.AbstractScalarSet},
 )
     if length(variables) != length(sets)
         return _error(
@@ -1507,7 +1507,7 @@ end
 
 function build_variable(
     ::Function,
-    variables::Vector{<:ScalarVariable},
+    variables::AbstractArray{<:ScalarVariable},
     set::MOI.AbstractScalarSet,
 )
     return VariableConstrainedOnCreation.(variables, Ref(set))

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1516,13 +1516,13 @@ end
 function build_variable(
     _error::Function,
     ::ScalarVariable,
-    ::Vector{<:MOI.AbstractScalarSet},
+    sets::AbstractArray{<:MOI.AbstractScalarSet},
 )
     return _error(
-        "It is not possible to add a scalar variable in a vector of " *
-        "sets. Either add a vector of scalar variables in a scalar set or " *
-        "add a vector of scalar variables in a vector of scalar sets of " *
-        "the same dimension. ",
+        "It is not possible to add a scalar variable in an Array of " *
+        "sets. Either add an Array of scalar variables in a scalar set or " *
+        "add an Array of scalar variables in an Array of scalar sets of " *
+        "the same dimension.",
     )
 end
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1492,6 +1492,41 @@ end
 
 function build_variable(
     ::Function,
+    variables::Vector{<:ScalarVariable},
+    sets::Vector{<:MOI.AbstractScalarSet},
+)
+    if length(variables) != length(sets)
+        return _error(
+            "Dimensions of the vector of scalar variables and the vector of " *
+            "scalar sets don't match.",
+        )
+    end
+    return VariableConstrainedOnCreation.(variables, sets)
+end
+
+function build_variable(
+    ::Function,
+    variables::Vector{<:ScalarVariable},
+    set::MOI.AbstractScalarSet,
+)
+    return VariableConstrainedOnCreation.(variables, Ref(set))
+end
+
+function build_variable(
+    _error::Function,
+    ::ScalarVariable,
+    ::Vector{<:MOI.AbstractScalarSet},
+)
+    return _error(
+        "It is not possible to add a scalar variable in a vector of " *
+        "sets. Either add a vector of scalar variables in a scalar set or " *
+        "add a vector of scalar variables in a vector of scalar sets of " *
+        "the same dimension. ",
+    )
+end
+
+function build_variable(
+    ::Function,
     variables::Vector{<:AbstractVariable},
     set::MOI.AbstractVectorSet,
 )

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1125,6 +1125,13 @@ function add_variable(
     )
     return VariableRef(model, var_index)
 end
+function add_variable(
+    model::Model,
+    variables::Vector{<:VariableConstrainedOnCreation},
+    names::Vector{String},
+)
+    return add_variable.(model, variables, names)
+end
 
 function _moi_add_constrained_variable(
     moi_backend::MOI.ModelLike,

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1125,6 +1125,7 @@ function add_variable(
     )
     return VariableRef(model, var_index)
 end
+
 function add_variable(
     model::Model,
     variables::Vector{<:VariableConstrainedOnCreation},

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1129,7 +1129,7 @@ end
 function add_variable(
     model::Model,
     variables::AbstractArray{<:VariableConstrainedOnCreation},
-    names::AbstractArray{String},
+    names::AbstractArray{<:String},
 )
     return add_variable.(model, variables, names)
 end

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1128,8 +1128,8 @@ end
 
 function add_variable(
     model::Model,
-    variables::Vector{<:VariableConstrainedOnCreation},
-    names::Vector{String},
+    variables::AbstractArray{<:VariableConstrainedOnCreation},
+    names::AbstractArray{String},
 )
     return add_variable.(model, variables, names)
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -1251,6 +1251,34 @@ function test_nlparameter_invalid_number()
     return
 end
 
+function test_broadcasting_variable_in_set()
+    model = Model()
+    @variable(model, z[1:2] in MOI.GreaterThan.([3., 2.]))
+    @test num_variables(model) == 2
+    @test lower_bound.(z) == [3., 2.]
+    @test has_upper_bound.(z) == [false, false]
+    @variable(model, w[1:2] in MOI.GreaterThan(3.0))
+    @test num_variables(model) == 4
+    @test lower_bound.(w) == [3., 3.]
+    @test has_upper_bound.(w) == [false, false]
+    @variable(model, v[1:2] in [MOI.GreaterThan(3.0), MOI.LessThan(3.0), ])
+    @test num_variables(model) == 6
+    @test lower_bound(v[1]) == 3.
+    @test has_upper_bound(v[1]) == false
+    @test upper_bound(v[2]) == 3.
+    @test has_lower_bound(v[2]) == false
+    @test_throws(
+        ErrorException,
+        @variable(model, k in MOI.GreaterThan.([3., 2.])),
+    )
+    @test_throws(
+        ErrorException,
+        @variable(model, u[1:3] in MOI.GreaterThan.([3., 2.])),
+    )
+    @test num_variables(model) == 6
+    return
+end
+
 end  # module
 
 TestMacros.runtests()

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -1277,17 +1277,20 @@ function test_broadcasting_variable_in_set()
     )
     @test num_variables(model) == 6
     # SparseAxisArray
-    @variable(model, b[i=1:2, j=1:2; i+j==3] in MOI.GreaterThan(3.0))
+    @variable(model, b[i = 1:2, j = 1:2; i + j == 3] in MOI.GreaterThan(3.0))
     @test num_variables(model) == 8
-    @variable(model, a[i=1:2, j=1:2; i+j==3] in
-        JuMP.Containers.SparseAxisArray(
+    @variable(
+        model,
+        a[i = 1:2, j = 1:2; i + j == 3] in JuMP.Containers.SparseAxisArray(
             Dict(
-                (1,2) => MOI.GreaterThan(3.0),
-                (2,1) => MOI.GreaterThan(3.0),
-    )))
+                (1, 2) => MOI.GreaterThan(3.0),
+                (2, 1) => MOI.GreaterThan(3.0),
+            ),
+        )
+    )
     @test num_variables(model) == 10
     # DenseAxisArray
-    @variable(model, dense_a[i=["x","xx"]] in MOI.GreaterThan(3.0))
+    @variable(model, dense_a[i = ["x", "xx"]] in MOI.GreaterThan(3.0))
     @test num_variables(model) == 12
     @variable(model, dense_b[1:2, 2:4] in MOI.GreaterThan(3.0))
     @test num_variables(model) == 18

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -1253,27 +1253,27 @@ end
 
 function test_broadcasting_variable_in_set()
     model = Model()
-    @variable(model, z[1:2] in MOI.GreaterThan.([3., 2.]))
+    @variable(model, z[1:2] in MOI.GreaterThan.([3.0, 2.0]))
     @test num_variables(model) == 2
-    @test lower_bound.(z) == [3., 2.]
+    @test lower_bound.(z) == [3.0, 2.0]
     @test has_upper_bound.(z) == [false, false]
     @variable(model, w[1:2] in MOI.GreaterThan(3.0))
     @test num_variables(model) == 4
-    @test lower_bound.(w) == [3., 3.]
+    @test lower_bound.(w) == [3.0, 3.0]
     @test has_upper_bound.(w) == [false, false]
-    @variable(model, v[1:2] in [MOI.GreaterThan(3.0), MOI.LessThan(3.0), ])
+    @variable(model, v[1:2] in [MOI.GreaterThan(3.0), MOI.LessThan(3.0)])
     @test num_variables(model) == 6
-    @test lower_bound(v[1]) == 3.
+    @test lower_bound(v[1]) == 3.0
     @test has_upper_bound(v[1]) == false
-    @test upper_bound(v[2]) == 3.
+    @test upper_bound(v[2]) == 3.0
     @test has_lower_bound(v[2]) == false
     @test_throws(
         ErrorException,
-        @variable(model, k in MOI.GreaterThan.([3., 2.])),
+        @variable(model, k in MOI.GreaterThan.([3.0, 2.0])),
     )
     @test_throws(
         ErrorException,
-        @variable(model, u[1:3] in MOI.GreaterThan.([3., 2.])),
+        @variable(model, u[1:3] in MOI.GreaterThan.([3.0, 2.0])),
     )
     @test num_variables(model) == 6
     return

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -1276,6 +1276,25 @@ function test_broadcasting_variable_in_set()
         @variable(model, u[1:3] in MOI.GreaterThan.([3.0, 2.0])),
     )
     @test num_variables(model) == 6
+
+    # SparseAxisArray
+    @variable(model, b[i=1:2, j=1:2; i+j==3] in MOI.GreaterThan(3.0))
+    @test num_variables(model) == 8
+
+    @variable(model, a[i=1:2, j=1:2; i+j==3] in
+        JuMP.Containers.SparseAxisArray(
+            Dict(
+                (1,2) => MOI.GreaterThan(3.0),
+                (2,1) => MOI.GreaterThan(3.0),
+    )))
+    @test num_variables(model) == 10
+
+    # #DenseAxisArray (F)
+    # @variable(model, a[i=["x","xx"]] in MOI.GreaterThan(3.0))
+    # @test num_variables(model) == 8
+
+    # @variable(model, z1[1:2, 2:4] in MOI.GreaterThan(3.0))
+    # @test num_variables(model) == 12
     return
 end
 

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -1276,11 +1276,9 @@ function test_broadcasting_variable_in_set()
         @variable(model, u[1:3] in MOI.GreaterThan.([3.0, 2.0])),
     )
     @test num_variables(model) == 6
-
     # SparseAxisArray
     @variable(model, b[i=1:2, j=1:2; i+j==3] in MOI.GreaterThan(3.0))
     @test num_variables(model) == 8
-
     @variable(model, a[i=1:2, j=1:2; i+j==3] in
         JuMP.Containers.SparseAxisArray(
             Dict(
@@ -1288,13 +1286,11 @@ function test_broadcasting_variable_in_set()
                 (2,1) => MOI.GreaterThan(3.0),
     )))
     @test num_variables(model) == 10
-
-    # #DenseAxisArray (F)
-    # @variable(model, a[i=["x","xx"]] in MOI.GreaterThan(3.0))
-    # @test num_variables(model) == 8
-
-    # @variable(model, z1[1:2, 2:4] in MOI.GreaterThan(3.0))
-    # @test num_variables(model) == 12
+    # DenseAxisArray
+    @variable(model, dense_a[i=["x","xx"]] in MOI.GreaterThan(3.0))
+    @test num_variables(model) == 12
+    @variable(model, dense_b[1:2, 2:4] in MOI.GreaterThan(3.0))
+    @test num_variables(model) == 18
     return
 end
 


### PR DESCRIPTION
Partially solves: #2148

this enables both:

```julia
model = Model()
@variable(model, x[1:2] in MOI.Integer())
```

and

```julia
model = Model()
@variable(model, x[1:2] in [MOI.Integer(), MOI.ZeroOne()])
```

`.in` does not parse in julia, so `@variable(model, x[1:2] .in MOI.GreaterThan.([3, 2]))` is not an option.

Also added protection to other cases.

This would be a great replacement for https://github.com/jump-dev/ParametricOptInterface.jl/pull/40

cc @guilhermebodin 