### PR TITLE
Refactor print.jl with no visible changes*

### DIFF
--- a/docs/src/manual/nlp.md
+++ b/docs/src/manual/nlp.md
@@ -60,17 +60,17 @@ nonlinear terms.
 
 ```jldoctest nl_expression; setup=:(model = Model(); @variable(model, x[1:2]))
 julia> expr = @NLexpression(model, exp(x[1]) + sqrt(x[2]))
-"subexpression[1]: exp(x[1]) + sqrt(x[2])"
+subexpression[1]: exp(x[1]) + sqrt(x[2])
 
 julia> my_anon_expr = @NLexpression(model, [i = 1:2], sin(x[i]))
 2-element Vector{NonlinearExpression}:
- "subexpression[2]: sin(x[1])"
- "subexpression[3]: sin(x[2])"
+ subexpression[2]: sin(x[1])
+ subexpression[3]: sin(x[2])
 
 julia> @NLexpression(model, my_expr[i = 1:2], sin(x[i]))
 2-element Vector{NonlinearExpression}:
- "subexpression[4]: sin(x[1])"
- "subexpression[5]: sin(x[2])"
+ subexpression[4]: sin(x[1])
+ subexpression[5]: sin(x[2])
 ```
 
 Nonlinear expression can be used in [`@NLobjective`](@ref), [`@NLconstraint`](@ref),
@@ -86,8 +86,8 @@ julia> @NLconstraint(model, [i = 1:2], my_expr[i] <= i)
 
 julia> @NLexpression(model, nested[i = 1:2], sin(my_expr[i]))
 2-element Vector{NonlinearExpression}:
- "subexpression[6]: sin(subexpression[4])"
- "subexpression[7]: sin(subexpression[5])"
+ subexpression[6]: sin(subexpression[4])
+ subexpression[7]: sin(subexpression[5])
 ```
 
 ## Create a nonlinear parameter
@@ -105,14 +105,14 @@ the `==` sign.
 ```jldoctest nonlinear_parameters; setup=:(model = Model(); @variable(model, x))
 julia> @NLparameter(model, p[i = 1:2] == i)
 2-element Vector{NonlinearParameter}:
- "parameter[1] == 1.0"
- "parameter[2] == 2.0"
+ parameter[1] == 1.0
+ parameter[2] == 2.0
 ```
 
 Create anonymous parameters using the `value` keyword:
 ```jldoctest nonlinear_parameters
 julia> anon_parameter = @NLparameter(model, value = 1)
-"parameter[3] == 1.0"
+parameter[3] == 1.0
 ```
 
 !!! info
@@ -153,7 +153,7 @@ Closest candidates are:
 [...]
 
 julia> @NLexpression(model, my_nl_expr, p[1] * x^2)
-"subexpression[1]: parameter[1] * x ^ 2.0"
+subexpression[1]: parameter[1] * x ^ 2.0
 ```
 
 ### When to use a parameter
@@ -201,7 +201,7 @@ ERROR: sin is not defined for type AbstractVariableRef. Are you trying to build 
 [...]
 
 julia> expr = @NLexpression(model, sin(x) + 1)
-"subexpression[1]: sin(x) + 1.0"
+subexpression[1]: sin(x) + 1.0
 ```
 
 ### Scalar operations only
@@ -594,12 +594,12 @@ julia> expr = :($(x) + sin($(x)^2))
 :(x + sin(x ^ 2))
 
 julia> expr_ref = add_NL_expression(model, expr)
-"subexpression[1]: x + sin(x ^ 2.0)"
+subexpression[1]: x + sin(x ^ 2.0)
 ```
 This is equivalent to
 ```jldoctest; setup=:(using JuMP; model = Model(); @variable(model, x))
 julia> expr_ref = @NLexpression(model, x + sin(x^2))
-"subexpression[1]: x + sin(x ^ 2.0)"
+subexpression[1]: x + sin(x ^ 2.0)
 ```
 
 !!! note

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -1371,34 +1371,39 @@ mutable struct _VariablePrintWrapper
     v::VariableRef
     mode::Any
 end
+
 function Base.show(io::IO, v::_VariablePrintWrapper)
     return print(io, function_string(v.mode, v.v))
 end
+
 mutable struct _ParameterPrintWrapper
     model::Model
     idx::Int
     mode::Any
 end
-function Base.show(io::IO, p::_ParameterPrintWrapper)
-    relevant_parameters = filter(
-        i -> i[2] isa NonlinearParameter && i[2].index == p.idx,
-        p.model.obj_dict,
-    )
-    if length(relevant_parameters) == 1
-        par_name = first(relevant_parameters)[1]
-        print(io, par_name)
-    else
-        if p.mode == IJuliaMode
-            print(io, "parameter_{$(p.idx)}")
-        else
-            print(io, "parameter[$(p.idx)]")
+
+function Base.show(io::IO, wrapper::_ParameterPrintWrapper)
+    p = NonlinearParameter(wrapper.model, wrapper.idx)
+    for (k, v) in object_dictionary(p.model)
+        if v == p
+            print(io, k)
+            return
         end
     end
+    # No named parameter; use a generic name.
+    if wrapper.mode == IJuliaMode
+        print(io, "parameter_{$(p.index)}")
+    else
+        print(io, "parameter[$(p.index)]")
+    end
+    return
 end
+
 mutable struct _SubexpressionPrintWrapper
     idx::Int
     mode::Any
 end
