### PR TITLE
[breaking] Add anonymous NLparameters and registered named parameters

### DIFF
--- a/docs/src/manual/nlp.md
+++ b/docs/src/manual/nlp.md
@@ -109,6 +109,12 @@ julia> @NLparameter(model, p[i = 1:2] == i)
  "Reference to nonlinear parameter #2"
 ```
 
+Create anonymous parameters using the `value` keyword:
+```jldoctest nonlinear_parameters
+julia> anon_parameter = @NLparameter(model, value = 1)
+"Reference to nonlinear parameter #3"
+```
+
 !!! info
     A parameter is not an optimization variable. It must be fixed to a value with
     `==`. If you want a parameter that is `<=` or `>=`, create a variable instead
@@ -131,9 +137,6 @@ julia> value.(p)
  1.0
  3.0
 ```
-
-!!! info
-    There is no anonymous syntax for creating parameters.
 
 Nonlinear parameters can be used *within nonlinear macros* only:
 

--- a/docs/src/tutorials/Conic programs/logistic_regression.jl
+++ b/docs/src/tutorials/Conic programs/logistic_regression.jl
@@ -185,6 +185,7 @@ X, y = generate_dataset(n, p, shift = 10.0);
 λ = 10.0
 model = build_logit_model(X, y, λ)
 set_optimizer(model, SCS.Optimizer)
+set_silent(model)
 JuMP.optimize!(model)
 
 #-
@@ -226,6 +227,7 @@ count_nonzero(v::Vector; tol = 1e-6) = sum(abs.(v) .>= tol)
 λ = 10.0
 sparse_model = build_sparse_logit_model(X, y, λ)
 set_optimizer(sparse_model, SCS.Optimizer)
+set_silent(sparse_model)
 JuMP.optimize!(sparse_model)
 
 #-

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -2238,6 +2238,23 @@ value(x)
 10.0
 ```
 
+    @NLparameter(model, value = param_value)
+
+Create and return an anonymous nonlinear parameter `param` attached to the model
+`model` with initial value set to `param_value`. Nonlinear parameters may be
+used only in nonlinear expressions.
+
+## Example
+
+```jldoctest; setup=:(using JuMP)
+model = Model()
+x = @NLparameter(model, value = 10)
+value(x)
+
+# output
+10.0
+```
+
     @NLparameter(model, param_collection[...] == value_expr)
 
 Create and return a collection of nonlinear parameters `param_collection`
@@ -2245,10 +2262,28 @@ attached to the model `model` with initial value set to `value_expr` (may
 depend on index sets).
 Uses the same syntax for specifying index sets as [`@variable`](@ref).
 
-# Example
+## Example
+
 ```jldoctest; setup=:(using JuMP)
 model = Model()
 @NLparameter(model, y[i = 1:10] == 2 * i)
+value(y[9])
+
+# output
+18.0
+```
+
+    @NLparameter(model, [...] == value_expr)
+
+Create and return an anonymous collection of nonlinear parameters attached to
+the model `model` with initial value set to `value_expr` (may depend on index
+sets). Uses the same syntax for specifying index sets as [`@variable`](@ref).
+
+## Example
+
+```jldoctest; setup=:(using JuMP)
+model = Model()
+y = @NLparameter(model, [i = 1:10] == 2 * i)
 value(y[9])
 
 # output
@@ -2261,22 +2296,34 @@ macro NLparameter(model, args...)
         return _macro_error(:NLparameter, (model, args...), __source__, str...)
     end
     pos_args, kw_args, requested_container = Containers._extract_kw_args(args)
-    if length(pos_args) > 1
+    value = missing
+    for arg in kw_args
+        if arg.args[1] == :value
+            value = arg.args[2]
+        end
+    end
+    kw_args = filter(kw -> kw.args[1] != :value, kw_args)
+    if !ismissing(value) && length(pos_args) > 0
+        _error(
+            "Invalid syntax: no positional args allowed for anonymous " *
+            "parameters.",
+        )
+    elseif length(pos_args) > 1
         _error("Invalid syntax: too many positional arguments.")
     elseif length(kw_args) > 0
         _error("Invalid syntax: unsupported keyword arguments.")
+    elseif ismissing(value) && isexpr(pos_args[1], :block)
+        _error("Invalid syntax: did you mean to use `@NLparameters`?")
+    elseif ismissing(value)
+        ex = pos_args[1]
+        if !isexpr(ex, :call) || length(ex.args) != 3 || ex.args[1] != :(==)
+            _error("Invalid syntax: expected syntax of form `param == value`.")
+        end
     end
-    ex = pos_args[1]
-    if isexpr(ex, :block)
-        _error("Invalid syntax. Did you mean to use `@NLparameters`?")
-    elseif !isexpr(ex, :call) || length(ex.args) != 3 || ex.args[1] != :(==)
-        _error("Invalid syntax: expected argument of form `param == value`.")
-    end
-    param, value = ex.args[2], ex.args[3]
-    if isexpr(param, :vect) || isexpr(param, :vcat)
-        _error(
-            "Anonymous nonlinear parameter syntax is not currently supported.",
-        )
+    param, anon = gensym(), true
+    if ismissing(value)
+        param, value = pos_args[1].args[2], pos_args[1].args[3]
+        anon = isexpr(param, :vect) || isexpr(param, :vcat)
     end
     index_vars, index_values = Containers._build_ref_sets(_error, param)
     if model in index_vars
