### PR TITLE
Fix bug when querying attributes from an optimizer

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -933,6 +933,15 @@ end
 
 Return the value of the solver-specific attribute `attr` in `model`.
 
+!!! warning
+    If you are querying a solver-specific attribute such as
+    `Gurobi.ModelAttribute`, and you are not using [`direct_model`](@ref), and
+    you have not called [`optimize!`](@ref), you must first call
+    `MOI.Utilities.attach_optimizer(model)` in order to first copy the problem
+    into the solver.
+
+See also: [`set_optimizer_attribute`](@ref), [`set_optimizer_attributes`](@ref).
+
 ## Examples
 
 Query model or optimizer attributes:
@@ -945,7 +954,11 @@ Query variable or constraint attributes:
 get_optimizer_attribute(model, MOI.VariablePrimalStart(), x)
 ```
 
-See also: [`set_optimizer_attribute`](@ref), [`set_optimizer_attributes`](@ref).
+Query a solver-specific attribute:
+```julia
+MOI.Utilities.attach_optimizer(model)
+get_optimizer_attribute(model, Gurobi.ModelAttribute("IsMIP"))
+```
 """
 function get_optimizer_attribute(model::Model, attr::MOI.AnyAttribute, args...)
     # If we're in direct mode, no need for `AttributeFromOptimizer`.

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -970,6 +970,15 @@ function get_optimizer_attribute(model::Model, attr::MOI.AnyAttribute, args...)
     return MOI.get(backend(model), new_attr, index.(args)...)
 end
 
+# Special case to the method above: no need to wrap optimizer attributes in
+# `AttributeFromOptimizer`.
+function get_optimizer_attribute(
+    model::Model,
+    attr::MOI.AbstractOptimizerAttribute,
+)
+    return MOI.get(backend(model), attr)
+end
+
 """
     set_silent(model::Model)
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -931,16 +931,9 @@ end
         args...
     )
 
-Return the value of the solver-specific attribute `attr` in `model`.
+Return the value of the attribute `attr` in `model`.
 
-!!! warning
-    If you are querying a solver-specific attribute such as
-    `Gurobi.ModelAttribute`, and you are not using [`direct_model`](@ref), and
-    you have not called [`optimize!`](@ref), you must first call
-    `MOI.Utilities.attach_optimizer(model)` in order to first copy the problem
-    into the solver.
-
-See also: [`set_optimizer_attribute`](@ref), [`set_optimizer_attributes`](@ref).
+See also: [`set_optimizer_attribute`](@ref).
 
 ## Examples
 
@@ -954,11 +947,27 @@ Query variable or constraint attributes:
 get_optimizer_attribute(model, MOI.VariablePrimalStart(), x)
 ```
 
-Query a solver-specific attribute:
+## Querying solver-specific attributes
+
+Solver-specific attributes are attributes which are defined in packages other
+than MathOptInterface. One example is Gurobi's `Gurobi.ModelAttribute`.
+
+If you are querying a solver-specific attribute, we strongly recommend that you
+use [`direct_model`](@ref) to create `model`.
+
+Querying solver-specific attributes for models constructed using [`Model`](@ref)
+is an advanced operation that may require additional solver-specific calls.
+
+For example, if you have not called [`optimize!`](@ref), you must first call
+`MOI.Utilities.attach_optimizer(model)` in order to first copy the problem into
+the solver.
 ```julia
 MOI.Utilities.attach_optimizer(model)
 get_optimizer_attribute(model, Gurobi.ModelAttribute("IsMIP"))
 ```