+
 function Base.show(io::IO, s::_SubexpressionPrintWrapper)
     if s.mode == IJuliaMode
         print(io, "subexpression_{$(s.idx)}")

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -2020,7 +2020,7 @@ programmatically, and you cannot use [`@NLexpression`](@ref).
 
 ```jldoctest; setup=:(using JuMP; model = Model(); @variable(model, x))
 julia> add_NL_expression(model, :(\$(x) + \$(x)^2))
-"subexpression[1]: x + x ^ 2.0"
+subexpression[1]: x + x ^ 2.0
 ```
 """
 function add_NL_expression(model::Model, ex)

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -176,15 +176,14 @@ function _init_NLP(m::Model)
     end
 end
 
+const NonlinearConstraintRef = ConstraintRef{Model,NonlinearConstraintIndex}
+
 """
-    is_valid(model::Model, c::ConstraintRef{Model,NonlinearConstraintIndex})
+    is_valid(model::Model, c::NonlinearConstraintRef)
 
 Return `true` if `c` refers to a valid nonlinear constraint in `model`.
 """
-function is_valid(
-    model::Model,
-    c::ConstraintRef{Model,NonlinearConstraintIndex},
-)
+function is_valid(model::Model, c::NonlinearConstraintRef)
     if model !== c.model
         return false
     end
@@ -193,11 +192,11 @@ function is_valid(
 end
 
 """
-    dual(c::ConstraintRef{Model,NonlinearConstraintIndex})
+    dual(c::NonlinearConstraintRef)
 
 Return the dual of the nonlinear constraint `c`.
 """
-function dual(c::ConstraintRef{Model,NonlinearConstraintIndex})
+function dual(c::NonlinearConstraintRef)
     _init_NLP(c.model)
     nldata::_NLPData = c.model.nlp_data
     # The array is cleared on every solve.

--- a/src/print.jl
+++ b/src/print.jl
@@ -24,7 +24,6 @@
 
 using Printf
 
-# Used for dispatching
 """
     PrintMode
 
@@ -65,6 +64,7 @@ inside a function.
 latex_formulation(model::AbstractModel) = _LatexModel(model)
 
 Base.show(io::IO, model::_LatexModel) = _print_latex(io, model.model)
+
 Base.show(io::IO, ::MIME"text/latex", model::_LatexModel) = show(io, model)
 
 function Base.print(model::AbstractModel)
@@ -76,24 +76,27 @@ function Base.print(model::AbstractModel)
     end
     return _print_model(stdout, model)
 end
+
 Base.print(io::IO, model::AbstractModel) = _print_model(io, model)
 
 # Whether something is zero or not for the purposes of printing it
 # oneunit is useful e.g. if coef is a Unitful quantity.
 _is_zero_for_printing(coef) = abs(coef) < 1e-10 * oneunit(coef)
+
 # Whether something is one or not for the purposes of printing it.
 _is_one_for_printing(coef) = _is_zero_for_printing(abs(coef) - oneunit(coef))
-_sign_string(coef) = coef < zero(coef) ? " - " : " + "
 
 # Helper function that rounds carefully for the purposes of printing
 # e.g.   5.3  =>  5.3
 #        1.0  =>  1
-function _string_round(f::Float64)
-    iszero(f) && return "0" # strip sign off zero
-    str = string(f)
-    return length(str) >= 2 && str[end-1:end] == ".0" ? str[1:end-2] : str
+function _string_round(x::Float64)
+    if isinteger(x)
+        return string(round(Int, x))
+    end
+    return string(x)
 end
-_string_round(f) = string(f)
+
+_string_round(x) = string(x)
 
 # REPL-specific symbols
 # Anything here: https://en.wikipedia.org/wiki/Windows-1252
@@ -194,7 +197,7 @@ end
 _wrap_in_math_mode(str) = "\$\$ $str \$\$"
 _wrap_in_inline_math_mode(str) = "\$ $str \$"
 
-_plural(n) = (isone(n) ? "" : "s")
+_plural(n) = isone(n) ? "" : "s"
 
 #------------------------------------------------------------------------
 ## Model
@@ -212,6 +215,10 @@ function name(model::Model)
     ret = MOI.get(model, MOI.Name())
     return isempty(ret) ? "A JuMP Model" : ret
 end
+
+###
+### print_summary
+###
 
 """
     _print_summary(io::IO, model::AbstractModel)
@@ -235,13 +242,8 @@ function _print_summary(io::IO, model::AbstractModel)
         print(io, "Feasibility")
     end
     println(io, " problem with:")
-    println(
-        io,
-        "Variable",
-        _plural(num_variables(model)),
-        ": ",
-        num_variables(model),
-    )
+    n = num_variables(model)
+    println(io, "Variable", _plural(n), ": ", n)
     if sense != FEASIBILITY_SENSE
         show_objective_function_summary(io, model)
     end
@@ -256,6 +258,40 @@ function _print_summary(io::IO, model::AbstractModel)
             join(string.(names_in_scope), ", "),
         )
     end
+    return
+end
+
+"""
+    show_objective_function_summary(io::IO, model::AbstractModel)
+
+Write to `io` a summary of the objective function type.
+"""
+function show_objective_function_summary(io::IO, model::Model)
+    nlobj = _nlp_objective_function(model)
+    print(io, "Objective function type: ")
+    if nlobj === nothing
+        println(io, objective_function_type(model))
+    else
+        println(io, "Nonlinear")
+    end
+    return
+end
+
+"""
+    show_constraints_summary(io::IO, model::AbstractModel)
+
+Write to `io` a summary of the number of constraints.
+"""
+function show_constraints_summary(io::IO, model::Model)
+    for (F, S) in list_of_constraint_types(model)
+        n = num_constraints(model, F, S)
+        println(io, "`$F`-in-`$S`: $n constraint", _plural(n))
+    end
+    n = num_nl_constraints(model)
+    if n > 0
+        println(io, "Nonlinear: ", n, " constraint", _plural(n))
+    end
+    return
 end
 
 """
