### PR TITLE
Fix bug in containers with tuple indices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuMP"
 uuid = "4076af6c-e467-56ae-b986-b466b2749572"
 repo = "https://github.com/jump-dev/JuMP.jl.git"
-version = "0.22.0"
+version = "0.22.1"
 
 [deps]
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -1,5 +1,10 @@
 # Release notes
 
+## Version 0.22.1 (In development)
+
+- Bug fixes:
+ * Fix bug in container with tuples as indices.
+
 ## Version 0.22.0 (November 10, 2021)
 
 **JuMP v0.22 is a breaking release**

--- a/src/Containers/macro.jl
+++ b/src/Containers/macro.jl
@@ -163,6 +163,9 @@ _depends_on(ex::Symbol, s::Symbol) = ex == s
 # For the case that `ex` might be an iterable literal like `4`.
 _depends_on(ex, s::Symbol) = false
 
+# For the case where the index set is compound, like `[(i, j) in S, k in i:K]`.
+_depends_on(ex1, ex2::Expr) = any(s -> _depends_on(ex1, s), ex2.args)
+
 function _has_dependent_sets(index_vars::Vector{Any}, index_sets::Vector{Any})
     for i in 2:length(index_sets)
         for j in 1:(i-1)

--- a/test/Containers/macro.jl
+++ b/test/Containers/macro.jl
@@ -11,7 +11,7 @@ using Test
         # alternative syntax
         Containers.@container(x[i in 1:3], i^2)
         @test x isa Vector{Int}
-        Containers.@container(x[i∈1:3], i^2)
+        Containers.@container(x[i ∈ 1:3], i^2)
         @test x isa Vector{Int}
     end
     @testset "Forced array" begin
@@ -154,5 +154,14 @@ using Test
             i + j,
             container = Int
         )
+    end
+    @testset "Compound indexing expressions" begin
+        Containers.@container(
+            x[(i, j) in [(1, 1), (2, 2)], k in i:3],
+            i + j + k,
+        )
+        @test x isa Containers.SparseAxisArray
+        @test length(x) == 5
+        @test x[(2, 2), 3] == 7
     end
 end

--- a/test/Containers/macro.jl
+++ b/test/Containers/macro.jl
@@ -11,7 +11,7 @@ using Test
         # alternative syntax
         Containers.@container(x[i in 1:3], i^2)
         @test x isa Vector{Int}
-        Containers.@container(x[i ∈ 1:3], i^2)
+        Containers.@container(x[i∈1:3], i^2)
         @test x isa Vector{Int}
     end
     @testset "Forced array" begin


### PR DESCRIPTION
Looks like I forgot to move this method when I was refactoring the containers module.  It surprised me that this syntax can't have been tested anywhere in JuMP (or in the documentation?).

Closes #2799