### PR TITLE
Adding the LP sensitivity report print function for `solution_summary`

### DIFF
--- a/src/print.jl
+++ b/src/print.jl
@@ -443,48 +443,58 @@ struct _LPConstraintSensitivitySummary
 end
 
 struct _LPSensitivitySummary
-    lp_variables_sensitivity_report::Dict{VariableRef, _LPVariableSensitivitySummary}
-    lp_constraints_sensitivity_report::Dict{ConstraintRef, _LPConstraintSensitivitySummary}
+    lp_variables_sensitivity_report::Dict{
+        VariableRef,
+        _LPVariableSensitivitySummary,
+    }
+    lp_constraints_sensitivity_report::Dict{
+        ConstraintRef,
+        _LPConstraintSensitivitySummary,
+    }
 end
 
 function _get_lp_sensitivity_summary(model)
-    report = lp_sensitivity_report(model);
+    report = lp_sensitivity_report(model)
 
-    obj_value_coeff_dict = Dict{VariableRef, Float64}()
+    obj_value_coeff_dict = Dict{VariableRef,Float64}()
     for (coeff, variable) in linear_terms(objective_function(model, AffExpr))
         obj_value_coeff_dict[variable] = coeff
     end
 
-    lp_variables_sensitivity_report = Dict{VariableRef, _LPVariableSensitivitySummary}()
+    lp_variables_sensitivity_report =
+        Dict{VariableRef,_LPVariableSensitivitySummary}()
     for variable in all_variables(model)
         v_lo, v_hi = report[variable]
         if haskey(obj_value_coeff_dict, variable)
-            lp_variables_sensitivity_report[variable] = _LPVariableSensitivitySummary(
-                name(variable),
-                obj_value_coeff_dict[variable],
-                reduced_cost.(variable),
-                has_lower_bound(variable) ? lower_bound(variable) : -Inf,
-                has_upper_bound(variable) ? upper_bound(variable) :  Inf,
-                value.(variable),
-                v_hi,
-                -v_lo,
-            )
+            lp_variables_sensitivity_report[variable] =
+                _LPVariableSensitivitySummary(
+                    name(variable),
+                    obj_value_coeff_dict[variable],
+                    reduced_cost.(variable),
+                    has_lower_bound(variable) ? lower_bound(variable) : -Inf,
+                    has_upper_bound(variable) ? upper_bound(variable) : Inf,
+                    value.(variable),
+                    v_hi,
+                    -v_lo,
+                )
         end
     end
 
-    lp_constraints_sensitivity_report = Dict{ConstraintRef, _LPConstraintSensitivitySummary}()
+    lp_constraints_sensitivity_report =
+        Dict{ConstraintRef,_LPConstraintSensitivitySummary}()
     for (function_type, set_type) in list_of_constraint_types(model)
         function_type != AffExpr && continue # ignore
         for constraint in all_constraints(model, function_type, set_type)
             c_lo, c_hi = report[constraint]
-            lp_constraints_sensitivity_report[constraint] = _LPConstraintSensitivitySummary(
-                name(constraint),
-                normalized_rhs(constraint),
-                shadow_price(constraint),
-                value(constraint),
-                c_hi,
-                -c_lo,
-            )
+            lp_constraints_sensitivity_report[constraint] =
+                _LPConstraintSensitivitySummary(
+                    name(constraint),
+                    normalized_rhs(constraint),
+                    shadow_price(constraint),
+                    value(constraint),
+                    c_hi,
+                    -c_lo,
+                )
         end
     end
 
@@ -518,7 +528,7 @@ struct _SolutionSummary
     node_count::Union{Missing,Int}
     # Sensitivity
     sensitivity::Bool
-    lp_sensitivity_summary::Union{Missing, _LPSensitivitySummary}
+    lp_sensitivity_summary::Union{Missing,_LPSensitivitySummary}
 end
 
 """
@@ -548,7 +558,11 @@ function foo(model)
 end
 ```
 """
