### PR TITLE
Prep for v0.22 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ embedded in [Julia](https://julialang.org/). You can find out more about us by
 visiting [jump.dev](https://jump.dev).
 
 
-**Latest Release**: [![version](https://juliahub.com/docs/JuMP/DmXqY/0.21.10/version.svg)](https://juliahub.com/ui/Packages/JuMP/DmXqY/0.21.10) (`release-0.21` branch):
+**Latest Release**: [![version](https://juliahub.com/docs/JuMP/DmXqY/0.22.0/version.svg)](https://juliahub.com/ui/Packages/JuMP/DmXqY/0.22.0) (`release-0.22` branch):
   * Installation via the Julia package manager:
     * `import Pkg; Pkg.add("JuMP")`
   * Get help:
-    * Read the [Documentation](https://jump.dev/JuMP.jl/v0.21.10/)
+    * Read the [Documentation](https://jump.dev/JuMP.jl/stable/)
     * Ask a question on the [Community forum]
   * Testing status:
-    * Github Actions: [![Build Status](https://github.com/jump-dev/JuMP.jl/workflows/CI/badge.svg?branch=release-0.21)](https://github.com/jump-dev/JuMP.jl/actions?query=workflow%3ACI)
+    * Github Actions: [![Build Status](https://github.com/jump-dev/JuMP.jl/workflows/CI/badge.svg?branch=release-0.22)](https://github.com/jump-dev/JuMP.jl/actions?query=workflow%3ACI)
   * [![deps](https://juliahub.com/docs/JuMP/deps.svg)](https://juliahub.com/ui/Packages/JuMP/DmXqY?t=2)
 
 **Development version** (`master` branch):

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Version 0.22.0 (In development)
+## Version 0.22.0 (November 4, 2021)
 
 **JuMP v0.22 is a breaking release**
 

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Version 0.22.0 (November 4, 2021)
+## Version 0.22.0 (November 10, 2021)
 
 **JuMP v0.22 is a breaking release**
 


### PR DESCRIPTION
A release post is ready to go out: https://github.com/jump-dev/jump-dev.github.io/pull/59