### PR TITLE
Fix bug in relax_integrality

### DIFF
--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1246,7 +1246,7 @@ function _info_from_variable(v::VariableRef)
     fixed_value = has_fix ? fix_value(v) : NaN
     has_start, start = false, NaN
     if MOI.supports(
-        owner_model(v),
+        backend(owner_model(v)),
         MOI.VariablePrimalStart(),
         MOI.VariableIndex,
     )

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1244,10 +1244,15 @@ function _info_from_variable(v::VariableRef)
     ub = has_ub ? upper_bound(v) : Inf
     has_fix = is_fixed(v)
     fixed_value = has_fix ? fix_value(v) : NaN
-    start_or_nothing = start_value(v)
-    has_start = !(start_or_nothing isa Nothing)
-    start = has_start ? start_or_nothing : NaN
-    has_start = start !== Nothing
+    has_start, start = false, NaN
+    if MOI.supports(
+        owner_model(v),
+        MOI.VariablePrimalStart(),
+        MOI.VariableIndex,
+    )
+        start = start_value(v)
+        has_start = start !== nothing
+    end
     binary = is_binary(v)
     integer = is_integer(v)
     return VariableInfo(


### PR DESCRIPTION
`relax_integrality` doesn't work for solvers in direct mode not supporting `VariablePrimalStart`:

```Julia
julia> model = direct_model(GLPK.Optimizer())
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: DIRECT
Solver name: GLPK

julia> @variable(model, x, Int)
x

julia> optimize!(model)

julia> undo = JuMP.relax_integrality(model)
ERROR: ArgumentError: ModelLike of type GLPK.Optimizer does not support accessing the attribute MathOptInterface.VariablePrimalStart()
Stacktrace:
  [1] get_fallback(model::GLPK.Optimizer, attr::MathOptInterface.VariablePrimalStart, args::MathOptInterface.VariableIndex)
    @ MathOptInterface ~/.julia/packages/MathOptInterface/YDdD3/src/attributes.jl:296
  [2] get(model::GLPK.Optimizer, attr::MathOptInterface.VariablePrimalStart, args::MathOptInterface.VariableIndex)
    @ MathOptInterface ~/.julia/packages/MathOptInterface/YDdD3/src/attributes.jl:293
  [3] get(model::Model, attr::MathOptInterface.VariablePrimalStart, v::VariableRef)
    @ JuMP ~/.julia/packages/JuMP/b3hGi/src/JuMP.jl:1234
  [4] start_value(v::VariableRef)
    @ JuMP ~/.julia/packages/JuMP/b3hGi/src/variables.jl:911
  [5] _info_from_variable(v::VariableRef)
    @ JuMP ~/.julia/packages/JuMP/b3hGi/src/variables.jl:1247
  [6] #34
    @ ~/.julia/packages/JuMP/b3hGi/src/variables.jl:1334 [inlined]
  [7] iterate
    @ ./generator.jl:47 [inlined]
  [8] _collect(c::Vector{VariableRef}, itr::Base.Generator{Vector{VariableRef}, JuMP.var"#34#35"}, #unused#::Base.EltypeUnknown, isz::Base.HasShape{1})
    @ Base ./array.jl:691
  [9] collect_similar
    @ ./array.jl:606 [inlined]
 [10] map
    @ ./abstractarray.jl:2294 [inlined]
 [11] relax_integrality(model::Model)
    @ JuMP ~/.julia/packages/JuMP/b3hGi/src/variables.jl:1333
 [12] top-level scope
    @ REPL[13]:1
```