### PR TITLE
Export Result and Termination status codes

### DIFF
--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -166,8 +166,8 @@ DocTestSetup = quote
     @objective(model, Max, -2x);
     optimize!(model);
     mock = unsafe_backend(model);
-    MOI.set(mock, MOI.TerminationStatus(), MOI.OPTIMAL)
-    MOI.set(mock, MOI.DualStatus(), MOI.FEASIBLE_POINT)
+    MOI.set(mock, MOI.TerminationStatus(), OPTIMAL)
+    MOI.set(mock, MOI.DualStatus(), FEASIBLE_POINT)
     MOI.set(mock, MOI.ConstraintDual(), optimizer_index(con), -2.0)
 end
 ```

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -198,7 +198,7 @@ describing the status of the dual solution.
 julia> dual_status(model)
 FEASIBLE_POINT::ResultStatusCode = 1
 ```
-Other common returns are `NO_SOLUTION`, and `MOI.INFEASIBILITY_CERTIFICATE`.
+Other common returns are `NO_SOLUTION`, and `INFEASIBILITY_CERTIFICATE`.
 The first means that the solver doesn't have a solution to return, and the
 second means that the dual solution is a certificate of primal infeasbility (a
 dual unbounded ray).
@@ -263,7 +263,7 @@ something like the following:
 ```jldoctest solutions
 if termination_status(model) == OPTIMAL
     println("Solution is optimal")
-elseif termination_status(model) == MOI.TIME_LIMIT && has_values(model)
+elseif termination_status(model) == TIME_LIMIT && has_values(model)
     println("Solution is suboptimal due to a time limit, but a primal solution is available")
 else
     error("The model was not solved correctly.")

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -94,17 +94,17 @@ OPTIMAL::TerminationStatusCode = 1
 The [`MOI.TerminationStatusCode`](@ref) enum describes the full list of statuses
 that could be returned.
 
-Common return values include `MOI.OPTIMAL`, `MOI.LOCALLY_SOLVED`,
-`MOI.INFEASIBLE`, `MOI.DUAL_INFEASIBLE`, and `MOI.TIME_LIMIT`.
+Common return values include `OPTIMAL`, `LOCALLY_SOLVED`, `INFEASIBLE`,
+`DUAL_INFEASIBLE`, and `TIME_LIMIT`.
 
 !!! info
-    A return status of `MOI.OPTIMAL` means the solver found (and proved) a
-    globally optimal solution. A return status of `MOI.LOCALLY_SOLVED` means the
+    A return status of `OPTIMAL` means the solver found (and proved) a
+    globally optimal solution. A return status of `LOCALLY_SOLVED` means the
     solver found a locally optimal solution (which may also be globally
     optimal, but it could not prove so).
 
 !!! warning
-    A return status of `MOI.DUAL_INFEASIBLE` does not guarantee that the primal
+    A return status of `DUAL_INFEASIBLE` does not guarantee that the primal
     is unbounded. When the dual is infeasible, the primal is unbounded if
     there exists a feasible primal solution.
 
@@ -125,7 +125,7 @@ describing the status of the primal solution.
 julia> primal_status(model)
 FEASIBLE_POINT::ResultStatusCode = 1
 ```
-Other common returns are `MOI.NO_SOLUTION`, and `MOI.INFEASIBILITY_CERTIFICATE`.
+Other common returns are `NO_SOLUTION`, and `INFEASIBILITY_CERTIFICATE`.
 The first means that the solver doesn't have a solution to return, and the
 second means that the primal solution is a certificate of dual infeasbility (a
 primal unbounded ray).
@@ -198,7 +198,7 @@ describing the status of the dual solution.
 julia> dual_status(model)
 FEASIBLE_POINT::ResultStatusCode = 1
 ```
-Other common returns are `MOI.NO_SOLUTION`, and `MOI.INFEASIBILITY_CERTIFICATE`.
+Other common returns are `NO_SOLUTION`, and `MOI.INFEASIBILITY_CERTIFICATE`.
 The first means that the solver doesn't have a solution to return, and the
 second means that the dual solution is a certificate of primal infeasbility (a
 dual unbounded ray).
@@ -261,7 +261,7 @@ And data, a 2-element Array{Float64,1}:
 The recommended workflow for solving a model and querying the solution is
 something like the following:
 ```jldoctest solutions