@@ -276,13 +312,19 @@ function show_backend_summary(io::IO, model::Model)
     return
 end
 
+###
+### print_model
+###
+
 """
     _print_model(io::IO, model::AbstractModel)
 
 Print a plain-text formulation of `model` to `io`.
 
-An `AbstractModel` subtype should implement `objective_function_string`,
-`constraints_string` and `_nl_subexpression_string` for this method to work.
+For this method to work, an `AbstractModel` subtype must implement:
+ * `objective_function_string`
+ * `constraints_string`
+ * `_nl_subexpression_string`
 """
 function _print_model(io::IO, model::AbstractModel)
     sense = objective_sense(model)
@@ -302,9 +344,9 @@ function _print_model(io::IO, model::AbstractModel)
     nl_subexpressions = _nl_subexpression_string(REPLMode, model)
     if !isempty(nl_subexpressions)
         println(io, "With NL expressions")
-    end
-    for expr in nl_subexpressions
-        println(io, " ", expr)
+        for expr in nl_subexpressions
+            println(io, " ", expr)
+        end
     end
     return
 end
@@ -314,8 +356,10 @@ end
 
 Print a LaTeX formulation of `model` to `io`.
 
-An `AbstractModel` subtype should implement `objective_function_string`,
-`constraints_string` and `_nl_subexpression_string` for this method to work.
+For this method to work, an `AbstractModel` subtype must implement:
+ * `objective_function_string`
+ * `constraints_string`
+ * `_nl_subexpression_string`
 """
 function _print_latex(io::IO, model::AbstractModel)
     println(io, "\$\$ \\begin{aligned}")
@@ -332,18 +376,19 @@ function _print_latex(io::IO, model::AbstractModel)
     constraints = constraints_string(IJuliaMode, model)
     if !isempty(constraints)
         print(io, "\\text{Subject to} \\quad")
-    end
-    for constraint in constraints
-        println(io, " & ", constraint, "\\\\")
+        for constraint in constraints
+            println(io, " & ", constraint, "\\\\")
+        end
     end
     nl_subexpressions = _nl_subexpression_string(IJuliaMode, model)
     if !isempty(nl_subexpressions)
         print(io, "\\text{With NL expressions} \\quad")
+        for expr in nl_subexpressions
+            println(io, " & ", expr, "\\\\")
+        end
     end
-    for expr in nl_subexpressions
-        println(io, " & ", expr, "\\\\")
-    end
-    return print(io, "\\end{aligned} \$\$")
+    print(io, "\\end{aligned} \$\$")
+    return
 end
 
 """
@@ -361,52 +406,9 @@ function model_string(print_mode, model::AbstractModel)
     end
 end
 
