### PR TITLE
Rename printing of anonymous JuMP variables

### DIFF
--- a/docs/src/manual/variables.md
+++ b/docs/src/manual/variables.md
@@ -217,15 +217,22 @@ As a work-around, JuMP provides *anonymous* variables. Create a scalar valued
 anonymous variable by omitting the name argument:
 ```jldoctest; setup=:(model=Model())
 julia> x = @variable(model)
-noname
+_[1]
 ```
+Anonymous variables get printed as an underscore followed by a unique index of
+the variable.
+
+!!! warning
+    The index of the variable may not correspond to the column of the variable
+    in the solver!
+
 Create a container of anonymous JuMP variables by dropping the name in front of
 the `[`:
 ```jldoctest; setup=:(model=Model())
 julia> y = @variable(model, [1:2])
 2-element Vector{VariableRef}:
- noname
- noname
+ _[1]
+ _[2]
 ```
 
 The `<=` and `>=` short-hand cannot be used to set bounds on scalar-valued
@@ -233,12 +240,13 @@ anonymous JuMP variables. Instead, use the `lower_bound` and `upper_bound`
 keywords:
 ```jldoctest; setup=:(model=Model())
 julia> x_lower = @variable(model, lower_bound = 1.0)
-noname
+_[1]
+
 julia> x_upper = @variable(model, upper_bound = 2.0)
-noname
+_[2]
 
 julia> x_interval = @variable(model, lower_bound = 3.0, upper_bound = 4.0)
-noname
+_[3]
 ```
 
 ## Variable names
@@ -346,7 +354,7 @@ Here's a summary of the differences:
  * Anonymous JuMP variables have the form `x = @variable(model)`. For anonymous
    variables:
    * The `String` name of the variable is set to `""`. When printed, this is
-     replaced with `"noname"`.
+     replaced with `"_[i]"` where `i` is the index of the variable.
    * You control the name of the Julia variable used as the binding.
    * No name is registered as a key in the model.
  * The `base_name` keyword can override the `String` name of the variable.

--- a/src/print.jl
+++ b/src/print.jl
@@ -436,6 +436,14 @@ function _nl_subexpression_string(print_mode, model::Model)
     return strings
 end
 
+anonymous_name(::Any, x::AbstractVariableRef) = "noname"
+
+anonymous_name(::Type{REPLMode}, x::VariableRef) = "_[$(index(x).value)]"
+
+function anonymous_name(::Type{IJuliaMode}, x::VariableRef)
+    return "\\_\\[$(index(x).value)\\]"
+end
+
 """
     function_string(
         print_mode::Type{<:JuMP.PrintMode},
@@ -448,7 +456,7 @@ Return a `String` representing the function `func` using print mode
 function function_string(::Type{REPLMode}, v::AbstractVariableRef)
     var_name = name(v)
     if isempty(var_name)
-        return "noname"
+        return anonymous_name(REPLMode, v)
     end
     return var_name
 end
@@ -456,7 +464,7 @@ end
 function function_string(::Type{IJuliaMode}, v::AbstractVariableRef)
     var_name = name(v)
     if isempty(var_name)
-        return "noname"
+        return anonymous_name(IJuliaMode, v)
     end
     # We need to escape latex math characters that appear in the name.
     # However, it's probably impractical to catch everything, so let's just

--- a/src/print.jl
+++ b/src/print.jl
@@ -441,7 +441,7 @@ anonymous_name(::Any, x::AbstractVariableRef) = "noname"
 anonymous_name(::Type{REPLMode}, x::VariableRef) = "_[$(index(x).value)]"
 
 function anonymous_name(::Type{IJuliaMode}, x::VariableRef)
-    return "\\_\\[$(index(x).value)\\]"
+    return "{\\_}_{$(index(x).value)}"
 end
 
 """

--- a/src/print.jl
+++ b/src/print.jl
@@ -436,7 +436,7 @@ function _nl_subexpression_string(print_mode, model::Model)
     return strings
 end
 
-anonymous_name(::Any, x::AbstractVariableRef) = "noname"
+anonymous_name(::Any, x::AbstractVariableRef) = "anon"
 
 anonymous_name(::Type{REPLMode}, x::VariableRef) = "_[$(index(x).value)]"
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -212,7 +212,7 @@ Returns the model to which `v` belongs.
 julia> model = Model();
 
 julia> x = @variable(model)
-noname
+_[1]
 
 julia> owner_model(x) === model
 true

--- a/test/print.jl
+++ b/test/print.jl
@@ -358,8 +358,13 @@ function printing_test(ModelType::Type{<:JuMP.AbstractModel})
 
         JuMP.set_name(x, "")
         @test JuMP.name(x) == ""
-        io_test(REPLMode, x, "noname")
-        io_test(IJuliaMode, x, "noname")
+        if x isa VariableRef
+            io_test(REPLMode, x, "_[1]")
+            io_test(IJuliaMode, x, "\\_\\[1\\]")
+        else
+            io_test(REPLMode, x, "noname")
+            io_test(IJuliaMode, x, "noname")
+        end
 
         @variable(m, z[1:2, 3:5])
         @test JuMP.name(z[1, 3]) == "z[1,3]"

--- a/test/print.jl
+++ b/test/print.jl
@@ -362,8 +362,8 @@ function printing_test(ModelType::Type{<:JuMP.AbstractModel})
             io_test(REPLMode, x, "_[1]")
             io_test(IJuliaMode, x, "{\\_}_{1}")
         else
-            io_test(REPLMode, x, "noname")
-            io_test(IJuliaMode, x, "noname")
+            io_test(REPLMode, x, "anon")
+            io_test(IJuliaMode, x, "anon")
         end
 
         @variable(m, z[1:2, 3:5])

--- a/test/print.jl
+++ b/test/print.jl
@@ -360,7 +360,7 @@ function printing_test(ModelType::Type{<:JuMP.AbstractModel})
         @test JuMP.name(x) == ""
         if x isa VariableRef
             io_test(REPLMode, x, "_[1]")
-            io_test(IJuliaMode, x, "\\_\\[1\\]")
+            io_test(IJuliaMode, x, "{\\_}_{1}")
         else
             io_test(REPLMode, x, "noname")
             io_test(IJuliaMode, x, "noname")


### PR DESCRIPTION
Part of #2814 

It's always annoyed me that you can't tell anonymous variables apart in printing:
```Julia
julia> model = Model();

julia> x = @variable(model, [1:4])
4-element Vector{VariableRef}:
 noname
 noname
 noname
 noname

julia> @objective(model, Min, sum(i * x[i] for i in 1:4))
noname + 2 noname + 3 noname + 4 noname
```

This PR changes things to:
```julia
julia> model = Model();

julia> x = @variable(model, [1:4])
4-element Vector{VariableRef}:
 _[1]
 _[2]
 _[3]
 _[4]

julia> @objective(model, Min, sum(i * x[i] for i in 1:4))
_[1] + 2 _[2] + 3 _[3] + 4 _[4]
```

It's an open question why the prefix should be:
 * `noname[3]`: this would be most similar to what we already have, and no one should name a variable `noname`?
 * `anon[3]`: relates to the fact it is anonymous. But requires people to know the abbreviation. someone might name a variable `anon`?
 * `_[3]`: the shortest. But requires people to be familiar with `_` as a placeholder for a variable.

