### PR TITLE
Warn if DenseAxisArray is passed length-1 axis

### DIFF
--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -147,7 +147,17 @@ function Base.get(
 end
 
 _abstract_vector(x::AbstractVector) = x
-_abstract_vector(x) = [a for a in x]
+function _abstract_vector(x)
+    axis = [a for a in x]
+    if length(axis) == 1
+        @warn(
+            "Axis contains one element: $x. If intended, you can safely " *
+            "ignore this warning. To explicitly pass the axis with one " *
+            "element, pass `[$(axis[1])]` instead of `$(x)`.",
+        )
+    end
+    return axis
+end
 
 """
     DenseAxisArray(data::Array{T, N}, axes...) where {T, N}

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -340,4 +340,11 @@ And data, a 0-dimensional $(Array{Int,0}):
         y = Array(X[:, (:a, "a")])
         @test all(y .== y[1])
     end
+
+    @testset "Singular axis" begin
+        x =  @test_logs (:warn,) DenseAxisArray([1.1 2.2], 1, 1:2)
+        @test x[1, 2] == 2.2
+        y =  @test_logs DenseAxisArray([1.1 2.2], [1], 1:2)
+        @test y[1, 2] == 2.2
+    end
 end


### PR DESCRIPTION
Part of #2318

This seems like it would highlight a common type of bug:

```julia
julia> model = Model()
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: NO_OPTIMIZER
Solver name: No optimizer attached.

julia> @variable(model, x[1:2, t=1])
┌ Warning: Axis contains one element: 1. If intended, you can safely ignore this warning. To explicitly pass the axis with one element, pass `[1]` instead of `1`.
└ @ JuMP.Containers ~/.julia/dev/JuMP/src/Containers/DenseAxisArray.jl:153
2-dimensional DenseAxisArray{VariableRef,2,...} with index sets:
    Dimension 1, Base.OneTo(2)
    Dimension 2, fill(1)
And data, a 2×1 Matrix{VariableRef}:
 x[1,1]
 x[2,1]

julia> @variable(model, y[1:2, t=[1]])
2-dimensional DenseAxisArray{VariableRef,2,...} with index sets:
    Dimension 1, Base.OneTo(2)
    Dimension 2, [1]
And data, a 2×1 Matrix{VariableRef}:
 y[1,1]
 y[2,1]
```