-if termination_status(model) == MOI.OPTIMAL
+if termination_status(model) == OPTIMAL
     println("Solution is optimal")
 elseif termination_status(model) == MOI.TIME_LIMIT && has_values(model)
     println("Solution is suboptimal due to a time limit, but a primal solution is available")
@@ -269,10 +269,10 @@ else
     error("The model was not solved correctly.")
 end
 println("  objective value = ", objective_value(model))
-if primal_status(model) == MOI.FEASIBLE_POINT
+if primal_status(model) == FEASIBLE_POINT
     println("  primal solution: x = ", value(x))
 end
-if dual_status(model) == MOI.FEASIBLE_POINT
+if dual_status(model) == FEASIBLE_POINT
     println("  dual solution: c1 = ", dual(c1))
 end
 
@@ -444,7 +444,7 @@ model = Model() # You must use a solver that supports conflict refining/IIS
 @constraint(model, c2, x <= 1)
 optimize!(model)
 
-# termination_status(model) will likely be MOI.INFEASIBLE,
+# termination_status(model) will likely be INFEASIBLE,
 # depending on the solver
 
 compute_conflict!(model)
@@ -485,7 +485,7 @@ Functions for querying the solutions, e.g., [`primal_status`](@ref) and
 used to specify which result to return.
 
 !!! warning
-    Even if [`termination_status`](@ref) is `MOI.OPTIMAL`, some of the returned
+    Even if [`termination_status`](@ref) is `OPTIMAL`, some of the returned
     solutions may be suboptimal! However, if the solver found at least one
     optimal solution, then `result = 1` will always return an optimal solution.
     Use [`objective_value`](@ref) to assess the quality of the remaining
@@ -498,7 +498,7 @@ model = Model()
 # ... other constraints ...
 optimize!(model)
 
-if termination_status(model) != MOI.OPTIMAL
+if termination_status(model) != OPTIMAL
     error("The model was not solved correctly.")
 end
 

--- a/docs/src/tutorials/algorithms/benders_decomposition.jl
+++ b/docs/src/tutorials/algorithms/benders_decomposition.jl
@@ -210,14 +210,14 @@ while true
     t_status = termination_status(master_problem_model)
     p_status = primal_status(master_problem_model)
 
-    if p_status == MOI.INFEASIBLE_POINT
+    if p_status == INFEASIBLE_POINT
         println("The problem is infeasible :-(")
         break
     end
 
-    (fm_current, x_current) = if t_status == MOI.INFEASIBLE_OR_UNBOUNDED
+    (fm_current, x_current) = if t_status == INFEASIBLE_OR_UNBOUNDED
         (M, M * ones(dim_x))
-    elseif p_status == MOI.FEASIBLE_POINT
+    elseif p_status == FEASIBLE_POINT
         (value(t), value.(x))
     else
         error("Unexpected status: $((t_status, p_status))")
@@ -272,7 +272,7 @@ while true
         fm_current,
     )
 
-    if p_status_sub == MOI.FEASIBLE_POINT && fs_x_current == fm_current # we are done
+    if p_status_sub == FEASIBLE_POINT && fs_x_current == fm_current # we are done
         Test.@test value(t) ≈ -4 #hide
         println("\n################################################")
         println("Optimal solution of the original problem found")
@@ -283,7 +283,7 @@ while true
         break
     end
 
-    if p_status_sub == MOI.FEASIBLE_POINT && fs_x_current < fm_current
+    if p_status_sub == FEASIBLE_POINT && fs_x_current < fm_current
         println(
             "\nThere is a suboptimal vertex, add the corresponding constraint",
         )
@@ -292,7 +292,7 @@ while true
         println("t + ", cv, "ᵀ x <= ", γ)
     end
 
-    if t_status_sub == MOI.INFEASIBLE_OR_UNBOUNDED
+    if t_status_sub == INFEASIBLE_OR_UNBOUNDED
         println(
             "\nThere is an  extreme ray, adding the corresponding constraint",
         )

