### PR TITLE
WIP: remove zero() and one() for variables and expressions

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -1092,15 +1092,6 @@ include("constraints.jl")
 include("variables.jl")
 include("objective.jl")
 
-function Base.zero(::Type{V}) where {V<:AbstractVariableRef}
-    return zero(GenericAffExpr{Float64,V})
-end
-Base.zero(v::AbstractVariableRef) = zero(typeof(v))
-function Base.one(::Type{V}) where {V<:AbstractVariableRef}
-    return one(GenericAffExpr{Float64,V})
-end
-Base.one(v::AbstractVariableRef) = one(typeof(v))
-
 _moi_optimizer_index(model::MOI.AbstractOptimizer, index::MOI.Index) = index
 function _moi_optimizer_index(model::MOIU.CachingOptimizer, index::MOI.Index)
     if MOIU.state(model) == MOIU.NO_OPTIMIZER

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -171,14 +171,7 @@ end
 function Base.iszero(expr::GenericAffExpr)
     return iszero(expr.constant) && all(iszero, values(expr.terms))
 end
-function Base.zero(::Type{GenericAffExpr{C,V}}) where {C,V}
-    return GenericAffExpr{C,V}(zero(C), OrderedDict{V,C}())
-end
-function Base.one(::Type{GenericAffExpr{C,V}}) where {C,V}
-    return GenericAffExpr{C,V}(one(C), OrderedDict{V,C}())
-end
-Base.zero(a::GenericAffExpr) = zero(typeof(a))
-Base.one(a::GenericAffExpr) = one(typeof(a))
+
 Base.copy(a::GenericAffExpr) = GenericAffExpr(copy(a.constant), copy(a.terms))
 Base.broadcastable(a::GenericAffExpr) = Ref(a)
 
@@ -204,7 +197,7 @@ function drop_zeros!(expr::GenericAffExpr)
     return
 end
 
-GenericAffExpr{C,V}() where {C,V} = zero(GenericAffExpr{C,V})
+GenericAffExpr{C,V}() where {C,V} = GenericAffExpr{C,V}(zero(C))
 
 function _affine_coefficient(f::GenericAffExpr{C,V}, variable::V) where {C,V}
     return get(f.terms, variable, zero(C))

--- a/src/copy.jl
+++ b/src/copy.jl
@@ -48,8 +48,8 @@ function Base.getindex(map::ReferenceMap, cref::ConstraintRef)
     return ConstraintRef(map.model, map.index_map[index(cref)], cref.shape)
 end
 
-function Base.getindex(map::ReferenceMap, expr::GenericAffExpr)
-    result = zero(expr)
+function Base.getindex(map::ReferenceMap, expr::GenericAffExpr{C,V}) where {C,V}
+    result = GenericAffExpr{C,V}(zero(C))
     for (coef, var) in linear_terms(expr)
         add_to_expression!(result, coef, map[var])
     end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -508,7 +508,7 @@ function build_constraint(
     ::MutableArithmetics.Zero,
     set::MOI.AbstractScalarSet,
 )
-    return build_constraint(_error, zero(AffExpr), set)
+    return build_constraint(_error, AffExpr(0.0), set)
 end
 
 function build_constraint(

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -101,20 +101,7 @@ end
 function Base.iszero(expr::GenericQuadExpr)
     return iszero(expr.aff) && all(iszero, values(expr.terms))
 end
-function Base.zero(::Type{GenericQuadExpr{C,V}}) where {C,V}
-    return GenericQuadExpr(
-        zero(GenericAffExpr{C,V}),
-        OrderedDict{UnorderedPair{V},C}(),
-    )
-end
-function Base.one(::Type{GenericQuadExpr{C,V}}) where {C,V}
-    return GenericQuadExpr(
-        one(GenericAffExpr{C,V}),
-        OrderedDict{UnorderedPair{V},C}(),
-    )
-end
-Base.zero(q::GenericQuadExpr) = zero(typeof(q))
-Base.one(q::GenericQuadExpr) = one(typeof(q))
+
 Base.copy(q::GenericQuadExpr) = GenericQuadExpr(copy(q.aff), copy(q.terms))
 Base.broadcastable(q::GenericQuadExpr) = Ref(q)
 
@@ -485,7 +472,10 @@ function Base.convert(
 ) where {C,V}
     return GenericQuadExpr(convert(GenericAffExpr{C,V}, v))
 end
-GenericQuadExpr{C,V}() where {C,V} = zero(GenericQuadExpr{C,V})
+
+function GenericQuadExpr{C,V}() where {C,V}
+    return GenericQuadExpr{C,V}(GenericAffExpr{C,V}(zero(C)))
+end
 
 function check_belongs_to_model(q::GenericQuadExpr, model::AbstractModel)
     check_belongs_to_model(q.aff, model)

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -34,7 +34,7 @@ mutable struct MyModel <: JuMP.AbstractModel
             Dict{ConstraintIndex,String}(),
             nothing,            # Constraints
             MOI.FEASIBILITY_SENSE,
-            zero(JuMP.GenericAffExpr{Float64,MyVariableRef}),
+            JuMP.GenericAffExpr{Float64,MyVariableRef}(0.0),
             Dict{Symbol,Any}(),
         )
     end

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -86,7 +86,7 @@ function test_AffExpr_scalar_constraints(ModelType, ::Any)
 
     cref = @constraint(model, 2 == 1)
     c = JuMP.constraint_object(cref)
