### PR TITLE
[Containers] convert axes to AbstractVector in DenseAxisArray

### DIFF
--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -308,4 +308,34 @@ And data, a 0-dimensional $(Array{Int,0}):
         push!(s, A)
         @test length(s) == 1
     end
+
+    @testset "Non-AbstractArray axes" begin
+        x = [1.0, 2.0, 3.0]
+        d = Dict(:a => "a", :b => "b", :c => "c")
+        X = DenseAxisArray(x, d)
+        for (k, v) in d
+            @test X[(k, v)] in x
+            @test X[(k, v)] == X[k=>v]
+        end
+        @test_throws KeyError X[(:a, "b")]
+        @test isassigned(X, :a => "a")
+        @test !isassigned(X, :a => "b")
+    end
+
+    @testset "Non-AbstractArray matrix" begin
+        x = [1.0 2.0 3.0; 1.0 2.0 3.0; 1.0 2.0 3.0]
+        d = Dict(:a => "a", :b => "b", :c => "c")
+        X = DenseAxisArray(x, d, d)
+        for (k, v) in d
+            @test X[(k, v), (k, v)] in x
+            @test X[(k, v), (k, v)] == X[k=>v, k=>v]
+        end
+        @test_throws BoundsError X[(:a, "b")]
+        @test_throws KeyError X[(:a, "b"), (:a, "a")]
+        @test_throws KeyError X[(:a, "a"), (:a, "b")]
+        @test isassigned(X, :a => "a", :a => "a")
+        @test !isassigned(X, :a => "b")
+        y = Array(X[:, (:a, "a")])
+        @test all(y .== y[1])
+    end
 end

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -318,8 +318,9 @@ And data, a 0-dimensional $(Array{Int,0}):
             @test X[(k, v)] == X[k=>v]
         end
         @test_throws KeyError X[(:a, "b")]
-        @test isassigned(X, :a => "a")
-        @test !isassigned(X, :a => "b")
+        @test isassigned(X, (:a, "a"))
+        @test !isassigned(X, (:a, "b"))
+        @test length(X[[(:a, "a"), (:c, "c")]]) == 2
     end
 
     @testset "Non-AbstractArray matrix" begin
@@ -333,8 +334,9 @@ And data, a 0-dimensional $(Array{Int,0}):
         @test_throws BoundsError X[(:a, "b")]
         @test_throws KeyError X[(:a, "b"), (:a, "a")]
         @test_throws KeyError X[(:a, "a"), (:a, "b")]
-        @test isassigned(X, :a => "a", :a => "a")
-        @test !isassigned(X, :a => "b")
+        @test isassigned(X, (:a, "a"), (:a, "a"))
+        @test !isassigned(X, (:a, "b"))
+        @test isassigned(X, (:a, "a"), (:b, "b"))
         y = Array(X[:, (:a, "a")])
         @test all(y .== y[1])
     end


### PR DESCRIPTION
This PR fixes some confusing behavior with iterative non AbstractVector axes in DenseAxisArray. 

Closes #2424

Note that now the axis is a vector of pairs, not a dictionary (which guarantees replicable iteration order), and you can access via tuples or pairs.

## Before

```Julia
julia> d = Dict("a" => 1, "b" => 2)
Dict{String,Int64} with 2 entries:
  "b" => 2
  "a" => 1

julia> model = Model();

julia> @variable(model, x[(k, v) in d])
1-dimensional DenseAxisArray{VariableRef,1,...} with index sets:
    Dimension 1, Dict("b" => 2,"a" => 1)
And data, a 2-element Array{VariableRef,1}:
 x[("b", 2)]
 x[("a", 1)]

julia> x[("a", 1)]
ERROR: KeyError: key ("a", 1) not found
Stacktrace:
 [1] getindex at ./dict.jl:467 [inlined]
 [2] lookup_index at /Users/oscar/.julia/packages/JuMP/qhoVb/src/Containers/DenseAxisArray.jl:140 [inlined]
 [3] _to_index_tuple at /Users/oscar/.julia/packages/JuMP/qhoVb/src/Containers/DenseAxisArray.jl:149 [inlined]
 [4] to_index at /Users/oscar/.julia/packages/JuMP/qhoVb/src/Containers/DenseAxisArray.jl:167 [inlined]
 [5] getindex(::JuMP.Containers.DenseAxisArray{VariableRef,1,Tuple{Dict{String,Int64}},Tuple{Dict{Pair{String,Int64},Int64}}}, ::Tuple{String,Int64}) at /Users/oscar/.julia/packages/JuMP/qhoVb/src/Containers/DenseAxisArray.jl:182
 [6] top-level scope at REPL[68]:1

julia> x["a" => 1]
x[("a", 1)]
```

## Now

```Julia
julia> using JuMP

julia> d = Dict("a" => 1, "b" => 2)
Dict{String, Int64} with 2 entries:
  "b" => 2
  "a" => 1

julia> model = Model();

julia> @variable(model, x[(k, v) in d])
1-dimensional DenseAxisArray{VariableRef,1,...} with index sets:
    Dimension 1, ["b" => 2, "a" => 1]
And data, a 2-element Vector{VariableRef}:
 x[("b", 2)]
 x[("a", 1)]

julia> x["a" => 1]
x[("a", 1)]

julia> x[("a", 1)]
x[("a", 1)]
```