### PR TITLE
Add set inequality syntax for any set

### DIFF
--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -608,13 +608,19 @@ julia> @constraint(model, X >= Y, PSDCone())
  X[2,1] - 2  X[2,2] - 1] ∈ PSDCone()
 ```
 
-The following three syntax are equivalent:
- * `@constraint(model, X >= Y, PSDCone())`
- * `@constraint(model, Y <= X, PSDCone())`
- * `@constraint(model, X - Y in PSDCone())`
+!!! tip
+    `@constraint(model, X >= Y, Set())` is short-hand for
+    `@constraint(model, X - Y in Set())`. Therefore, the following calls are
+    equivalent:
+     * `@constraint(model, X >= Y, PSDCone())`
+     * `@constraint(model, Y <= X, PSDCone())`
+     * `@constraint(model, X - Y in PSDCone())`
+    This also works for any vector-valued cone, so instead of
+    `@constraint(model, X - Y in MOI.Nonnegatives(2))`, you can write
+    `@constraint(model, X >= Y, MOI.Nonnegatives(2))`.
 
-!!! note
-    Non-zero constants are not supported:
+!!! warning
+    Non-zero constants are not supported in this syntax:
     ```jldoctest con_psd
     julia> @constraint(model, X >= 1, PSDCone())
     ERROR: Operation `sub_mul!` between `Matrix{VariableRef}` and `Int64` is not allowed. You should use broadcast.

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -115,20 +115,6 @@ function build_constraint(
     return build_constraint(_error, new_f, extra)
 end
 
-function _MA.operate!(
-    ::typeof(_MA.sub_mul),
-    x::AbstractMatrix{<:AbstractJuMPScalar},
-    y::Int,
-)
-    if !iszero(y)
-        error(
-            "Operation `sub_mul!` between `$(typeof(x))` and `$(typeof(y))` " *
-            "is not allowed. You should use broadcast.",
-        )
-    end
-    return x
-end
-
 """
     SymmetricMatrixShape
 

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -1053,6 +1053,33 @@ function test_PSDCone_Symmetric_constraints(::Any, ::Any)
     return
 end
 
+"""
+    test_set_inequalities(::Any, ::Any)
+
+Test the syntax `@constraint(model, X >= Y, Set())` is the same as
+`@constraint(model, X - Y in Set())`.
+"""
+function test_set_inequalities(::Any, ::Any)
+    model = Model()
+    @variable(model, X[1:2])
+    Y = [3.0, 4.0]
+    f1 = 1 .* X
+    f2 = X .- Y
+    c1 = @constraint(model, X >= 0, MOI.Nonnegatives(2))
+    c2 = @constraint(model, X >= Y, MOI.Nonnegatives(2))
+    c3 = @constraint(model, 0 <= X, MOI.Nonnegatives(2))
+    c4 = @constraint(model, Y <= X, MOI.Nonnegatives(2))
+    @test constraint_object(c1).func == f1
+    @test constraint_object(c2).func == f2
+    @test constraint_object(c3).func == f1
+    @test constraint_object(c4).func == f2
+    @test constraint_object(c1).set == MOI.Nonnegatives(2)
+    @test constraint_object(c2).set == MOI.Nonnegatives(2)
+    @test constraint_object(c3).set == MOI.Nonnegatives(2)
+    @test constraint_object(c4).set == MOI.Nonnegatives(2)
+    return
+end
+
 function runtests()
     for name in names(@__MODULE__; all = true)
         if !startswith("$(name)", "test_")


### PR DESCRIPTION
Follows on from #2732

The open question is how to type the `extra` argument to:
```
function build_constraint(
    _error::Function,
    f::AbstractArray{<:AbstractJuMPScalar},
    s::MOI.GreaterThan,
    extra,
)
    @assert iszero(s.lower)
    return build_constraint(_error, f, extra)
end
```

The options are
 * `extra::Any`
 * `extra::Union{MOI.AbstractVectorSet,JuMP.AbstractVectorSet}`
 * `extra::Union{... explicitly choose sets}`

The advantage of the first is that it lets any set work by default. The downside is that users might write syntax that doesn't make mathematical sense, like `@constraint(model, [2x + 1, x] >= 0, MOI.Complements(2))`. 

The second option adds a bit more type checking, and prevents people doing stuff like `, MOI.Integer()`. 

The third allows us to restrict the sets to proper cones mathematically, but it requires knowing about these in JuMP, which rules out Hypatia. We could add a new trait to MOI, `is_proper`, but that's also a lot of work.

My vote is the `::Any`, with the documentation that `X >= Y, Set()` is just syntactic sugar for `X - Y in Set()`, and it's up to the user to write meaningful constraints.