### PR TITLE
nothing comparison improvement in DenseAxisArray.jl

### DIFF
--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -309,11 +309,11 @@ function Base.eltype(iter::DenseAxisArrayKeys)
 end
 function Base.iterate(iter::DenseAxisArrayKeys)
     next = iterate(iter.product_iter)
-    return next == nothing ? nothing : (DenseAxisArrayKey(next[1]), next[2])
+    return next === nothing ? nothing : (DenseAxisArrayKey(next[1]), next[2])
 end
 function Base.iterate(iter::DenseAxisArrayKeys, state)
     next = iterate(iter.product_iter, state)
-    return next == nothing ? nothing : (DenseAxisArrayKey(next[1]), next[2])
+    return next === nothing ? nothing : (DenseAxisArrayKey(next[1]), next[2])
 end
 function Base.keys(a::DenseAxisArray)
     return DenseAxisArrayKeys(a)


### PR DESCRIPTION
I'm not sure this is intended or not, but `DenseAxisArray.jl` is using equality comparison (==) for nothing, not identical comparison (===).
If this is not intended, I think later one should be used for small performance improvement.
If this is intended, I'm sorry for bothering you, please close this PR.