-_nl_subexpression_string(print_mode, ::AbstractModel) = String[]
-
-function _nl_subexpression_string(print_mode, model::Model)
-    strings = String[]
-    if model.nlp_data !== nothing
-        num_subexpressions = length(model.nlp_data.nlexpr)::Int
-        for k in 1:num_subexpressions
-            ex = model.nlp_data.nlexpr[k]
-            expr_string = _tape_to_expr(
-                model,
-                1, # start index in the expression
-                ex.nd,
-                adjmat(ex.nd),
-                ex.const_values,
-                [], # parameter_values (not used)
-                [], # subexpressions (not needed because !splat_subexpressions)
-                model.nlp_data.user_operators,
-                false, # generic_variable_names
-                false, # splat_subexpressions
-                print_mode,
-            )
-            if print_mode == IJuliaMode
-                expr_name = "subexpression_{$k}"
-            else
-                expr_name = "subexpression[$k]"
-            end
-            push!(strings, "$expr_name: $expr_string")
-        end
-    end
-    return strings
-end
-
-"""
-    show_objective_function_summary(io::IO, model::AbstractModel)
-
-Write to `io` a summary of the objective function type.
-"""
-function show_objective_function_summary(io::IO, model::Model)
-    nlobj = _nlp_objective_function(model)
-    print(io, "Objective function type: ")
-    if nlobj === nothing
-        println(io, objective_function_type(model))
-    else
-        println(io, "Nonlinear")
-    end
-end
+###
+### objective_function_string
+###
 
 """
     objective_function_string(print_mode, model::AbstractModel)::String
@@ -422,18 +424,148 @@ function objective_function_string(print_mode, model::Model)
     end
 end
 
-#------------------------------------------------------------------------
-## VariableRef
-#------------------------------------------------------------------------
+###
+### constraints_string
+###
 
+"""
+    nl_constraint_string(model::Model, mode, c::_NonlinearConstraint)
+
+Return a string representation of the nonlinear constraint `c` belonging to
+`model`, given the `print_mode`. `print_mode` should be `IJuliaMode` or
+`REPLMode`.
+"""
+function nl_constraint_string(model::Model, mode, c::_NonlinearConstraint)
+    s = _sense(c)
+    nl = nl_expr_string(model, mode, c.terms)
+    if s == :range
+        out_str =
+            "$(_string_round(c.lb)) " *
+            _math_symbol(mode, :leq) *
+            " $nl " *
+            _math_symbol(mode, :leq) *
+            " " *
+            _string_round(c.ub)
+    else
+        if s == :<=
+            rel = _math_symbol(mode, :leq)
+        elseif s == :>=
+            rel = _math_symbol(mode, :geq)
+        else
+            rel = _math_symbol(mode, :eq)
+        end
+        out_str = string(nl, " ", rel, " ", _string_round(_rhs(c)))
+    end
+    return out_str
+end
+
+"""
+    constraints_string(print_mode, model::AbstractModel)::Vector{String}
+
+Return a list of `String`s describing each constraint of the model.
+"""
+function constraints_string(print_mode, model::Model)
+    strings = String[
+        constraint_string(print_mode, cref, in_math_mode = true) for
+        (F, S) in list_of_constraint_types(model) for
+        cref in all_constraints(model, F, S)
+    ]
+    if model.nlp_data !== nothing
+        for nl_constraint in model.nlp_data.nlconstr
+            push!(
+                strings,
+                nl_constraint_string(model, print_mode, nl_constraint),
+            )
+        end
+    end
+    return strings
+end
+
+###
+### _nl_subexpression_string
+###
+
+"""
+    nl_expr_string(model::Model, print_mode, c::_NonlinearExprData)
+
+Return a string representation of the nonlinear expression `c` belonging to
+`model`, given the `print_mode`. `print_mode` should be `IJuliaMode` or
+`REPLMode`.
+"""
+function nl_expr_string(model::Model, print_mode, c::_NonlinearExprData)
+    ex = _tape_to_expr(
+        model,
+        1,
+        c.nd,
+        adjmat(c.nd),
+        c.const_values,
+        [],
+        [],
+        model.nlp_data.user_operators,
+        false,
+        false,
+        print_mode,
+    )
+    if print_mode == IJuliaMode
+        ex = _latexify_exponentials(ex)
+    end
+    return string(ex)
+end
+
+# Change x ^ -2.0 to x ^ {-2.0}
+# x ^ (x ^ 2.0) to x ^ {x ^ {2.0}}
+# and so on
+_latexify_exponentials(ex) = ex
+
+function _latexify_exponentials(ex::Expr)
+    for i in 1:length(ex.args)
+        ex.args[i] = _latexify_exponentials(ex.args[i])
+    end
+    if length(ex.args) == 3 && ex.args[1] == :^
+        ex.args[3] = Expr(:braces, ex.args[3])
+    end
+    return ex
+end
+
+_nl_subexpression_string(print_mode, ::AbstractModel) = String[]
+
+function _nl_subexpression_string(print_mode, model::Model)
+    if model.nlp_data === nothing
+        return String[]
+    end
+    strings = String[]
+    for k in 1:length(model.nlp_data.nlexpr)::Int
+        expr = nl_expr_string(model, print_mode, model.nlp_data.nlexpr[k])
+        if print_mode == IJuliaMode
+            push!(strings, "subexpression_{$k}: $expr")
+        else
+            push!(strings, "subexpression[$k]: $expr")
+        end
+    end
+    return strings
+end
+
+###
+### function_string
+###
+
+"""
+    function_string(
+        print_mode::Type{<:JuMP.PrintMode},
+        func::Union{JuMP.AbstractJuMPScalar,Vector{<:JuMP.AbstractJuMPScalar}},
+    )
+
+Return a `String` representing the function `func` using print mode
+`print_mode`.
+"""
 function function_string(::Type{REPLMode}, v::AbstractVariableRef)
     var_name = name(v)
-    if !isempty(var_name)
-        return var_name
-    else
+    if isempty(var_name)
         return "noname"
     end
+    return var_name
 end
+
 function function_string(::Type{IJuliaMode}, v::AbstractVariableRef)
     var_name = name(v)
     if isempty(var_name)
@@ -451,182 +583,65 @@ function function_string(::Type{IJuliaMode}, v::AbstractVariableRef)
     if m !== nothing
         var_name = m[1] * "_{" * m[2] * "}"
     end
-
     return var_name
 end
 
-#------------------------------------------------------------------------
-## GenericAffExpr
-#------------------------------------------------------------------------
-
 function function_string(mode, a::GenericAffExpr, show_constant = true)
-    # If the expression is empty, return the constant (or 0)
     if length(linear_terms(a)) == 0
         return show_constant ? _string_round(a.constant) : "0"
     end
-
-    term_str = Array{String}(undef, 2 * length(linear_terms(a)))
-    elm = 1
-
-    for (coef, var) in linear_terms(a)
-        pre = _is_one_for_printing(coef) ? "" : _string_round(abs(coef)) * " "
-
-        term_str[2*elm-1] = _sign_string(coef)
-        term_str[2*elm] = string(pre, function_string(mode, var))
-        elm += 1
-    end
-
-    if elm == 1
-        # Will happen with cancellation of all terms
-        # We should just return the constant, if its desired
-        return show_constant ? _string_round(a.constant) : "0"
-    else
-        # Correction for very first term - don't want a " + "/" - "
-        term_str[1] = (term_str[1] == " - ") ? "-" : ""
-        ret = join(term_str[1:2*(elm-1)])
-        if !_is_zero_for_printing(a.constant) && show_constant
-            ret = string(
-                ret,
-                _sign_string(a.constant),
-                _string_round(abs(a.constant)),
-            )
+    terms = fill("", 2 * length(linear_terms(a)))
+    for (elm, (coef, var)) in enumerate(linear_terms(a))
+        terms[2*elm-1] = coef < zero(coef) ? " - " : " + "
+        v = function_string(mode, var)
+        if _is_one_for_printing(coef)
+            terms[2*elm] = v
+        else
+            terms[2*elm] = string(_string_round(abs(coef)), " ", v)
         end
-        return ret
     end
+    terms[1] = terms[1] == " - " ? "-" : ""
+    ret = join(terms)
+    if show_constant && !_is_zero_for_printing(a.constant)
+        ret = string(
+            ret,
+            a.constant < zero(a.constant) ? " - " : " + ",
+            _string_round(abs(a.constant)),
+        )
+    end
+    return ret
 end
 
-#------------------------------------------------------------------------
-## GenericQuadExpr
-#------------------------------------------------------------------------
-
 function function_string(mode, q::GenericQuadExpr)
-    length(quad_terms(q)) == 0 && return function_string(mode, q.aff)
-
-    # Odd terms are +/i, even terms are the variables/coeffs
-    term_str = Array{String}(undef, 2 * length(quad_terms(q)))
-    elm = 1
-    if length(term_str) > 0
-        for (coef, var1, var2) in quad_terms(q)
-            pre =
-                _is_one_for_printing(coef) ? "" : _string_round(abs(coef)) * " "
-
-            x = function_string(mode, var1)
-            y = function_string(mode, var2)
-
-            term_str[2*elm-1] = _sign_string(coef)
-            term_str[2*elm] = "$pre$x"
-            if x == y
-                term_str[2*elm] *= _math_symbol(mode, :sq)
-            else
-                term_str[2*elm] *= string(_math_symbol(mode, :times), y)
-            end
-            if elm == 1
-                # Correction for first term as there is no space
-                # between - and variable coefficient/name
-                term_str[1] = coef < zero(coef) ? "-" : ""
-            end
-            elm += 1
+    if length(quad_terms(q)) == 0
+        return function_string(mode, q.aff)
+    end
+    terms = fill("", 2 * length(quad_terms(q)))
+    for (elm, (coef, var1, var2)) in enumerate(quad_terms(q))
+        x = function_string(mode, var1)
+        y = function_string(mode, var2)
+        terms[2*elm-1] = coef < zero(coef) ? " - " : " + "
+        if _is_one_for_printing(coef)
+            terms[2*elm] = "$x"
+        else
+            terms[2*elm] = string(_string_round(abs(coef)), " ", x)
+        end
+        if x == y
+            terms[2*elm] *= _math_symbol(mode, :sq)
+        else
+            terms[2*elm] *= string(_math_symbol(mode, :times), y)
         end
     end
-    ret = join(term_str[1:2*(elm-1)])
-
+    terms[1] = terms[1] == " - " ? "-" : ""
+    ret = join(terms)
     aff_str = function_string(mode, q.aff)
     if aff_str == "0"
         return ret
+    elseif aff_str[1] == '-'
+        return string(ret, " - ", aff_str[2:end])
     else
-        if aff_str[1] == '-'
-            return string(ret, " - ", aff_str[2:end])
-        else
-            return string(ret, " + ", aff_str)
-        end
+        return string(ret, " + ", aff_str)
     end
-end
-
-#------------------------------------------------------------------------
-## Constraints
-#------------------------------------------------------------------------
-
-"""
-    show_constraints_summary(io::IO, model::AbstractModel)
-
-Write to `io` a summary of the number of constraints.
-"""
-function show_constraints_summary(io::IO, model::Model)
-    for (F, S) in list_of_constraint_types(model)
-        n_constraints = num_constraints(model, F, S)
-        println(
-            io,
-            "`$F`-in-`$S`: $n_constraints constraint",
-            _plural(n_constraints),
-        )
-    end
-    if !iszero(num_nl_constraints(model))
-        println(
-            io,
-            "Nonlinear: ",
-            num_nl_constraints(model),
-            " constraint",
-            _plural(num_nl_constraints(model)),
-        )
-    end
-end
-
-"""
-    constraints_string(print_mode, model::AbstractModel)::Vector{String}
-
-Return a list of `String`s describing each constraint of the model.
-"""
-function constraints_string(print_mode, model::Model)
-    strings = String[]
-    for (F, S) in list_of_constraint_types(model)
-        for cref in all_constraints(model, F, S)
-            push!(
-                strings,
-                constraint_string(print_mode, cref, in_math_mode = true),
-            )
-        end
-    end
-    if model.nlp_data !== nothing
-        for nl_constraint in model.nlp_data.nlconstr
-            push!(
-                strings,
-                nl_constraint_string(model, print_mode, nl_constraint),
-            )
-        end
-    end
-    return strings
-end
-
-## Notes for extensions
-# For a `ConstraintRef{ModelType, IndexType}` where `ModelType` is not
-# `JuMP.Model` or `IndexType` is not `MathOptInterface.ConstraintIndex`, the
-# methods `JuMP.name` and `JuMP.constraint_object` should be implemented for
-# printing to work. If the `AbstractConstraint` returned by `constraint_object`
-# is not `JuMP.ScalarConstraint` nor `JuMP.VectorConstraint`, then either
-# `JuMP.jump_function` or `JuMP.function_string` and either `JuMP.moi_set` or
-# `JuMP.in_set_string` should be implemented.
-function Base.show(io::IO, ref::ConstraintRef)
-    return print(io, constraint_string(REPLMode, ref))
-end
-function Base.show(io::IO, ::MIME"text/latex", ref::ConstraintRef)
-    return print(io, constraint_string(IJuliaMode, ref))
-end
-
-"""
-    function_string(print_mode::Type{<:JuMP.PrintMode},
-                    func::Union{JuMP.AbstractJuMPScalar,
-                                Vector{<:JuMP.AbstractJuMPScalar}})
-
-Return a `String` representing the function `func` using print mode
-`print_mode`.
-"""
-function function_string end
-
-function Base.show(io::IO, f::AbstractJuMPScalar)
-    return print(io, function_string(REPLMode, f))
-end
-function Base.show(io::IO, ::MIME"text/latex", f::AbstractJuMPScalar)
-    return print(io, _wrap_in_math_mode(function_string(IJuliaMode, f)))
 end
 
 function function_string(print_mode, vector::Vector{<:AbstractJuMPScalar})
@@ -671,17 +686,28 @@ function function_string(
     return str * "\\end{bmatrix}"
 end
 
-"""
-    function_string(print_mode::{<:JuMP.PrintMode},
-                    constraint::JuMP.AbstractConstraint)
-
-Return a `String` representing the function of the constraint `constraint`
-using print mode `print_mode`.
-"""
 function function_string(print_mode, constraint::AbstractConstraint)
     f = reshape_vector(jump_function(constraint), shape(constraint))
     return function_string(print_mode, f)
 end
+
+function function_string(print_mode::Type{<:PrintMode}, p::NonlinearExpression)
+    s = nl_expr_string(p.model, print_mode, p.model.nlp_data.nlexpr[p.index])
+    return "subexpression[$(p.index)]: " * s
+end
+
+function function_string(::Type{<:PrintMode}, p::NonlinearParameter)
+    for (k, v) in object_dictionary(p.model)
+        if v == p
+            return "$k == $(value(p))"
+        end
+    end
+    return "parameter[$(p.index)] == $(value(p))"
+end
+
+###
+### in_set_string
+###
 
 """
     in_set_string(print_mode::Type{<:PrintMode}, set)