+
+In addition, `get_optimizer_attribute` will not work for solvers
+which use multiple [`MOI.Utilities.CachingOptimizer`](@ref) layers.
 """
 function get_optimizer_attribute(model::Model, attr::MOI.AnyAttribute, args...)
     # If we're in direct mode, no need for `AttributeFromOptimizer`.

--- a/test/model.jl
+++ b/test/model.jl
@@ -494,12 +494,14 @@ function test_get_optimizer_attribute_EMPTY_OPTIMIZER()
     @variable(model, x >= 1.5)
     @constraint(model, c, 2x + 1 == 0)
     @test MOI.Utilities.state(backend(model)) == MOI.Utilities.EMPTY_OPTIMIZER
-    # MockModelAttribute has a default value.
-    @test get_optimizer_attribute(model, MOIU.MockModelAttribute()) == 0
-    # We don't query x and c attributes because we can't set them in the mock
-    # without attaching!
-    @test MOI.Utilities.state(backend(model)) ==
-          MOI.Utilities.ATTACHED_OPTIMIZER
+    @test_throws(
+        KeyError,
+        get_optimizer_attribute(model, MOIU.MockModelAttribute()),
+    )
+    @test get_optimizer_attribute(model, MOIU.MockVariableAttribute(), x) ===
+          nothing
+    @test get_optimizer_attribute(model, MOIU.MockConstraintAttribute(), c) ===
+          nothing
     return
 end
 


### PR DESCRIPTION
In particular, we now wrap attributes in AttributeFromOptimizer.

Note that we do not need to do this for set, because the attributes
will be stored in the model cache, and copied to the optimizer when
it is attached.

Closes #2587

I've confirmed this works with Gurobi as well
```julia
julia> @testset "Gurobi" begin
       @testset "direct_model" begin
           model = direct_model(Gurobi.Optimizer())
           @variable(model, x >= 1.5)
           @constraint(model, c, 2x + 1 == 0)

           @test get_optimizer_attribute(model, Gurobi.ModelAttribute("IsMIP")) == 0
           @test get_optimizer_attribute(model, Gurobi.VariableAttribute("LB"), x) == 1.5
           @test get_optimizer_attribute(model, Gurobi.ConstraintAttribute("RHS"), c) == -1.0
       end
       @testset "NO_OPTIMIZER" begin
           model = Model()
           @variable(model, x >= 1.5)
           @constraint(model, c, 2x + 1 == 0)
           @test_throws(
               KeyError,
               get_optimizer_attribute(model, Gurobi.ModelAttribute("IsMIP")),
           )
           @test get_optimizer_attribute(model, Gurobi.VariableAttribute("LB"), x) === nothing
           @test get_optimizer_attribute(model, Gurobi.ConstraintAttribute("RHS"), c) === nothing
       end
       @testset "EMPTY_OPTIMIZER" begin
           model = Model(Gurobi.Optimizer)
           @variable(model, x >= 1.5)
           @constraint(model, c, 2x + 1 == 0)

           @test get_optimizer_attribute(model, Gurobi.ModelAttribute("IsMIP")) == 0
           @test get_optimizer_attribute(model, Gurobi.VariableAttribute("LB"), x) == 1.5
           @test get_optimizer_attribute(model, Gurobi.ConstraintAttribute("RHS"), c) == -1.0
       end
       @testset "ATTACHED_OPTIMIZER" begin
           model = Model(Gurobi.Optimizer)
           @variable(model, x >= 1.5)
           @constraint(model, c, 2x + 1 == 0)
           MOI.Utilities.attach_optimizer(model)
           @test get_optimizer_attribute(model, Gurobi.ModelAttribute("IsMIP")) == 0
           @test get_optimizer_attribute(model, Gurobi.VariableAttribute("LB"), x) == 1.5
           @test get_optimizer_attribute(model, Gurobi.ConstraintAttribute("RHS"), c) == -1.0
       end
       end
Academic license - for non-commercial use only - expires 2021-11-06
Academic license - for non-commercial use only - expires 2021-11-06
Academic license - for non-commercial use only - expires 2021-11-06
Test Summary: | Pass  Total
Gurobi        |   12     12
Test.DefaultTestSet("Gurobi", Any[Test.DefaultTestSet("direct_model", Any[], 3, false, false), Test.DefaultTestSet("NO_OPTIMIZER", Any[], 3, false, false), Test.DefaultTestSet("EMPTY_OPTIMIZER", Any[], 3, false, false), Test.DefaultTestSet("ATTACHED_OPTIMIZER", Any[], 3, false, false)], 0, false, false)
```