--- a/docs/src/tutorials/algorithms/benders_lazy_constraints.jl
+++ b/docs/src/tutorials/algorithms/benders_lazy_constraints.jl
@@ -165,11 +165,11 @@ function benders_lazy_constraint_callback(cb_data)
 
     γ = b' * u_current
 
-    if p_status_sub == MOI.FEASIBLE_POINT && fs_x_current ≈ fm_current # we are done
+    if p_status_sub == FEASIBLE_POINT && fs_x_current ≈ fm_current # we are done
         @info("No additional constraint from the subproblem")
     end
 
-    if p_status_sub == MOI.FEASIBLE_POINT && fs_x_current < fm_current
+    if p_status_sub == FEASIBLE_POINT && fs_x_current < fm_current
         println(
             "\nThere is a suboptimal vertex, add the corresponding constraint",
         )
@@ -182,7 +182,7 @@ function benders_lazy_constraint_callback(cb_data)
         )
     end
 
-    if t_status_sub == MOI.INFEASIBLE_OR_UNBOUNDED
+    if t_status_sub == INFEASIBLE_OR_UNBOUNDED
         println(
             "\nThere is an  extreme ray, adding the corresponding constraint",
         )
@@ -207,16 +207,16 @@ optimize!(master_problem_model)
 t_status = termination_status(master_problem_model)
 p_status = primal_status(master_problem_model)
 
-if p_status == MOI.INFEASIBLE_POINT
+if p_status == INFEASIBLE_POINT
     println("The problem is infeasible :-(")
 end
 
-if t_status == MOI.INFEASIBLE_OR_UNBOUNDED
+if t_status == INFEASIBLE_OR_UNBOUNDED
     fm_current = M
     x_current = M * ones(dim_x)
 end
 
-if p_status == MOI.FEASIBLE_POINT
+if p_status == FEASIBLE_POINT
     fm_current = value(t)
     x_current = value.(x)
 end

--- a/docs/src/tutorials/algorithms/cutting_stock_column_generation.jl
+++ b/docs/src/tutorials/algorithms/cutting_stock_column_generation.jl
@@ -216,7 +216,7 @@ function example_cutting_stock(; max_gen_cols::Int = 5_000)
     )
     ## First solve of the master problem.
     optimize!(m)
-    if termination_status(m) != MOI.OPTIMAL
+    if termination_status(m) != OPTIMAL
         warn("Master not optimal ($ncols patterns so far)")
     end
     ## Then, generate new patterns, based on the dual information.
@@ -260,7 +260,7 @@ function example_cutting_stock(; max_gen_cols::Int = 5_000)
         end
         ## Solve the new master problem to update the dual variables.
         optimize!(m)
-        if termination_status(m) != MOI.OPTIMAL
+        if termination_status(m) != OPTIMAL
             @warn("Master not optimal ($ncols patterns so far)")
         end
     end
@@ -271,7 +271,7 @@ function example_cutting_stock(; max_gen_cols::Int = 5_000)
     ## solution).
     set_integer.(θ)
     optimize!(m)
-    if termination_status(m) != MOI.OPTIMAL
+    if termination_status(m) != OPTIMAL
         @warn("Final master not optimal ($ncols patterns)")
         return
     end

--- a/docs/src/tutorials/applications/power_systems.jl
+++ b/docs/src/tutorials/applications/power_systems.jl
@@ -369,7 +369,7 @@ function solve_uc(generators::Vector, wind, scenario)
     )
     optimize!(uc)
     status = termination_status(uc)