@@ -716,9 +742,9 @@ function in_set_string(print_mode, set::MOI.Interval)
 end
 
 in_set_string(print_mode, ::MOI.ZeroOne) = "binary"
-in_set_string(print_mode, ::MOI.Integer) = "integer"
-
 in_set_string(::Type{IJuliaMode}, ::MOI.ZeroOne) = "\\in \\{0, 1\\}"
+
+in_set_string(print_mode, ::MOI.Integer) = "integer"
 in_set_string(::Type{IJuliaMode}, ::MOI.Integer) = "\\in \\mathbb{Z}"
 
 function in_set_string(print_mode, set::Union{PSDCone,MOI.AbstractSet})
@@ -740,6 +766,29 @@ Return a `String` representing the membership to the set of the constraint
 function in_set_string(print_mode, constraint::AbstractConstraint)
     set = reshape_set(moi_set(constraint), shape(constraint))
     return in_set_string(print_mode, set)
+end
+
+###
+### constraint_string
+###
+
+"""
+    constraint_string(
+        print_mode,
+        ref::ConstraintRef;
+        in_math_mode::Bool = false)
+
+Return a string representation of the constraint `ref`, given the `print_mode`.
+
+`print_mode` should be `IJuliaMode` or `REPLMode`.
+"""
+function constraint_string(print_mode, ref::ConstraintRef; in_math_mode = false)
+    return constraint_string(
+        print_mode,
+        name(ref),
+        constraint_object(ref),
+        in_math_mode = in_math_mode,
+    )
 end
 
 function constraint_string(print_mode, constraint_object::AbstractConstraint)
