### PR TITLE
Add error message for variable comparison with number

### DIFF
--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1445,7 +1445,7 @@ end
 ### Error messages for common incorrect usages
 ###
 
-for sym in (:(==), :(<=), :(>=))
+for sym in (:(<=), :(>=), :(<), :(>))
     msg = """Cannot evaluate `$(sym)` between a variable and a number.
 
     There are two common mistakes that lead to this.

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1440,3 +1440,56 @@ function relax_integrality(model::Model)
     end
     return unrelax
 end
+
+###
+### Error messages for common incorrect usages
+###
+
+for sym in (:(==), :(<=), :(>=))
+    msg = """Cannot evaluate `$(sym)` between a variable and a number.
+
+    There are two common mistakes that lead to this.
+
+     * You tried to write a constraint that depends on the value of a variable
+
+       For example:
+       ```julia
+       model = Model()
+       @variable(model, x[1:2])
+       if x[1] $(sym) 1
+           @constraint(model, x[2] == 0)
+       end
+       ```
+
+       You cannot write a model like this. You must formulate your problem as a
+       single optimization problem. Unfortunately, the way to do this is
+       problem-specific and depends on your choice of solver. You may be able to
+       use indicator constraints, or some other mixed-integer linear
+       reformulation. If stuck, post your problem on the community forum:
+       https://discourse.julialang.org/c/domain/opt/13
+
+     * You wrote a function that expected the value of a variable, but it was
+       passed the variable instead
+
+       For example:
+       ```julia
+       foo(x) = x $(sym) 1 ? 0 : 1 - x
+       model = Model()
+       @variable(model, x)
+       @objective(model, foo(x))
+       ```
+
+       To fix this, create a nonlinear model with a user-defined function:
+       ```julia
+       foo(x) = x $(sym) 1 ? 0 : 1 - x
+       model = Model()
+       register(model, :foo, 1, foo; autodiff = true)
+       @variable(model, x)
+       @NLobjective(model, foo(x))
+       ```
+    """
+    @eval begin
+        Base.$(sym)(::VariableRef, ::Number) = error($(msg))
+        Base.$(sym)(::Number, ::VariableRef) = error($(msg))
+    end
+end

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -1006,20 +1006,22 @@ function test_Model_error_messages(::Any, ::Any)
     model = Model()
     @variable(model, x)
     err = try
-        x == 1
+        x >= 1
     catch err
         err
     end
     function f(s)
         return ErrorException(
-            replace(replace(err.msg, "== 1" => "$(s) 1"), "`==`" => "`$(s)`"),
+            replace(replace(err.msg, ">= 1" => "$(s) 1"), "`>=`" => "`$(s)`"),
         )
     end
-    @test_throws err 1 == x
+    @test_throws err 1 >= x
     @test_throws f("<=") x <= 1
     @test_throws f("<=") 1 <= x
-    @test_throws f(">=") x >= 1
-    @test_throws f(">=") 1 >= x
+    @test_throws f(">") x > 1
+    @test_throws f(">") 1 > x
+    @test_throws f("<") x < 1
+    @test_throws f("<") 1 < x
     return
 end
 

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -1005,14 +1005,14 @@ end
 function test_Model_error_messages(::Any, ::Any)
     model = Model()
     @variable(model, x)
-    e = try
+    err = try
         x == 1
     catch err
         err
     end
     function f(s)
         return ErrorException(
-            replace(replace(e.msg, "== 1" => "$(s) 1"), "`==`" => "`$(s)`"),
+            replace(replace(err.msg, "== 1" => "$(s) 1"), "`==`" => "`$(s)`"),
         )
     end
     @test_throws err 1 == x

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -1002,6 +1002,27 @@ function test_Model_unsupported_VariableName(::Any, ::Any)
     return
 end
 
+function test_Model_error_messages(::Any, ::Any)
+    model = Model()
+    @variable(model, x)
+    e = try
+        x == 1
+    catch err
+        err
+    end
+    function f(s)
+        return ErrorException(
+            replace(replace(e.msg, "== 1" => "$(s) 1"), "`==`" => "`$(s)`"),
+        )
+    end
+    @test_throws err 1 == x
+    @test_throws f("<=") x <= 1
+    @test_throws f("<=") 1 <= x
+    @test_throws f(">=") x >= 1
+    @test_throws f(">=") 1 >= x
+    return
+end
+
 function runtests()
     for name in names(@__MODULE__; all = true)
         if !startswith("$(name)", "test_")


### PR DESCRIPTION
I see this on the forum a lot, so this error message should help. I'm a little wary of it breaking things though. There might be valid cases for comparing variables and numbers (e.g., in the keys of a dictionary).