-    if status != MOI.OPTIMAL
+    if status != OPTIMAL
         return (status = status,)
     end
     return (
@@ -410,7 +410,7 @@ uc_df = DataFrames.DataFrame(
 for demand_scale in 0.2:0.1:1.5
     new_scenario = scale_demand(scenario, demand_scale)
     sol = solve_uc(generators, wind_generator, new_scenario)
-    if sol.status == MOI.OPTIMAL
+    if sol.status == OPTIMAL
         push!(
             uc_df,
             (

--- a/docs/src/tutorials/conic/min_distortion.jl
+++ b/docs/src/tutorials/conic/min_distortion.jl
@@ -65,8 +65,8 @@ function example_min_distortion()
     end
     @objective(model, Min, c²)
     optimize!(model)
-    Test.@test termination_status(model) == MOI.OPTIMAL
-    Test.@test primal_status(model) == MOI.FEASIBLE_POINT
+    Test.@test termination_status(model) == OPTIMAL
+    Test.@test primal_status(model) == FEASIBLE_POINT
     Test.@test objective_value(model) ≈ 4 / 3 atol = 1e-4
     return
 end

--- a/docs/src/tutorials/conic/min_ellipse.jl
+++ b/docs/src/tutorials/conic/min_ellipse.jl
@@ -40,8 +40,8 @@ function example_min_ellipse()
     @objective(model, Min, LinearAlgebra.tr(weights * X))
     @constraint(model, [As_i in As], X >= As_i, PSDCone())
     optimize!(model)
-    Test.@test termination_status(model) == MOI.OPTIMAL
-    Test.@test primal_status(model) == MOI.FEASIBLE_POINT
+    Test.@test termination_status(model) == OPTIMAL
+    Test.@test primal_status(model) == FEASIBLE_POINT
     Test.@test objective_value(model) ≈ 6.46233 atol = 1e-5
     Test.@test value.(X) ≈ [3.1651 0.8022; 0.8022 3.2972] atol = 1e-4
     return

--- a/docs/src/tutorials/getting_started/getting_started_with_JuMP.jl
+++ b/docs/src/tutorials/getting_started/getting_started_with_JuMP.jl
@@ -62,7 +62,7 @@
 
 # !!! note
 #     JuMP re-exports the MathOptInterface.jl package via the `MOI` constant.
-#     When you see code like `MOI.OPTIMAL`, this is a constant from the
+#     When you see code like `OPTIMAL`, this is a constant from the
 #     MathOptInterface package.
 
 # ## Installation
@@ -270,7 +270,7 @@ function solve_infeasible()
     @constraint(model, x + y >= 3)
     @objective(model, Max, x + 2y)
     optimize!(model)
-    if termination_status(model) != MOI.OPTIMAL
+    if termination_status(model) != OPTIMAL
         @warn("The model was not solved correctly.")
         return nothing
     end

--- a/docs/src/tutorials/linear/callbacks.jl
+++ b/docs/src/tutorials/linear/callbacks.jl
@@ -48,8 +48,8 @@ function example_lazy_constraint()
     end
     MOI.set(model, MOI.LazyConstraintCallback(), my_callback_function)
     optimize!(model)
-    Test.@test termination_status(model) == MOI.OPTIMAL    #src
-    Test.@test primal_status(model) == MOI.FEASIBLE_POINT  #src
+    Test.@test termination_status(model) == OPTIMAL    #src
+    Test.@test primal_status(model) == FEASIBLE_POINT  #src
     Test.@test lazy_called    #src
     Test.@test value(x) == 1  #src
     Test.@test value(y) == 2  #src
@@ -88,8 +88,8 @@ function example_user_cut_constraint()
     end
     MOI.set(model, MOI.UserCutCallback(), my_callback_function)
     optimize!(model)
-    Test.@test termination_status(model) == MOI.OPTIMAL  #src
-    Test.@test primal_status(model) == MOI.FEASIBLE_POINT  #src
+    Test.@test termination_status(model) == OPTIMAL  #src
+    Test.@test primal_status(model) == FEASIBLE_POINT  #src
     Test.@test callback_called  #src
     @show callback_called
     return
@@ -123,8 +123,8 @@ function example_heuristic_solution()
     end
     MOI.set(model, MOI.HeuristicCallback(), my_callback_function)
     optimize!(model)
-    Test.@test termination_status(model) == MOI.OPTIMAL  #src
-    Test.@test primal_status(model) == MOI.FEASIBLE_POINT  #src
+    Test.@test termination_status(model) == OPTIMAL  #src
+    Test.@test primal_status(model) == FEASIBLE_POINT  #src
     Test.@test callback_called  #src
     return
 end
@@ -162,8 +162,8 @@ function example_solver_dependent_callback()
     end
     MOI.set(model, GLPK.CallbackFunction(), my_callback_function)
     optimize!(model)
-    Test.@test termination_status(model) == MOI.OPTIMAL  #src
-    Test.@test primal_status(model) == MOI.FEASIBLE_POINT  #src
+    Test.@test termination_status(model) == OPTIMAL  #src
+    Test.@test primal_status(model) == FEASIBLE_POINT  #src
     Test.@test lazy_called  #src
     Test.@test value(x) == 1  #src
     Test.@test value(y) == 2  #src

--- a/docs/src/tutorials/linear/cannery.jl
+++ b/docs/src/tutorials/linear/cannery.jl
@@ -120,6 +120,6 @@ for p in P, m in M
     println(p, " => ", m, ": ", value(x[p, m]))
 end
 
-Test.@test termination_status(model) == MOI.OPTIMAL    #src
-Test.@test primal_status(model) == MOI.FEASIBLE_POINT  #src
+Test.@test termination_status(model) == OPTIMAL    #src
+Test.@test primal_status(model) == FEASIBLE_POINT  #src
 Test.@test objective_value(model) == 1_680.0           #src

--- a/docs/src/tutorials/linear/diet.jl
+++ b/docs/src/tutorials/linear/diet.jl
@@ -123,7 +123,7 @@ print(model)
 
 optimize!(model)
 
-Test.@test primal_status(model) == MOI.FEASIBLE_POINT   #hide
+Test.@test primal_status(model) == FEASIBLE_POINT   #hide
 Test.@test objective_value(model) ≈ 11.8288 atol = 1e-4 #hide
 
 solution_summary(model)
@@ -149,8 +149,8 @@ end
 
 optimize!(model)
 
-Test.@test termination_status(model) == MOI.INFEASIBLE  #hide
-Test.@test primal_status(model) == MOI.NO_SOLUTION      #hide
+Test.@test termination_status(model) == INFEASIBLE  #hide
+Test.@test primal_status(model) == NO_SOLUTION      #hide
 
 solution_summary(model)
 

--- a/docs/src/tutorials/linear/factory_schedule.jl
+++ b/docs/src/tutorials/linear/factory_schedule.jl
@@ -145,7 +145,7 @@ function example_factory_schedule()
     optimize!(model)
     ## Check the solution!
     Test.@testset "Check the solution against known optimal" begin
-        Test.@test termination_status(model) == MOI.OPTIMAL
+        Test.@test termination_status(model) == OPTIMAL
         Test.@test objective_value(model) == 12_906_400.0
         Test.@test value.(production)[1, :A] == 70_000
         Test.@test value.(status)[1, :A] == 1

--- a/docs/src/tutorials/linear/knapsack.jl
+++ b/docs/src/tutorials/linear/knapsack.jl
@@ -35,8 +35,8 @@ function example_knapsack(; verbose = true)
             println(", p[$i]/w[$i] = ", profit[i] / weight[i])
         end
     end
-    Test.@test termination_status(model) == MOI.OPTIMAL
-    Test.@test primal_status(model) == MOI.FEASIBLE_POINT
+    Test.@test termination_status(model) == OPTIMAL
+    Test.@test primal_status(model) == FEASIBLE_POINT
     Test.@test objective_value(model) == 16.0
     return
 end

--- a/docs/src/tutorials/linear/multi.jl
+++ b/docs/src/tutorials/linear/multi.jl
@@ -92,8 +92,8 @@ function example_multi(; verbose = true)
         sum(trans[i, j, p] for p in 1:numprod) - limit[i, j] <= 0
     )
     optimize!(multi)
-    Test.@test termination_status(multi) == MOI.OPTIMAL
-    Test.@test primal_status(multi) == MOI.FEASIBLE_POINT
+    Test.@test termination_status(multi) == OPTIMAL
+    Test.@test primal_status(multi) == FEASIBLE_POINT
     Test.@test objective_value(multi) == 225_700.0
     if verbose
         println("RESULTS:")

--- a/docs/src/tutorials/linear/prod.jl
+++ b/docs/src/tutorials/linear/prod.jl
@@ -279,8 +279,8 @@ function example_prod(; verbose = true)
     )
     ## Obtain solution
     optimize!(prod)
-    Test.@test termination_status(prod) == MOI.OPTIMAL
-    Test.@test primal_status(prod) == MOI.FEASIBLE_POINT
+    Test.@test termination_status(prod) == OPTIMAL
+    Test.@test primal_status(prod) == FEASIBLE_POINT
     Test.@test objective_value(prod) ≈ 4_426_822.89 atol = 1e-2
     if verbose
         println("RESULTS:")

--- a/docs/src/tutorials/linear/steelT3.jl
+++ b/docs/src/tutorials/linear/steelT3.jl
@@ -86,8 +86,8 @@ function example_steelT3(; verbose = true)
         )
     )
     optimize!(model)
