### PR TITLE
Don't return MA.Zero from expressions

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1257,6 +1257,14 @@ function _throw_error_for_invalid_sense(
 end
 
 """
+    _replace_zero(x)
+
+Replaces `_MA.Zero` with a floating point `0.0`.
+"""
+_replace_zero(::_MA.Zero) = 0.0
+_replace_zero(x) = x
+
+"""
     @objective(model::Model, sense, func)
 
 Set the objective sense to `sense` and objective function to `func`. The
@@ -1322,6 +1330,9 @@ macro objective(model, args...)
     newaff, parsecode = _MA.rewrite(x)
     code = quote
         $parsecode
+        # Don't leak a `_MA.Zero` if the objective expression is an empty
+        # summation, or other structure that returns `_MA.Zero()`.
+        $newaff = _replace_zero($newaff)
         set_objective($esc_model, $sense_expr, $newaff)
         $newaff
     end
@@ -1383,6 +1394,11 @@ macro expression(args...)
         )
     end
     code = _MA.rewrite_and_return(x)
+    code = quote
+        # Don't leak a `_MA.Zero` if the expression is an empty summation, or
+        # other structure that returns `_MA.Zero()`.
+        _replace_zero($code)
+    end
     code = Containers.container_code(idxvars, indices, code, requestedcontainer)
     # don't do anything with the model, but check that it's valid anyway
     if anonvar

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -1432,6 +1432,21 @@ function test_broadcasting_variable_in_set()
     return
 end
 
+function test_MA_Zero_objective()
+    model = Model()
+    @test @objective(model, Min, sum(i for i in 1:0)) === 0.0
+    return
+end
+
+function test_MA_Zero_expression()
+    model = Model()
+    @test @expression(model, sum(i for i in 1:0)) === 0.0
+    @expression(model, expr[j=1:2], sum(i for i in j:0))
+    @test expr == [0.0, 0.0]
+    @test expr isa Vector{Float64}
+    return
+end
+
 end  # module
 
 TestMacros.runtests()


### PR DESCRIPTION
Closes #2677 

This should remove a lot of issues with people reporting `MA.Zero` related problems.