@@ -775,73 +824,55 @@ function constraint_string(
     end
 end
 
-"""
-    constraint_string(
-        print_mode,
-        ref::ConstraintRef;
-        in_math_mode::Bool = false)
+## Notes for extensions
+# For a `ConstraintRef{ModelType, IndexType}` where `ModelType` is not
+# `JuMP.Model` or `IndexType` is not `MathOptInterface.ConstraintIndex`, the
+# methods `JuMP.name` and `JuMP.constraint_object` should be implemented for
+# printing to work. If the `AbstractConstraint` returned by `constraint_object`
+# is not `JuMP.ScalarConstraint` nor `JuMP.VectorConstraint`, then either
+# `JuMP.jump_function` or `JuMP.function_string` and either `JuMP.moi_set` or
+# `JuMP.in_set_string` should be implemented.
 
-Return a string representation of the constraint `ref`, given the `print_mode`.
+###
+### Base.show
+###
 
-`print_mode` should be `IJuliaMode` or `REPLMode`.
-"""
-function constraint_string(print_mode, ref::ConstraintRef; in_math_mode = false)
-    return constraint_string(
-        print_mode,
-        name(ref),
-        constraint_object(ref),
-        in_math_mode = in_math_mode,
-    )
+function Base.show(io::IO, ref::ConstraintRef)
+    return print(io, constraint_string(REPLMode, ref))
 end
 
-#------------------------------------------------------------------------
-## _NonlinearExprData
-#------------------------------------------------------------------------
-
-"""
-    nl_expr_string(model::Model, print_mode, c::_NonlinearExprData)
-
-Return a string representation of the nonlinear expression `c` belonging to
-`model`, given the `print_mode`. `print_mode` should be `IJuliaMode` or
-`REPLMode`.
-"""
-function nl_expr_string(model::Model, print_mode, c::_NonlinearExprData)
-    ex = _tape_to_expr(
-        model,
-        1,
-        c.nd,
-        adjmat(c.nd),
-        c.const_values,
-        [],
-        [],
-        model.nlp_data.user_operators,
-        false,
-        false,
-        print_mode,
-    )
-    if print_mode == IJuliaMode
-        ex = _latexify_exponentials(ex)
-    end
-    return string(ex)
+function Base.show(io::IO, ::MIME"text/latex", ref::ConstraintRef)
+    return print(io, constraint_string(IJuliaMode, ref))
 end
 
-# Change x ^ -2.0 to x ^ {-2.0}
-# x ^ (x ^ 2.0) to x ^ {x ^ {2.0}}
-# and so on
-_latexify_exponentials(ex) = ex
-function _latexify_exponentials(ex::Expr)
-    for i in 1:length(ex.args)
-        ex.args[i] = _latexify_exponentials(ex.args[i])
-    end
-    if length(ex.args) == 3 && ex.args[1] == :^
-        ex.args[3] = Expr(:braces, ex.args[3])
-    end
-    return ex
+function Base.show(io::IO, f::AbstractJuMPScalar)
+    return print(io, function_string(REPLMode, f))
 end
-#------------------------------------------------------------------------
-## _NonlinearConstraint
-#------------------------------------------------------------------------
-const NonlinearConstraintRef = ConstraintRef{Model,NonlinearConstraintIndex}
+
+function Base.show(io::IO, ::MIME"text/latex", f::AbstractJuMPScalar)
+    return print(io, _wrap_in_math_mode(function_string(IJuliaMode, f)))
+end
+
+function Base.show(io::IO, evaluator::NLPEvaluator)
+    _init_NLP(evaluator.model)
+    Base.print(io, "An NLPEvaluator with available features:")
+    for feat in MOI.features_available(evaluator)
+        print(io, "\n  * :", feat)
+    end
+    return
+end
+
+function Base.show(io::IO, ex::Union{NonlinearExpression,NonlinearParameter})
+    return Base.show(io, function_string(REPLMode, ex))
+end
+
+function Base.show(
+    io::IO,
+    ::MIME"text/latex",
+    ex::Union{NonlinearExpression,NonlinearParameter},
+)
+    return print(io, function_string(IJuliaMode, ex))
+end
 
 function Base.show(io::IO, c::NonlinearConstraintRef)
     return print(
@@ -862,75 +893,4 @@ function Base.show(io::IO, ::MIME"text/latex", c::NonlinearConstraintRef)
             nl_constraint_string(c.model, IJuliaMode, constraint),
         ),
     )
