### PR TITLE
Add a fallback for getting constraint basis status in `lp_sensitivity_report`

### DIFF
--- a/src/lp_sensitivity2.jl
+++ b/src/lp_sensitivity2.jl
@@ -419,10 +419,10 @@ function _try_get_constraint_basis_status(model::Model, constraint)
         return MOI.get(model, MOI.ConstraintBasisStatus(), constraint)
     catch e
         error(
-            "Unable to query LP sensitivity information because this solver " * 
+            "Unable to query LP sensitivity information because this solver " *
             "does not support querying the status of variables and constraints " *
-            "in the optimal basis."
-            )
+            "in the optimal basis.",
+        )
     end
 end
 

--- a/src/lp_sensitivity2.jl
+++ b/src/lp_sensitivity2.jl
@@ -418,7 +418,11 @@ function _try_get_constraint_basis_status(model::Model, constraint)
     try
         return MOI.get(model, MOI.ConstraintBasisStatus(), constraint)
     catch e
-        error("This solver doesn't support querying the basis.")
+        error(
+            "Unable to query LP sensitivity information because this solver " * 
+            "does not support querying the status of variables and constraints " *
+            "in the optimal basis."
+            )
     end
 end
 


### PR DESCRIPTION
To fix #2569

I added a fallback for getting constraint basis status in `lp_sensitivity_report`.
I would like to add a test for it, but I'm not sure this is testable using `mockoptimizer`.

This is my local test results:
```
julia> using JuMP, Clp

julia> M = Model(Clp.Optimizer);

julia> @variable M A[1:2] >= 0;

julia> @constraint M sum(a for a in A) <= 1;

julia> @objective M Max sum(a for a in A);

julia> optimize!(M);
Coin0506I Presolve 0 (-1) rows, 0 (-2) columns and 0 (-2) elements
Clp3002W Empty problem - 0 rows, 0 columns and 0 elements
Clp0000I Optimal - objective value 1
Coin0511I After Postsolve, objective 1, infeasibilities - dual 0 (0), primal 0 (0)
Clp0032I Optimal objective 1 - 0 iterations time 0.002, Presolve 0.00

julia> lp_sensitivity_report(M)
ERROR: Unable to query LP sensitivity information because this solver does not support querying the status of variables and constraints in the optimal basis.
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] _try_get_constraint_basis_status(model::Model, constraint::ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.SingleVariable, MathOptInterface.GreaterThan{Float64}}, ScalarShape})
   @ JuMP ~/work/julia/JuMP.jl/src/lp_sensitivity2.jl:421
 [3] _standard_form_basis(model::Model, std_form::NamedTuple{(:columns, :lower, :upper, :A, :bounds, :constraints), Tuple{Dict{VariableRef, Int64}, Vector{Float64}, Vector{Float64}, SparseArrays.SparseMatrixCSC{Float64, Int64}, Vector{ConstraintRef}, Vector{ConstraintRef}}})
   @ JuMP ~/work/julia/JuMP.jl/src/lp_sensitivity2.jl:431
 [4] lp_sensitivity_report(model::Model; atol::Float64)
   @ JuMP ~/work/julia/JuMP.jl/src/lp_sensitivity2.jl:76
 [5] lp_sensitivity_report(model::Model)
   @ JuMP ~/work/julia/JuMP.jl/src/lp_sensitivity2.jl:64
 [6] top-level scope
   @ REPL[10]:1
```