-    Test.@test termination_status(model) == MOI.OPTIMAL
-    Test.@test primal_status(model) == MOI.FEASIBLE_POINT
+    Test.@test termination_status(model) == OPTIMAL
+    Test.@test primal_status(model) == FEASIBLE_POINT
     Test.@test objective_value(model) == 172850.0
     if verbose
         println("RESULTS:")

--- a/docs/src/tutorials/linear/transp.jl
+++ b/docs/src/tutorials/linear/transp.jl
@@ -46,8 +46,8 @@ function example_transp()
         end
     )
     optimize!(model)
-    Test.@test termination_status(model) == MOI.OPTIMAL
-    Test.@test primal_status(model) == MOI.FEASIBLE_POINT
+    Test.@test termination_status(model) == OPTIMAL
+    Test.@test primal_status(model) == FEASIBLE_POINT
     Test.@test objective_value(model) == 196200.0
     println("The optimal solution is:")
     println(value.(trans))

--- a/docs/src/tutorials/linear/urban_plan.jl
+++ b/docs/src/tutorials/linear/urban_plan.jl
@@ -56,8 +56,8 @@ function example_urban_plan()
     end
     ## Solve it
     optimize!(model)
-    Test.@test termination_status(model) == MOI.OPTIMAL
-    Test.@test primal_status(model) == MOI.FEASIBLE_POINT
+    Test.@test termination_status(model) == OPTIMAL
+    Test.@test primal_status(model) == FEASIBLE_POINT
     Test.@test objective_value(model) ≈ 14.0
     return
 end