@@ -2297,12 +2344,15 @@ macro NLparameter(model, args...)
         code,
         requested_container,
     )
-    # TODO: NLparameters are not registered in the model because we don't yet
-    # have an anonymous version.
-    macro_code = _macro_assign_and_return(
-        creation_code,
-        gensym(),
-        Containers._get_name(param),
-    )
+    macro_code = if anon
+        creation_code
+    else
+        _macro_assign_and_return(
+            creation_code,
+            gensym(),
+            Containers._get_name(param),
+            model_for_registering = esc_m,
+        )
+    end
     return _finalize_macro(esc_m, macro_code, __source__)
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -1241,6 +1241,16 @@ function test_nlparameter_anonymous()
     return
 end
 
+function test_nlparameter_anonymous_error()
+    msg = "Invalid syntax: no positional args allowed for anonymous parameters."
+    model = Model()
+    @test_macro_throws(
+        ErrorException("In `@NLparameter(model, p, value = 1)`: $(msg)"),
+        @NLparameter(model, p, value = 1),
+    )
+    return
+end
+
 function test_nlparameter_invalid_number()
     msg = "Parameter value is not a number."
     model = Model()

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -1090,7 +1090,7 @@ function test_singular_plural_error()
     @test_macro_throws(
         ErrorException(
             "In `@NLparameter(model, begin\n    x == 1\nend)`: " *
-            "Invalid syntax. Did you mean to use `@NLparameters`?",
+            "Invalid syntax: did you mean to use `@NLparameters`?",
         ),
         @NLparameter(model, begin
             x == 1
@@ -1222,7 +1222,7 @@ function test_nlparameter_unsupported_keyword_args()
 end
 
 function test_nlparameter_invalid_syntax()
-    msg = "Invalid syntax: expected argument of form `param == value`."
+    msg = "Invalid syntax: expected syntax of form `param == value`."
     model = Model()
     @test_macro_throws(
         ErrorException("In `@NLparameter(model, p)`: $(msg)"),
@@ -1232,12 +1232,12 @@ function test_nlparameter_invalid_syntax()
 end
 
 function test_nlparameter_anonymous()
-    msg = "Anonymous nonlinear parameter syntax is not currently supported."
     model = Model()
-    @test_macro_throws(
-        ErrorException("In `@NLparameter(model, [i = 1:2] == i)`: $(msg)"),
-        @NLparameter(model, [i = 1:2] == i),
-    )
+    p = @NLparameter(model, [i = 1:2] == i)
+    @test p isa Vector{NonlinearParameter}
+    @test length(p) == 2
+    q = @NLparameter(model, value = 1)
+    @test q isa NonlinearParameter
     return
 end
 
@@ -1248,6 +1248,18 @@ function test_nlparameter_invalid_number()
         ErrorException("In `@NLparameter(model, p == :a)`: $(msg)"),
         @NLparameter(model, p == :a),
     )
+    return
+end
+
+function test_nlparameter_register()
+    model = Model()
+    @NLparameter(model, p == 1)
+    @test model[:p] === p
+    @NLparameter(model, q[i = 1:3; isodd(i)] == i)
+    @test model[:q] === q
+    @test_throws ErrorException @NLparameter(model, p == 1)
+    r = @NLparameter(model, value = 1)
+    @test_throws KeyError model[:r]
     return
 end
 

--- a/test/print.jl
+++ b/test/print.jl
@@ -204,13 +204,13 @@ end
 
     @testset "Nonlinear parameters" begin
         model = Model()
-        @NLparameter(model, param == 1.0)
+        param = @NLparameter(model, value = 1.0)
         io_test(REPLMode, param, "\"Reference to nonlinear parameter #1\"")
     end
 
     @testset "Registered nonlinear parameters" begin
         model = Model()
-        model[:param] = @NLparameter(model, param == 1.0)
+        @NLparameter(model, param == 1.0)
         io_test(REPLMode, param, "\"Reference to nonlinear parameter param\"")
     end
 
@@ -291,7 +291,7 @@ end
         model = Model()
         @variable(model, x)
         expr = @NLexpression(model, x + 1)
-        @NLparameter(model, param == 1.0)
+        param = @NLparameter(model, value = 1.0)
 
         constr = @NLconstraint(model, expr - param <= 0)
         io_test(


### PR DESCRIPTION
Closes #2510 

This is breaking for anyone who added multiple parameters of the same name.

i.e., this used to work, but now throws an error:
```Julia
@NLparameter(model, p == 1)
@NLparameter(model, p == 2)
```

Preview: https://jump.dev/JuMP.jl/previews/PR2719/manual/nlp/#Create-a-nonlinear-parameter