### PR TITLE
[Containers] disallow CartesianIndex as a key for DenseAxisArray

### DIFF
--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -159,7 +159,7 @@ function _abstract_vector(x::AbstractVector)
     return x
 end
 
-_abstract_vector(x) = _abstract_vector([a for a in x])
+_abstract_vector(x) = _abstract_vector(vec([a for a in x]))
 
 function _abstract_vector(x::Number)
     @warn(

--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -148,18 +148,17 @@ function Base.get(
     return get(x.data, key[1] => key[2], default)
 end
 
-function _abstract_vector(x::AbstractVector)
-    if eltype(x) <: CartesianIndex
-        error(
-            "Unsupported index type `CartesianIndex` in axis: $x. Cartesian " *
-            "indices are restricted for indexing into and iterating over " *
-            "multidimensional arrays.",
-        )
-    end
-    return x
+_abstract_vector(x::AbstractVector) = x
+
+function _abstract_vector(x::AbstractVector{<:CartesianIndex})
+    return error(
+        "Unsupported index type `CartesianIndex` in axis: $x. Cartesian " *
+        "indices are restricted for indexing into and iterating over " *
+        "multidimensional arrays.",
+    )
 end
 
-_abstract_vector(x) = _abstract_vector(vec([a for a in x]))
+_abstract_vector(x) = _abstract_vector([a for a in x])
 
 function _abstract_vector(x::Number)
     @warn(

--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -160,6 +160,8 @@ end
 
 _abstract_vector(x) = _abstract_vector([a for a in x])
 
+_abstract_vector(x::AbstractArray) = vec(x)
+
 function _abstract_vector(x::Number)
     @warn(
         "Axis contains one element: $x. If intended, you can safely " *

--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -148,9 +148,18 @@ function Base.get(
     return get(x.data, key[1] => key[2], default)
 end
 
-_abstract_vector(x::AbstractVector) = x
+function _abstract_vector(x::AbstractVector)
+    if eltype(x) <: CartesianIndex
+        error(
+            "Unsupported index type `CartesianIndex` in axis: $x. Cartesian " *
+            "indices are restricted for indexing into and iterating over " *
+            "multidimensional arrays.",
+        )
+    end
+    return x
+end
 
-_abstract_vector(x) = [a for a in x]
+_abstract_vector(x) = _abstract_vector([a for a in x])
 
 function _abstract_vector(x::Number)
     @warn(
@@ -158,7 +167,7 @@ function _abstract_vector(x::Number)
         "ignore this warning. To explicitly pass the axis with one " *
         "element, pass `[$x]` instead of `$x`.",
     )
-    return [x]
+    return _abstract_vector([x])
 end
 
 """

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -358,9 +358,6 @@ And data, a 0-dimensional $(Array{Int,0}):
             "indices are restricted for indexing into and iterating over " *
             "multidimensional arrays.",
         )
-        @test_throws(
-            err,
-            DenseAxisArray([1.1 2.2], S),
-        )
+        @test_throws(err, DenseAxisArray([1.1, 2.2], S))
     end
 end

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -360,4 +360,12 @@ And data, a 0-dimensional $(Array{Int,0}):
         )
         @test_throws(err, DenseAxisArray([1.1, 2.2], S))
     end
+
+    @testset "Matrix indices" begin
+        sources = ["A", "B", "C"]
+        sinks = ["D", "E"]
+        S = [(source, sink) for source in sources, sink in sinks]
+        x = DenseAxisArray(1:6, S)
+        @test size(x) == (6,)
+    end
 end

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -350,4 +350,17 @@ And data, a 0-dimensional $(Array{Int,0}):
         y = @test_logs DenseAxisArray([1.1 2.2], [1], 1:2)
         @test y[1, 2] == 2.2
     end
+
+    @testset "CartesianIndex error" begin
+        S = CartesianIndex.([2, 4])
+        err = ErrorException(
+            "Unsupported index type `CartesianIndex` in axis: $S. Cartesian " *
+            "indices are restricted for indexing into and iterating over " *
+            "multidimensional arrays.",
+        )
+        @test_throws(
+            err,
+            DenseAxisArray([1.1 2.2], S),
+        )
+    end
 end


### PR DESCRIPTION
Technically breaking, but it has buggy behavior at present, so this is a bug-fix. 

We don't want cartesian indices as indices. They're not intended for that purpose. The original poster on stack overflow should use a different approach: https://stackoverflow.com/questions/70284721/julia-jump-how-to-use-variable-with-cartesianindex/70296103

Closes #2825