-end
-
-"""
-    nl_constraint_string(model::Model, mode, c::_NonlinearConstraint)
-
-Return a string representation of the nonlinear constraint `c` belonging to
-`model`, given the `print_mode`. `print_mode` should be `IJuliaMode` or
-`REPLMode`.
-"""
-function nl_constraint_string(model::Model, mode, c::_NonlinearConstraint)
-    s = _sense(c)
-    nl = nl_expr_string(model, mode, c.terms)
-    if s == :range
-        out_str =
-            "$(_string_round(c.lb)) " *
-            _math_symbol(mode, :leq) *
-            " $nl " *
-            _math_symbol(mode, :leq) *
-            " " *
-            _string_round(c.ub)
-    else
-        if s == :<=
-            rel = _math_symbol(mode, :leq)
-        elseif s == :>=
-            rel = _math_symbol(mode, :geq)
-        else
-            rel = _math_symbol(mode, :eq)
-        end
-        out_str = string(nl, " ", rel, " ", _string_round(_rhs(c)))
-    end
-    return out_str
-end
-
-#------------------------------------------------------------------------
-## Opaque nonlinear objects
-#------------------------------------------------------------------------
-
-function function_string(print_mode::Type{<:PrintMode}, p::NonlinearExpression)
-    model = p.model
-    s = nl_expr_string(model, print_mode, model.nlp_data.nlexpr[p.index])
-    return "subexpression[$(p.index)]: " * s
-end
-
-function function_string(::Type{<:PrintMode}, p::NonlinearParameter)
-    for (k, v) in object_dictionary(p.model)
-        if v == p
-            return "$k == $(value(p))"
-        end
-    end
-    return "parameter[$(p.index)] == $(value(p))"
-end
-
-function Base.show(io::IO, ex::Union{NonlinearExpression,NonlinearParameter})
-    return Base.show(io, function_string(REPLMode, ex))
-end
-
-function Base.show(
-    io::IO,
-    ::MIME"text/latex",
-    ex::Union{NonlinearExpression,NonlinearParameter},
-)
-    return print(io, function_string(IJuliaMode, ex))
-end
-
-function Base.show(io::IO, evaluator::NLPEvaluator)
-    _init_NLP(evaluator.model)
-    Base.print(io, "An NLPEvaluator with available features:")
-    for feat in MOI.features_available(evaluator)
-        print(io, "\n  * :", feat)
-    end
-    return
 end

--- a/src/print.jl
+++ b/src/print.jl
@@ -108,42 +108,11 @@ function _math_symbol(::Type{REPLMode}, name::Symbol)
         return Sys.iswindows() ? ">=" : "≥"
     elseif name == :eq
         return Sys.iswindows() ? "==" : "="
-    elseif name == :times
-        return "*"
     elseif name == :sq
         return "²"
-    elseif name == :ind_open
-        return "["
-    elseif name == :ind_close
-        return "]"
-    elseif name == :for_all
-        return Sys.iswindows() ? "for all" : "∀"
-    elseif name == :in
-        return Sys.iswindows() ? "in" : "∈"
-    elseif name == :open_set
-        return "{"
-    elseif name == :dots
-        return Sys.iswindows() ? ".." : "…"
-    elseif name == :close_set
-        return "}"
-    elseif name == :union
-        return Sys.iswindows() ? "or" : "∪"
-    elseif name == :infty
-        return Sys.iswindows() ? "Inf" : "∞"
-    elseif name == :open_rng
-        return "["
-    elseif name == :close_rng
-        return "]"
-    elseif name == :integer
-        return "integer"
-    elseif name == :succeq0
-        return " is semidefinite"
-    elseif name == :Vert
-        return Sys.iswindows() ? "||" : "‖"
-    elseif name == :sub2
-        return Sys.iswindows() ? "_2" : "₂"
     else
-        error("Internal error: Unrecognized symbol $name.")
+        @assert name == :in
+        return Sys.iswindows() ? "in" : "∈"
     end
 end
 
@@ -155,42 +124,11 @@ function _math_symbol(::Type{IJuliaMode}, name::Symbol)
         return "\\geq"
     elseif name == :eq
         return "="
-    elseif name == :times
-        return "\\times "
     elseif name == :sq
         return "^2"