--- a/docs/src/tutorials/nonlinear/clnlbeam.jl
+++ b/docs/src/tutorials/nonlinear/clnlbeam.jl
@@ -57,8 +57,8 @@ function example_clnlbeam()
     primal_status      = $(primal_status(model))
     objective_value    = $(objective_value(model))
     """)
-    Test.@test termination_status(model) == MOI.LOCALLY_SOLVED  #src
-    Test.@test primal_status(model) == MOI.FEASIBLE_POINT  #src
+    Test.@test termination_status(model) == LOCALLY_SOLVED  #src
+    Test.@test primal_status(model) == FEASIBLE_POINT  #src
     Test.@test objective_value(model) ≈ 350.0  #src
     return
 end

--- a/docs/src/tutorials/nonlinear/qcp.jl
+++ b/docs/src/tutorials/nonlinear/qcp.jl
@@ -28,8 +28,8 @@ function example_qcp(; verbose = true)
         println("x = ", value(x))
         println("y = ", value(y))
     end
-    Test.@test termination_status(model) == MOI.LOCALLY_SOLVED
-    Test.@test primal_status(model) == MOI.FEASIBLE_POINT
+    Test.@test termination_status(model) == LOCALLY_SOLVED
+    Test.@test primal_status(model) == FEASIBLE_POINT
     Test.@test objective_value(model) ≈ 0.32699 atol = 1e-5
     Test.@test value(x) ≈ 0.32699 atol = 1e-5
     Test.@test value(y) ≈ 0.25707 atol = 1e-5

--- a/docs/src/tutorials/nonlinear/rosenbrock.jl
+++ b/docs/src/tutorials/nonlinear/rosenbrock.jl
@@ -19,8 +19,8 @@ function example_rosenbrock()
     @NLobjective(model, Min, (1 - x)^2 + 100 * (y - x^2)^2)
     optimize!(model)
 
-    Test.@test termination_status(model) == MOI.LOCALLY_SOLVED
-    Test.@test primal_status(model) == MOI.FEASIBLE_POINT
+    Test.@test termination_status(model) == LOCALLY_SOLVED
+    Test.@test primal_status(model) == FEASIBLE_POINT
     Test.@test objective_value(model) ≈ 0.0 atol = 1e-10
     Test.@test value(x) ≈ 1.0
     Test.@test value(y) ≈ 1.0

--- a/docs/src/tutorials/nonlinear/space_shuttle_reentry_trajectory.jl
+++ b/docs/src/tutorials/nonlinear/space_shuttle_reentry_trajectory.jl
@@ -305,7 +305,7 @@ end
 
 set_silent(model)  # Hide solver's verbose output
 optimize!(model)  # Solve for the control and state
-@assert termination_status(model) == MOI.LOCALLY_SOLVED
+@assert termination_status(model) == LOCALLY_SOLVED
 
 ## Show final crossrange of the solution
 println(

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -1428,6 +1428,21 @@ include("file_formats.jl")
 include("feasibility_checker.jl")
 include("deprecate.jl")
 
+# MOI contains a number of Enums that are often accessed by users such as
+# `MOI.OPTIMAL`. This piece of code re-exports them from JuMP so that users can
+# use: `MOI.OPTIMAL`, `JuMP.OPTIMAL`, or `using JuMP; OPTIMAL`.
+
+function _reexport_enum(enum)
+    @eval const $(Symbol(enum)) = $(enum)
+    for name in instances(enum)
+        @eval const $(Symbol(name)) = $(name)
+    end
+    return
+end
+
+_reexport_enum(MOI.ResultStatusCode)
+_reexport_enum(MOI.TerminationStatusCode)
+
 # JuMP exports everything except internal symbols, which are defined as those
 # whose name starts with an underscore. Macros whose names start with
 # underscores are internal as well. If you don't want all of these symbols

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -1432,16 +1432,15 @@ include("deprecate.jl")
 # `MOI.OPTIMAL`. This piece of code re-exports them from JuMP so that users can
 # use: `MOI.OPTIMAL`, `JuMP.OPTIMAL`, or `using JuMP; OPTIMAL`.
 
-function _reexport_enum(enum)
-    @eval const $(Symbol(enum)) = $(enum)
-    for name in instances(enum)
-        @eval const $(Symbol(name)) = $(name)
-    end
-    return
+const ResultStatusCode = MOI.ResultStatusCode
+for name in instances(ResultStatusCode)
+    @eval const $(Symbol(name)) = $(name)
 end
 
-_reexport_enum(MOI.ResultStatusCode)
-_reexport_enum(MOI.TerminationStatusCode)
+const TerminationStatusCode = MOI.TerminationStatusCode
+for name in instances(TerminationStatusCode)
+    @eval const $(Symbol(name)) = $(name)
+end
 
 # JuMP exports everything except internal symbols, which are defined as those
 # whose name starts with an underscore. Macros whose names start with

--- a/test/model.jl
+++ b/test/model.jl
@@ -776,7 +776,7 @@ function test_copy_conflict()
     JuMP.optimize!(model)
 
     mockoptimizer = JuMP.backend(model).optimizer.model
-    MOI.set(mockoptimizer, MOI.TerminationStatus(), MOI.INFEASIBLE)
+    MOI.set(mockoptimizer, MOI.TerminationStatus(), INFEASIBLE)
     MOI.set(mockoptimizer, MOI.ConflictStatus(), MOI.CONFLICT_FOUND)
     MOI.set(
         mockoptimizer,


### PR DESCRIPTION
This PR pulls a trick with `@eval` so that:
```julia
julia> OPTIMAL
OPTIMAL::TerminationStatusCode = 1

julia> MOI.OPTIMAL === JuMP.OPTIMAL === OPTIMAL
true
```
This makes it non-breaking, since all usages of `MOI.OPTIMAL` will continue to work.

So far, I've only done this for. `ResultStatusCode` and `TerminationStatusCode`. The reason being that these are the most commonly used. The others, like `CallbackStatusCode` and `BasisStatusCode` are a bit more expert-level and indicate that something else is going on.