### PR TITLE
[docs] add section on custom artifacts

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -178,6 +178,7 @@ const _PAGES = [
     "Developer Docs" => [
         "Contributing" => "developers/contributing.md",
         "Extensions" => "developers/extensions.md",
+        "Custom binaries" => "developers/custom_solver_binaries.md",
         "Style Guide" => "developers/style.md",
         "Roadmap" => "developers/roadmap.md",
     ],

--- a/docs/src/developers/custom_solver_binaries.md
+++ b/docs/src/developers/custom_solver_binaries.md
@@ -1,0 +1,137 @@
+# How to use a custom binary
+
+Many solvers are not written in Julia, but instead in languages like C or C++.
+For many open-source solvers, we automatically install the appropriate binary
+when you run `Pkg.add("Solver")`. For example, `Pkg.add("ECOS")` will also
+install the ECOS binary.
+
+This page explains how this installation works, and how you can use a custom
+binary.
+
+## Background
+
+Each solver that JuMP supports is structured as a Julia package. For example,
+the interface for the [ECOS](https://github.com/embotech/ecos) solver is
+provided by the [ECOS.jl](https://github.com/jump-dev/ECOS.jl) package.
+
+!!! tip
+    This page uses the example of ECOS.jl because it is simple to compile. Other
+    solvers follow similar conventions. For example, the interface to the Clp
+    solver is provided by Clp.jl.
+
+The ECOS.jl package provides an interface between the C API of ECOS and
+MathOptInterface. However, it does not handle the installation of the solver
+binary; that is the job for a JLL package.
+
+A JLL is a Julia package that wraps a pre-compiled binary.
+The binaries are built using https://github.com/JuliaPackaging/Yggdrasil
+and hosted in the `JuliaBinaryWrappers` GitHub repository.
+
+For example, the build script for ECOS is located at:
+https://github.com/JuliaPackaging/Yggdrasil/blob/master/E/ECOS/build_tarballs.jl
+and the binaries are hosted at
+https://github.com/JuliaBinaryWrappers/ECOS_jll.jl
+
+JLL packages contain little code. Their only job is to `dlopen` a dynamic
+library, along with any dependencies.
+
+JLL packages manage their binary dependencies using [Julia's artifact system](https://pkgdocs.julialang.org/v1/artifacts/).
+Each JLL package has an `Artifacts.toml` file which describes where to find each
+binary artifact for each different platform that it might be installed on. Here
+is the [Artifacts.toml file for ECOS_jll.jl](https://github.com/JuliaBinaryWrappers/ECOS_jll.jl/blob/main/Artifacts.toml).
+
+The binaries installed by the JLL package should be sufficient for most users.
+In a rare case however, you may require a custom binary. The two main reasons to
+use a custom binary are:
+
+ * You want a binary with custom compilation settings (for example, debugging)
+ * You want a binary with a different set of dependencies that is available on
+   Yggdrasil (for example, a commerial solver like Gurobi or CPLEX).
+
+The following section explains how to replace the binaries provided by a JLL
+package with the custom ones you have compiled. As a reminder, we use ECOS as an
+example for simplicity, but the steps are the same for other solvers.
+
+## Using ECOS with a custom binary
+
+The first step is to find where Julia stores the binaries:
+```julia
+julia> using ECOS_jll
+
+julia> ECOS_jll.artifact_dir
+"/Users/oscar/.julia/artifacts/2addb75332eff5a1657b46bb6bf30d2410bc7ecf"
+```
+The name of the last folder is important and we will need it later.
+
+!!! tip
+    This path may be different on other machines.
+
+In order to use a custom installation of ECOS, we need to reproduce the
+structure of this directory. Here is what it contains:
+```julia
+julia> readdir(ECOS_jll.artifact_dir)
+4-element Vector{String}:
+ "include"
+ "lib"
+ "logs"
+ "share"
+
+julia> readdir(joinpath(ECOS_jll.artifact_dir, "lib"))
+1-element Vector{String}:
+ "libecos.dylib"
+```
+
+In most cases you need only reproduce the `include`, `lib`, and `bin`
+directories (if they exist). You can safely ignore any `logs` or `share`
+directories. Take careful note of what files each directory contains and what
+they are called.
+
+### Compile a custom version of the solver
+
+The next step is to compile a custom version of ECOS. Because ECOS is written in
+C with no dependencies, this is easy to do if you have a C compiler:
+```julia
+oscar@Oscars-MBP jll_example % git clone https://github.com/embotech/ecos.git
+[... lines omitted ...]
+oscar@Oscars-MBP jll_example % cd ecos
+oscar@Oscars-MBP ecos % make shared
+[... many lines omitted...]
+oscar@Oscars-MBP ecos % mkdir lib
+oscar@Oscars-MBP ecos % cp libecos.dylib lib
+```
+
+!!! warning
+    Compiling custom solver binaries is an advanced operation. Due to the
+    complexities of compiling various solvers, the JuMP community may be unable
+    to help you diagonse and fix compilation issues.
+
+After this compilation step, we now have a folder `/tmp/jll_example/ecos`
+that contains `lib` and `include` directories with the same files as `ECOS_jll`:
+```julia
+julia> readdir(joinpath("ecos", "lib"))
+1-element Vector{String}:
+ "libecos.dylib"
+```
+
+### Override the artifact location
+
+As a final step, we need to tell Julia to use our custom installation instead of
+the default. We can do this by making an over-ride file at
+`~/.julia/artifacts/Overrides.toml`.
+
+`Overrides.toml` has the following content:
+```julia
+# Override for ECOS_jll
+2addb75332eff5a1657b46bb6bf30d2410bc7ecf = "/tmp/jll_example/ecos"
+```
+Where `2addb75332eff5a1657b46bb6bf30d2410bc7ecf` is the folder from the original
+`ECOS_jll.artifact_dir` and `"/tmp/jll_example/ecos"` is the location of our new
+installation.
+
+If you restart Julia after creating the override file, you will see:
+```julia
+julia> using ECOS_jll
+
+julia> ECOS_jll.artifact_dir
+"/tmp/jll_example/ecos"
+```

--- a/docs/src/developers/custom_solver_binaries.md
+++ b/docs/src/developers/custom_solver_binaries.md
@@ -133,3 +133,65 @@ julia> ECOS_jll.artifact_dir
 "/tmp/jll_example/ecos"
 ```
 Now when we use ECOS it will use our custom binary.
+
+## Using Cbc with a custom binary
+
+As a second example, we demonstrate how to use
+[Cbc.jl](https://github.com/jump-dev/Cbc.jl) with a custom binary.
+
+First, let's check where `Cbc_jll` is installed:
+```julia
+julia> using Cbc_jll
+
+julia> Cbc_jll.artifact_dir
+"/Users/oscar/.julia/artifacts/e481bc81db5e229ba1f52b2b4bd57484204b1b06"
+
+julia> readdir(Cbc_jll.artifact_dir)
+5-element Vector{String}:
+ "bin"
+ "include"
+ "lib"
+ "logs"
+ "share"
+
+julia> readdir(joinpath(Cbc_jll.artifact_dir, "bin"))
+1-element Vector{String}:
+ "cbc"
+
+julia> readdir(joinpath(Cbc_jll.artifact_dir, "lib"))
+10-element Vector{String}:
+ "libCbc.3.10.5.dylib"
+ "libCbc.3.dylib"
+ "libCbc.dylib"
+ "libCbcSolver.3.10.5.dylib"
+ "libCbcSolver.3.dylib"
+ "libCbcSolver.dylib"
+ "libOsiCbc.3.10.5.dylib"
+ "libOsiCbc.3.dylib"
+ "libOsiCbc.dylib"
+ "pkgconfig"
+```
+
+Next, we need to compile Cbc. Cbc can be difficult to compile (it has a lot of
+dependencies), but for macOS users there is a homebrew recipe:
+```
+(base) oscar@Oscars-MBP jll_example % brew install cbc
+[ ... lines omitted ... ]
+(base) oscar@Oscars-MBP jll_example % brew list cbc
+/usr/local/Cellar/cbc/2.10.5/bin/cbc
+/usr/local/Cellar/cbc/2.10.5/include/cbc/ (76 files)
+/usr/local/Cellar/cbc/2.10.5/lib/libCbc.3.10.5.dylib
+/usr/local/Cellar/cbc/2.10.5/lib/libCbcSolver.3.10.5.dylib
+/usr/local/Cellar/cbc/2.10.5/lib/libOsiCbc.3.10.5.dylib
+/usr/local/Cellar/cbc/2.10.5/lib/pkgconfig/ (2 files)
+/usr/local/Cellar/cbc/2.10.5/lib/ (6 other files)
+/usr/local/Cellar/cbc/2.10.5/share/cbc/ (59 files)
+/usr/local/Cellar/cbc/2.10.5/share/coin/ (4 files)
+```
+
+To use the homebrew install as our custom binary we add the following to
+`~/.julia/artifacts/Overrides.toml`:
+```julia
+# Override for Cbc_jll
+e481bc81db5e229ba1f52b2b4bd57484204b1b06 = "/usr/local/Cellar/cbc/2.10.5"
+```

--- a/docs/src/developers/custom_solver_binaries.md
+++ b/docs/src/developers/custom_solver_binaries.md
@@ -24,13 +24,10 @@ MathOptInterface. However, it does not handle the installation of the solver
 binary; that is the job for a JLL package.
 
 A JLL is a Julia package that wraps a pre-compiled binary.
-The binaries are built using https://github.com/JuliaPackaging/Yggdrasil
-and hosted in the `JuliaBinaryWrappers` GitHub repository.
-
-For example, the build script for ECOS is located at:
-https://github.com/JuliaPackaging/Yggdrasil/blob/master/E/ECOS/build_tarballs.jl
-and the binaries are hosted at
-https://github.com/JuliaBinaryWrappers/ECOS_jll.jl
+The binaries are built using [Yggdrasil](https://github.com/JuliaPackaging/Yggdrasil)
+(for example, [ECOS](https://github.com/JuliaPackaging/Yggdrasil/blob/master/E/ECOS/build_tarballs.jl))
+and hosted in the [JuliaBinaryWrappers](https://github.com/JuliaBinaryWrappers)
+GitHub repository (for example, [ECOS_jll.jl](https://github.com/JuliaBinaryWrappers/ECOS_jll.jl)).
 
 JLL packages contain little code. Their only job is to `dlopen` a dynamic
 library, along with any dependencies.
@@ -61,7 +58,7 @@ julia> using ECOS_jll
 julia> ECOS_jll.artifact_dir
 "/Users/oscar/.julia/artifacts/2addb75332eff5a1657b46bb6bf30d2410bc7ecf"
 ```
-The name of the last folder is important and we will need it later.
+The name of the last folder is important, and we will need it later.
 
 !!! tip
     This path may be different on other machines.
@@ -102,8 +99,8 @@ oscar@Oscars-MBP ecos % cp libecos.dylib lib
 
 !!! warning
     Compiling custom solver binaries is an advanced operation. Due to the
-    complexities of compiling various solvers, the JuMP community may be unable
-    to help you diagonse and fix compilation issues.
+    complexities of compiling various solvers, the JuMP community is unable to
+    help you diagnose and fix compilation issues.
 
 After this compilation step, we now have a folder `/tmp/jll_example/ecos`
 that contains `lib` and `include` directories with the same files as `ECOS_jll`:
@@ -126,7 +123,7 @@ the default. We can do this by making an over-ride file at
 ```
 Where `2addb75332eff5a1657b46bb6bf30d2410bc7ecf` is the folder from the original
 `ECOS_jll.artifact_dir` and `"/tmp/jll_example/ecos"` is the location of our new
-installation.
+installation. Replace these as appropriate for your system.
 
 If you restart Julia after creating the override file, you will see:
 ```julia
@@ -135,3 +132,4 @@ julia> using ECOS_jll
 julia> ECOS_jll.artifact_dir
 "/tmp/jll_example/ecos"
 ```
+Now when we use ECOS it will use our custom binary.


### PR DESCRIPTION
Now that Julia 1.6 is the new LTS, we can drop 1.0 support in the solvers. That also means we can drop the need to have solvers load libraries from an environment variable. 

So no more instructions like this https://github.com/jump-dev/GLPK.jl#custom-installation and hacks like https://github.com/jump-dev/GLPK.jl/blob/5982ae9289bd4373f843b7f08cbfd8861df83914/src/GLPK.jl#L3-L13.

Instead, we can collate instructions and point people to one central set of documentation for overriding artifacts.

Preview: https://jump.dev/JuMP.jl/previews/PR2823/developers/custom_solver_binaries/