-    elseif name == :ind_open
-        return "_{"
-    elseif name == :ind_close
-        return "}"
-    elseif name == :for_all
-        return "\\quad\\forall"
-    elseif name == :in
-        return "\\in"
-    elseif name == :open_set
-        return "\\{"
-    elseif name == :dots
-        return "\\dots"
-    elseif name == :close_set
-        return "\\}"
-    elseif name == :union
-        return "\\cup"
-    elseif name == :infty
-        return "\\infty"
-    elseif name == :open_rng
-        return "\\["
-    elseif name == :close_rng
-        return "\\]"
-    elseif name == :integer
-        return "\\in \\mathbb{Z}"
-    elseif name == :succeq0
-        return "\\succeq 0"
-    elseif name == :Vert
-        return "\\Vert"
-    elseif name == :sub2
-        return "_2"
     else
-        error("Internal error: Unrecognized symbol $name.")
+        @assert name == :in
+        return "\\in"
     end
 end
 
@@ -629,7 +567,8 @@ function function_string(mode, q::GenericQuadExpr)
         if x == y
             terms[2*elm] *= _math_symbol(mode, :sq)
         else
-            terms[2*elm] *= string(_math_symbol(mode, :times), y)
+            times = mode == IJuliaMode ? "\\times " : "*"
+            terms[2*elm] *= string(times, y)
         end
     end
     terms[1] = terms[1] == " - " ? "-" : ""
@@ -729,16 +668,13 @@ function in_set_string(print_mode, set::MOI.EqualTo)
     return string(_math_symbol(print_mode, :eq), " ", set.value)
 end
 
-function in_set_string(print_mode, set::MOI.Interval)
-    return string(
-        _math_symbol(print_mode, :in),
-        " ",
-        _math_symbol(print_mode, :open_rng),
-        set.lower,
-        ", ",
-        set.upper,
-        _math_symbol(print_mode, :close_rng),
-    )
+function in_set_string(::Type{IJuliaMode}, set::MOI.Interval)
+    return string("\\in \\[", set.lower, ", ", set.upper, "\\]")
+end
+
+function in_set_string(::Type{REPLMode}, set::MOI.Interval)
+    in = _math_symbol(REPLMode, :in)
+    return string("$in [", set.lower, ", ", set.upper, "]")
 end
 
 in_set_string(print_mode, ::MOI.ZeroOne) = "binary"

--- a/src/solution_summary.jl
+++ b/src/solution_summary.jl
@@ -3,6 +3,8 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import Printf
+
 struct _SolutionSummary
     verbose::Bool
     solver::String
@@ -154,7 +156,7 @@ function _show_work_counters_summary(io::IO, summary::_SolutionSummary)
     _print_if_not_missing(
         io,
         "  Solve time (sec)   : ",
-        @sprintf("%.5f", summary.solve_time),
+        Printf.@sprintf("%.5f", summary.solve_time),
     )
     _print_if_not_missing(
         io,

--- a/test/print.jl
+++ b/test/print.jl
@@ -199,19 +199,19 @@ end
         model = Model()
         @variable(model, x)
         expr = @NLexpression(model, x + 1)
-        io_test(REPLMode, expr, "\"subexpression[1]: x + 1.0\"")
+        io_test(REPLMode, expr, "subexpression[1]: x + 1.0")
     end
 
     @testset "Nonlinear parameters" begin
         model = Model()
         param = @NLparameter(model, value = 1.0)
-        io_test(REPLMode, param, "\"parameter[1] == 1.0\"")
+        io_test(REPLMode, param, "parameter[1] == 1.0")
     end
 
     @testset "Registered nonlinear parameters" begin
         model = Model()
         @NLparameter(model, param == 1.0)
-        io_test(REPLMode, param, "\"param == 1.0\"")
+        io_test(REPLMode, param, "param == 1.0")
     end
 
     @testset "NLPEvaluator" begin

--- a/test/print.jl
+++ b/test/print.jl
@@ -8,7 +8,7 @@
 # See https://github.com/jump-dev/JuMP.jl
 #############################################################################
 # test/print.jl
-# Testing $fa pretty-printing-related functionality
+# Testing for all pretty-printing-related functionality
 #############################################################################
 
 using JuMP
@@ -502,12 +502,7 @@ end
 function model_printing_test(ModelType::Type{<:JuMP.AbstractModel})
     @testset "Model" begin
         repl(s) = JuMP._math_symbol(REPLMode, s)
-        le, ge, eq, fa = repl(:leq), repl(:geq), repl(:eq), repl(:for_all)
-        inset, dots = repl(:in), repl(:dots)
-        infty, union = repl(:infty), repl(:union)
-        Vert, sub2 = repl(:Vert), repl(:sub2)
-        for_all = repl(:for_all)
-
+        le, ge, eq, inset = repl(:leq), repl(:geq), repl(:eq), repl(:in)
         #------------------------------------------------------------------
 
         model_1 = ModelType()
@@ -690,12 +685,7 @@ end
 function model_extension_printing_test(ModelType::Type{<:JuMP.AbstractModel})
     @testset "Model" begin
         repl(s) = JuMP._math_symbol(REPLMode, s)
-        le, ge, eq, fa = repl(:leq), repl(:geq), repl(:eq), repl(:for_all)
-        inset, dots = repl(:in), repl(:dots)
-        infty, union = repl(:infty), repl(:union)
-        Vert, sub2 = repl(:Vert), repl(:sub2)
-        for_all = repl(:for_all)
-
+        le, inset = repl(:leq), repl(:in)
         #------------------------------------------------------------------
 
         model_1 = ModelType()


### PR DESCRIPTION
This doesn't change any user-visible printing, it only refactors internal parts of functions and re-orders the file to a more logical order.

Part of #2814

*except for one trivial change in the subexpression nonlinear parameter printing to not print as a `String`.