-    @test JuMP.isequal_canonical(c.func, zero(JuMP.AffExpr))
+    @test JuMP.isequal_canonical(c.func, JuMP.AffExpr(0.0))
     @test c.set == MOI.EqualTo(-1.0)
 end
 
@@ -112,8 +112,8 @@ function test_AffExpr_vector_constraints(ModelType, ::Any)
     model = ModelType()
     cref = @constraint(model, [1, 2] in MOI.Zeros(2))
     c = JuMP.constraint_object(cref)
-    @test JuMP.isequal_canonical(c.func[1], zero(JuMP.AffExpr) + 1)
-    @test JuMP.isequal_canonical(c.func[2], zero(JuMP.AffExpr) + 2)
+    @test JuMP.isequal_canonical(c.func[1], JuMP.AffExpr(0.0) + 1)
+    @test JuMP.isequal_canonical(c.func[2], JuMP.AffExpr(0.0) + 2)
     @test c.set == MOI.Zeros(2)
     @test c.shape isa JuMP.VectorShape
     @test_throws DimensionMismatch @constraint(model, [1, 2] in MOI.Zeros(3))

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -146,7 +146,7 @@ function expressions_test(
 
     @testset "linear_terms(::AffExpr) for empty expression" begin
         k = 0
-        aff = zero(AffExprType)
+        aff = AffExprType(0.0)
         @test length(linear_terms(aff)) == 0
         for (coeff, var) in linear_terms(aff)
             k += 1

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -388,7 +388,7 @@ function macros_test(
 
         cref = @constraint(m, 3 + 5 * 7 <= 0)
         c = JuMP.constraint_object(cref)
-        @test JuMP.isequal_canonical(c.func, zero(AffExpr))
+        @test JuMP.isequal_canonical(c.func, AffExpr(0.0))
         @test c.set == MOI.LessThan(-38.0)
     end
 

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -19,10 +19,7 @@ struct MySumType{T}
     a::T
 end
 Base.copy(t::MyType) = t
-Base.zero(::Type{MyType{T}}) where {T} = MyType(zero(T))
-Base.one(::Type{MyType{T}}) where {T} = MyType(one(T))
-Base.zero(::Type{MySumType{T}}) where {T} = MySumType(zero(T))
-Base.zero(::MySumType{T}) where {T} = MySumType(zero(T))
+
 Base.transpose(t::MyType) = MyType(t.a)
 Base.transpose(t::MySumType) = MySumType(t.a)
 LinearAlgebra.adjoint(t::Union{MyType,MySumType}) = t
@@ -178,7 +175,7 @@ function test_custom_dimension_mismatch(ModelType, VariableRefType)
     @test size(z) == (1, 3)
     for i in 1:3
         # Q is symmetric
-        a = zero(JuMP.GenericAffExpr{Float64,VariableRefType})
+        a = JuMP.GenericAffExpr{Float64,VariableRefType}(0.0)
         a += Q[1, i]
         a += 2Q[2, i]
         a += 3Q[3, i]


### PR DESCRIPTION
See issue #1151 for background.

The problem is that calls like zero(AffExpr) lead to hard-to-diagnose
bugs.

However, much of Julia's LinearAlgebra routines assume that zero and
one are defined for the element types of arrays. Thus, if we do remove
these methods, we're likely to break a lot of user-code.

Perhaps we're best to just keep these definitions, and document their gotchas.