-function solution_summary(model::Model; verbose::Bool = false, sensitivity = false)
+function solution_summary(
+    model::Model;
+    verbose::Bool = false,
+    sensitivity = false,
+)
     return _SolutionSummary(
         verbose,
         solver_name(model),
@@ -585,7 +599,8 @@ function Base.show(io::IO, summary::_SolutionSummary)
     _show_status_summary(io, summary)
     _show_candidate_solution_summary(io, summary)
     _show_work_counters_summary(io, summary)
-    summary.sensitivity && _show_lp_sensitivity_summary(io, summary.lp_sensitivity_summary)
+    summary.sensitivity &&
+        _show_lp_sensitivity_summary(io, summary.lp_sensitivity_summary)
     return
 end
 
@@ -673,8 +688,14 @@ end
 function _show_lp_sensitivity_summary(io::IO, summary::_LPSensitivitySummary)
     println(io, "")
     println(io, "* LP sensitivity summary")
-    _show_lp_variables_sensitivity_report(io, summary.lp_variables_sensitivity_report)
-    _show_lp_constraints_sensitivity_report(io, summary.lp_constraints_sensitivity_report)
+    _show_lp_variables_sensitivity_report(
+        io,
+        summary.lp_variables_sensitivity_report,
+    )
+    _show_lp_constraints_sensitivity_report(
+        io,
+        summary.lp_constraints_sensitivity_report,
+    )
     return
 end
 
@@ -683,37 +704,17 @@ function _show_lp_variables_sensitivity_report(io::IO, report)
     println(io, "- Variables sensitivity")
 
     for key in sort(collect(keys(report)), by = k -> report[k].variable_name)
-        summary = report[key] 
-        _print_if_not_missing(
-            io,
-            "  Variable name : ",
-            summary.variable_name,
-        )
+        summary = report[key]
+        _print_if_not_missing(io, "  Variable name : ", summary.variable_name)
         _print_if_not_missing(
             io,
             "    Objective value coefficient : ",
             summary.obj_value_coeff,
         )
-        _print_if_not_missing(
-            io,
-            "    Reduced cost : ",
-            summary.reduced_cost,
-        )
-        _print_if_not_missing(
-            io,
-            "    Lower bound : ",
-            summary.lower_bound,
-        )
-        _print_if_not_missing(
-            io,
-            "    Upper bound : ",
-            summary.upper_bound,
-        )
-        _print_if_not_missing(
-            io,
-            "    Optimal value : ",
-            summary.optimal_value,
-        )
+        _print_if_not_missing(io, "    Reduced cost : ", summary.reduced_cost)
+        _print_if_not_missing(io, "    Lower bound : ", summary.lower_bound)
+        _print_if_not_missing(io, "    Upper bound : ", summary.upper_bound)
+        _print_if_not_missing(io, "    Optimal value : ", summary.optimal_value)
         _print_if_not_missing(
             io,
             "    Allowable increase in objective coefficient : ",
@@ -732,7 +733,7 @@ function _show_lp_constraints_sensitivity_report(io::IO, report)
     println(io, "- Constraints sensitivity")
 
     for key in sort(collect(keys(report)), by = k -> report[k].constraint_name)
-        summary = report[key] 
+        summary = report[key]
         _print_if_not_missing(
             io,
             "  Constraint name : ",
@@ -745,10 +746,16 @@ function _show_lp_constraints_sensitivity_report(io::IO, report)
         )
         println(io, "    Shadow price : ", summary.shadow_price)
         println(io, "    RHS optimal value : ", summary.rhs_opt_value)
-        println(io, "    Allowable increase in RHS coefficient  : ",
-         summary.allowable_increase_rhs_coeff)
-        println(io, "    Allowable decrease in RHS coefficient  : ",
-         summary.allowable_decrease_rhs_coeff)
+        println(
+            io,
+            "    Allowable increase in RHS coefficient  : ",
+            summary.allowable_increase_rhs_coeff,
+        )
+        println(
+            io,
+            "    Allowable decrease in RHS coefficient  : ",
+            summary.allowable_decrease_rhs_coeff,
+        )
     end
 end
 

--- a/src/print.jl
+++ b/src/print.jl
@@ -522,12 +522,15 @@ struct _SolutionSummary
 end
 
 """
-    solution_summary(model::Model; verbose::Bool = false)
+    solution_summary(model::Model; verbose::Bool = false, sensitivity = false)
 
 Return a struct that can be used print a summary of the solution.
 
 If `verbose=true`, write out the primal solution for every variable and the
 dual solution for every constraint, excluding those with empty names.
+
+If `sensitivity=true`, write out the LP sensitivity reports for every variable and
+for every constraint.
 
 ## Examples
 

--- a/test/print.jl
+++ b/test/print.jl
@@ -997,7 +997,6 @@ struct TestSensitivitySolution
 end
 
 @testset "Print LP sensitivity report" begin
-
     m = MOIU.MockOptimizer(
         MOIU.Model{Float64}(),
         eval_variable_constraint_dual = false,
@@ -1013,29 +1012,29 @@ end
         c2: x + y         <= 2.0
         """
     solution = Dict(
-            "x" => TestSensitivitySolution(
-                1.0,
-                NaN,
-                MOI.NONBASIC_AT_UPPER,
-                (-0.1, Inf),
-            ),
-            "y" => TestSensitivitySolution(1.0, NaN, MOI.BASIC, (-1, 0.1)),
-            "z" => TestSensitivitySolution(1.0, NaN, MOI.NONBASIC, (-Inf, Inf)),
-            "w" => TestSensitivitySolution(-2.0, NaN, MOI.BASIC, (-Inf, 1.0)),
-            ("x", MOI.GreaterThan{Float64}) =>
-                TestSensitivitySolution(NaN, 0.0, MOI.BASIC, (-Inf, 2.0)),
-            ("x", MOI.LessThan{Float64}) =>
-                TestSensitivitySolution(NaN, -0.1, MOI.NONBASIC, (-2, 1.0)),
-            ("y", MOI.GreaterThan{Float64}) =>
-                TestSensitivitySolution(NaN, 0.0, MOI.BASIC, (-Inf, 1.0)),
-            "c1" =>
-                TestSensitivitySolution(NaN, 0.0, MOI.NONBASIC, (-Inf, Inf)),
-            "c2" =>
-                TestSensitivitySolution(NaN, -1.0, MOI.NONBASIC, (-1.0, Inf)),
-            ("z", MOI.EqualTo{Float64}) =>
-                TestSensitivitySolution(NaN, 0.0, MOI.NONBASIC, (-Inf, Inf)),
-        )
-    
+        "x" => TestSensitivitySolution(
+            1.0,
+            NaN,
+            MOI.NONBASIC_AT_UPPER,
+            (-0.1, Inf),
+        ),
+        "y" => TestSensitivitySolution(1.0, NaN, MOI.BASIC, (-1, 0.1)),
+        "z" => TestSensitivitySolution(1.0, NaN, MOI.NONBASIC, (-Inf, Inf)),
+        "w" => TestSensitivitySolution(-2.0, NaN, MOI.BASIC, (-Inf, 1.0)),
+        ("x", MOI.GreaterThan{Float64}) =>
+            TestSensitivitySolution(NaN, 0.0, MOI.BASIC, (-Inf, 2.0)),
+        ("x", MOI.LessThan{Float64}) =>
+            TestSensitivitySolution(NaN, -0.1, MOI.NONBASIC, (-2, 1.0)),
+        ("y", MOI.GreaterThan{Float64}) =>
+            TestSensitivitySolution(NaN, 0.0, MOI.BASIC, (-Inf, 1.0)),
+        "c1" =>
+            TestSensitivitySolution(NaN, 0.0, MOI.NONBASIC, (-Inf, Inf)),
+        "c2" =>
+            TestSensitivitySolution(NaN, -1.0, MOI.NONBASIC, (-1.0, Inf)),
+        ("z", MOI.EqualTo{Float64}) =>
+            TestSensitivitySolution(NaN, 0.0, MOI.NONBASIC, (-Inf, Inf)),
+    )
+
     model = direct_model(m)
     MOI.Utilities.loadfromstring!(m, model_string)
     optimize!(model)
@@ -1077,7 +1076,7 @@ end
     end
 
     @test sprint(
-        (io, model) -> show(io, solution_summary(model, sensitivity=true)),
+        (io, model) -> show(io, solution_summary(model, sensitivity = true)),
         model,
     ) == """
 * Solver : Mock
@@ -1132,7 +1131,10 @@ end
 """
 
     @test sprint(
-        (io, model) -> show(io, solution_summary(model, verbose = true, sensitivity=true)),
+        (io, model) -> show(
+            io,
+            solution_summary(model, verbose = true, sensitivity = true),
+        ),
         model,
     ) == """
 * Solver : Mock
@@ -1195,5 +1197,4 @@ end
     Allowable increase in RHS coefficient  : Inf
     Allowable decrease in RHS coefficient  : 1.0
 """
-
 end


### PR DESCRIPTION
I added the LP sensitivity report print function for `solution_summary` to fix #2662.

Currently, just a printing function is added, not using Table.jl interfaces.
This is a print example:
```
* Solver : Mock
* Status
  Termination status : OPTIMAL
  Primal status      : FEASIBLE_POINT
  Dual status        : FEASIBLE_POINT
  Message from the solver:
  "solver specific string"
* Candidate solution
  Objective value      : 2.1
  Dual objective value : 2.1
* Work counters
  Solve time (sec)   : 5.00000
* LP sensitivity summary
- Variables sensitivity
  Variable name : x
    Objective value coefficient : 1.1
    Reduced cost : 0.1
    Lower bound : -1.0
    Upper bound : 1.0
    Optimal value : 1.0
    Allowable increase in objective coefficient : Inf
    Allowable decrease in objective coefficient : 0.1
  Variable name : y
    Objective value coefficient : 1.0
    Reduced cost : -0.0
    Lower bound : 0.0
    Upper bound : Inf
    Optimal value : 1.0
    Allowable increase in objective coefficient : 0.1
    Allowable decrease in objective coefficient : 1.0
- Constraints sensitivity
  Constraint name : c1
    Right hand side (RHS) coefficient : 1.0
    Shadow price : -0.0
    RHS optimal value : 1.0
    Allowable increase in RHS coefficient  : Inf
    Allowable decrease in RHS coefficient  : Inf
  Constraint name : c2
    Right hand side (RHS) coefficient : 2.0
    Shadow price : 1.0
    RHS optimal value : 2.0
    Allowable increase in RHS coefficient  : Inf
    Allowable decrease in RHS coefficient  : 1.0
```

I'm not sure how to get `slack or surplus value` for each constraint.
If someone can advise me how to do it, I'd like to add it.

