### PR TITLE
Create tsp_lazy_constraints

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -147,6 +147,7 @@ const _PAGES = [
             "tutorials/algorithms/benders_decomposition.md",
             "tutorials/algorithms/benders_lazy_constraints.md",
             "tutorials/algorithms/cutting_stock_column_generation.md",
+            "tutorials/algorithms/tsp_lazy.md",
         ],
         "Applications" => ["tutorials/applications/power_systems.md"],
     ],

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -147,7 +147,7 @@ const _PAGES = [
             "tutorials/algorithms/benders_decomposition.md",
             "tutorials/algorithms/benders_lazy_constraints.md",
             "tutorials/algorithms/cutting_stock_column_generation.md",
-            "tutorials/algorithms/tsp_lazy.md",
+            "tutorials/algorithms/tsp_lazy_constraints.md",
         ],
         "Applications" => ["tutorials/applications/power_systems.md"],
     ],

--- a/docs/src/tutorials/algorithms/tsp_lazy_constraints
+++ b/docs/src/tutorials/algorithms/tsp_lazy_constraints
@@ -30,7 +30,7 @@
 
 
 using JuMP
-using Combinatorics
+import Combinatorics
 # using Gurobi
 using GLPK
 import LinearAlgebra

--- a/docs/src/tutorials/algorithms/tsp_lazy_constraints
+++ b/docs/src/tutorials/algorithms/tsp_lazy_constraints
@@ -32,7 +32,7 @@
 using JuMP
 import Combinatorics
 # using Gurobi
-using GLPK
+import GLPK
 import LinearAlgebra
 import Random
 

--- a/docs/src/tutorials/algorithms/tsp_lazy_constraints
+++ b/docs/src/tutorials/algorithms/tsp_lazy_constraints
@@ -259,7 +259,7 @@ optimize!(tsp)
 # As a quick sanity check, we might visualize the optimal tour to verify that no subtour is present.
 
 
-using Plots
+import Plots
 
 plot()
 for i = 1:n

--- a/docs/src/tutorials/algorithms/tsp_lazy_constraints
+++ b/docs/src/tutorials/algorithms/tsp_lazy_constraints
@@ -1,0 +1,286 @@
+
+# Copyright (c) 2019 Arpit Bhatia and contributors                               #src
+#                                                                                #src
+# Permission is hereby granted, free of charge, to any person obtaining a copy   #src
+# of this software and associated documentation files (the "Software"), to deal  #src
+# in the Software without restriction, including without limitation the rights   #src
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      #src
+# copies of the Software, and to permit persons to whom the Software is          #src
+# furnished to do so, subject to the following conditions:                       #src
+#                                                                                #src
+# The above copyright notice and this permission notice shall be included in all #src
+# copies or substantial portions of the Software.                                #src
+#                                                                                #src
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     #src
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       #src
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    #src
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         #src
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  #src
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  #src
+# SOFTWARE.     
+
+
+# ## [Traveling Salesperson Problem (via callbacks)](@id tsp_lazy)
+# 
+# **Originally Contributed by**: Daniel Schermer
+# 
+# This notebook describes how to implement the Traveling Salesperson Problem in JuMP using lazy constraints that dynamically separate subtours.
+# To be more precise, we use lazy constraints to cut off feasible subtours only when necessary and not before needed.
+# The model has been tested with Julia Version 1.7.0, JuMP.jl Version 0.22.1, Gurobi.jl Version 0.10.1 (Solver Version 9.5), and GLPK Version 0.15.2.
+
+
+using JuMP
+using Combinatorics
+# using Gurobi
+using GLPK
+import LinearAlgebra
+import Random
+
+
+# # Mathematical Formulation
+# 
+# Assume that we are given a complete graph $\mathcal{G}(V,E)$ where $V$ is the set of vertices and $E$ is the set of edges. 
+# For each pair of vertices $i, j \in V, i \neq j$ the edge $(i,j) \in E$ is associated with a distance (or weight) $d_{ij} \in \mathbb{R}^+$.
+# For the purpose of this Notebook, we assume the problem to be symmetric, i.e., $d_{ij} = d_{ji} \, \forall i,j \in V$.
+# In the Traveling Salesperson Problem, we are tasked with finding a tour with minimal length that visits every vertex exactly once and then returns to the point of origin, i.e., a hamiltonian cycle with minimal weight.
+# 
+# In order to model the problem, we introduce a binary variable $x_{ij} \in \{0,1\} \; \forall i, j \in V$ that indicates if item edge $(i,j)$ is part of the tour or not.
+# Using these variables, the Traveling Salesperson Problem can be modeled through the following Integer Linear Programming Formulation:
+# 
+# ## Objective Function
+# The objective consists in minimizing the weighted edges (due to the assumed symmetry, the second sum only contains $j>i$).
+# $$\text{min } \sum_{i \in V}  \sum_{j \in V, j > i} d_{ij} x_{ij}$$
+# 
+# ## Constraints
+# For the formulation of our problem, we need four classes of constraints which we will discuss in what follows.
+# 
+# ### Symmetry
+# Due to the presumed symmetry, the following constraints must hold.
+# 
+# $$ x_{ij} = x_{ji} \quad \forall (i,j) \in V $$
+# 
+# ### Degree Constraints
+# For each vertex $i$, exactly two edges must be selected that connect it to other vertices $j$.
+# $$ \sum_{i,j \in V} x_{ij} = 2 \quad \forall i \in V $$
+# 
+# ### Loops
+# We do not permit loops.
+# $$ x_{ii} = 0 \quad \forall i \in V $$
+
+
+Random.seed!(1)
+
+# Number of vertices
+n = 25
+
+# The vertices are assumed to be randomly distributed in the Euclidean space
+X = 100 * rand(n)
+Y = 100 * rand(n)
+
+
+# Thus, the distance (weight) of each edge is defined as follows
+d = zeros(n, n)
+for i = 1:n
+    for j = 1:n
+        d[i, j] = LinearAlgebra.norm([X[i] - X[j], Y[i] - Y[j]], 2)
+    end
+end
+
+# Initialize the model object
+
+# Gurobi
+# tsp = Model(Gurobi.Optimizer)
+
+# GLPK
+tsp = Model(GLPK.Optimizer)
+
+# Initialize the binary decision variables
+@variable(tsp, x[i in 1:n, j in 1:n], Bin)
+
+@constraint(tsp, symmetry[i in 1:n, j in 1:n], x[i, j] == x[j, i]);
+
+@constraint(tsp, two_degree[i in 1:n], sum(x[i, j] for j = 1:n) == 2);
+
+@constraint(tsp, no_loop[i in 1:n], x[i, i] == 0);
+
+@objective(tsp, Min, sum(x[i, j] * d[i, j] for i = 1:n for j = 1:n))
+
+
+# ## Subtour Elimination
+# A major difficulty of the Traveling Salesperson Problem arises from the fact that we need to prevent *subtours*, i.e., several distinct Hamiltonian paths existing on distinct subgraphs of the graph $G$.
+# Note that the previous parts of the model (listed above) *do not* guarantee that the solution will be free of subtours.
+# 
+# To this end, by $S$ we label a subset of vertices. Then, for each proper subset $S \subset V$, the following constraints guarantee that no subtour may occur (due to the right-hand side).
+# 
+# $$ \sum_{i \in S} \sum_{j \in S, j \neq i} x_{ij} \leq \vert S \vert - 1 \quad \forall S \subset V $$
+# 
+# These constraints have the disadvantage that we require exponentially many of them as $\vert V \vert$ increases.
+# Therefore, we will add these constraints as **lazy constraints** , i.e., not before needed and only when necessary.
+# 
+# We do this through the callback **subtour_elimination()** below, which is only run whenever we encounter an integer-feasible solution.
+# Based on the edges that are currently in the solution, we identify the shortest cycle through the function **subtour()**.
+# Once the subtour has been identified, the constraint above is added to the model.
+
+
+function subtour_elimination(cb_data)
+
+    # We only checkfor subtours when we encounter integer-feasible solutions
+
+    # Gurobi
+    #if cb_where == GRB_CB_MIPSOL #
+
+    # GPLK
+    status = callback_node_status(cb_data, tsp)
+    if status == MOI.CALLBACK_NODE_STATUS_INTEGER
+
+        # Load the callback data at the current node
+
+        # Gurobi
+        #Gurobi.load_callback_variable_primal(cb_data, cb_where)
+        # x_val = callback_value(cb_data, x)        
+
+        # GLPK
+        x_val = zeros(n, n)
+        for i = 1:n
+            for j = 1:n
+                x_val[i, j] = callback_value(cb_data, x[i, j])
+            end
+        end
+
+
+
+        # Write the current edges in a tuple list
+        edges = Tuple{Int,Int}[]
+        for i = 1:n
+            for j = 1:n
+                if (x_val[i, j] > 0.5)
+                    push!(edges, (i, j))
+                end
+            end
+        end
+
+        # Get the shortest cycle from the list of edges
+        cycle = subtour(edges)
+
+        # A subtour contains at least 2 locations and at most (n-1)
+        if length(cycle) > 1 && length(cycle) < n
+
+            subtour_edges = subtour_edges_helper(cycle)
+            con = @build_constraint(sum(x[c[1], c[2]] for c in subtour_edges) <= length(cycle) - 1)
+            MOI.submit(tsp, MOI.LazyConstraint(cb_data), con)
+
+        end
+
+
+    end
+end
+
+# Helper for constraint building
+function subtour_edges_helper(cycle)
+
+    subtour_edges = []
+    for i = 1:length(cycle)-1
+        push!(subtour_edges, [cycle[i], cycle[i+1]])
+    end
+    push!(subtour_edges, [cycle[length(cycle)], cycle[1]])
+    return subtour_edges
+end
+
+
+# Given a list of edges, the function **subtour()**, is programmed to identify the shortest subtour as follows.
+# Note that the resulting cycle is passed back to **subtour_elimination()**.
+
+
+function subtour(edges)
+    # A list of all unvisited vertices
+    unvisited = Set(collect(1:n))
+
+    # Placeholder for the shortest subtour
+    cycle = collect(1:n)
+
+    while !(isempty(unvisited))
+        thiscycle = []
+        neighbors = unvisited
+        while !(isempty(neighbors))
+            # Get the first item         
+            current = pop!(neighbors)
+
+            # Add it to the current cycle and remove it from unvisited
+            push!(thiscycle, current)
+
+            # If we are in the first iteration of the inner while loop,
+            # then the previous pop! already removed `current'
+            if length(thiscycle) > 1
+                pop!(unvisited, current)
+            end
+
+            # Get the index of all edges to which the current node is connected
+            index = findall(edges -> edges[1] == current, edges)
+
+            # Based on the index, add the neighbors
+            neighbors = []
+            for i in index
+                append!(neighbors, edges[i][2])
+            end
+
+            # Only consider neighbors that have not yet been visited
+            neighbors = intersect(neighbors, unvisited)
+
+        end
+        # We always store the shortest cycle as subtour
+        if length(thiscycle) < length(cycle)
+            cycle = thiscycle
+        end
+    end
+    return cycle
+end
+
+
+# All that is left to do is to run the model.
+# To do this, we need to make sure that **LazyConstraints** are enabled and that the proper **Callback** is passed.
+
+
+# Lazy constraints need to be set; otherwise, subtours might exist.
+
+# Gurobi
+#MOI.set(tsp, MOI.RawOptimizerAttribute("LazyConstraints"), 1)
+#MOI.set(tsp, Gurobi.CallbackFunction(), subtour_elimination)
+
+# GPLK - when using GPLK in conjunction with callbacks, the simple rounding heuristic needs to be turned off.
+# Otherwise, the final solution will be infeasible, because the lazy constraint callback is not involved.
+# See this discussion: https://discourse.julialang.org/t/solution-foun-by-heuristic-glpk/38772/7
+MOI.set(tsp, MOI.LazyConstraintCallback(), subtour_elimination)
+set_optimizer_attribute(tsp, "msg_lev", GLPK.GLP_MSG_ON)
+set_optimizer_attribute(tsp, "sr_heur", GLPK.GLP_OFF)
+
+optimize!(tsp)
+
+
+# As a quick sanity check, we might visualize the optimal tour to verify that no subtour is present.
+
+
+using Plots
+
+plot()
+for i = 1:n
+    for j = i:n
+        if (value.(x[i, j]) > 0.8)
+            plot!([X[i], X[j]], [Y[i], Y[j]], legend = false, linecolor = :black)
+        end
+    end
+end
+
+plot!()
+
+
+# # References
+# 
+# The mathematical formulation was inspired by the following reference.
+# 
+# ```@raw html
+# <a id='c1'></a>
+# ```
+# 
+# 1. Gurobi Optimization, LLC. Gurobi Optimizer Reference Manual. (2021).
+
+

--- a/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
+++ b/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
@@ -23,7 +23,7 @@
 # 
 # **Originally Contributed by**: Daniel Schermer
 # 
-# This notebook describes how to implement the Traveling Salesperson Problem in JuMP using lazy constraints that dynamically separate subtours.
+# This notebook describes how to implement the Traveling Salesperson Problem in JuMP using solver-independent lazy constraints that dynamically separate subtours.
 # To be more precise, we use lazy constraints to cut off infeasible subtours only when necessary and not before needed.
 
 using JuMP
@@ -37,31 +37,37 @@ import Plots
 # Assume that we are given a complete graph $\mathcal{G}(V,E)$ where $V$ is the set of vertices (or cities) and $E$ is the set of edges (or roads). 
 # For each pair of vertices $i, j \in V, i \neq j$ the edge $(i,j) \in E$ is associated with a weight (or distance) $d_{ij} \in \mathbb{R}^+$.
 # For this Notebook, we assume the problem to be symmetric, i.e., $d_{ij} = d_{ji} \, \forall i,j \in V$.
-#
+
 # In the Traveling Salesperson Problem, we are tasked with finding a tour with minimal length that visits every vertex exactly once and then returns to the point of origin, i.e., a *hamiltonian cycle* with minimal weight.
 # 
 # In order to model the problem, we introduce a binary variable $x_{ij} \in \{0,1\} \; \forall i, j \in V$ that indicates if edge $(i,j)$ is part of the tour or not.
 # Using these variables, the Traveling Salesperson Problem can be modeled through the following Integer Linear Programming Formulation.
 # 
 # ## [Objective Function](@id tsp_objective)
-# The objective consists in minimizing the weighted edges (due to the assumed symmetry, the second sum only contains $j>i$).
+# The objective consists in minimizing the weighted edges (due to the assumed symmetry, the second sum only contains $i<j$).
 #
 # ```math
-# \text{min } \sum_{i \in V}  \sum_{j \in V, j > i} d_{ij} x_{ij}
+# \text{min } \sum_{i \in V}  \sum_{j \in V, i < j} d_{ij} x_{ij}
 # ```
-# 
+#
+# Note that it is also psosible to use the following objective function instead.
+#
+# ```math
+# \text{min } \sum_{i \in V}  \sum_{j \in V} \dfrac{d_{ij} x_{ij}}{2}
+# ```
+#
 # ## [Constraints](@id tsp_constraints)
 # For the formulation of our problem, we need four classes of constraints which we will discuss in what follows.
 # Due to the presumed symmetry, the following constraints must hold.
 #
 # ```math
-# x_{ij} = x_{ji} \quad \forall (i,j) \in V
+# x_{ij} = x_{ji} \quad \forall i,j \in V
 # ```
 #
 # For each vertex $i$, exactly two edges must be selected that connect it to other vertices $j$ in the graph $G$.
 #
 # ```math
-# \sum_{i,j \in V} x_{ij} = 2 \quad \forall i \in V
+# \sum_{j \in V} x_{ij} = 2 \quad \forall i \in V
 # ```
 # 
 # We do not permit loops to occur.
@@ -75,7 +81,7 @@ import Plots
 # thus, the weight (distance) of each edge is defined as follows.
 
 Random.seed!(1)
-n = 25
+n = 75
 X = 100 * rand(n)
 Y = 100 * rand(n)
 d = zeros(n, n)
@@ -89,13 +95,20 @@ end
 # For the JuMP model, we first initialize the model object.
 # Then, we create the the binary decision variables and add the objective function and constraints (as introduced above).
 
-tsp = Model(GLPK.Optimizer)
+# !!! warning
+#     When using `GLPK` in conjunction with callbacks, the simple rounding heuristic (`sr_heur`) needs to be turned *off*.
+#     Otherwise, the final solution will be infeasible, because the lazy constraint callback is not involved when a new incumbent is identified through the rounding heuristic.
+#     For more details, refer to: [https://discourse.julialang.org/t/solution-foun-by-heuristic-glpk/38772](https://discourse.julialang.org/t/solution-foun-by-heuristic-glpk/38772).
 
-@variable(tsp, x[i in 1:n, j in 1:n], Bin)
+tsp = Model(GLPK.Optimizer);
+set_optimizer_attribute(tsp, "sr_heur", GLPK.GLP_OFF)
+## set_optimizer_attribute(tsp, "msg_lev", GLPK.GLP_MSG_ON)
 
-@objective(tsp, Min, sum(x[i, j] * d[i, j] for i in 1:n for j in 1:n))
+@variable(tsp, x[i in 1:n, j in 1:n], Bin);
 
-@constraint(tsp, symmetry[i in 1:n, j in 1:n], x[i, j] == x[j, i]);
+@objective(tsp, Min, sum(x[i, j] * d[i, j] / 2 for i in 1:n for j in 1:n));
+
+@constraint(tsp, symmetry[i in 1:n, j in i:n, i!=j], x[i, j] == x[j, i]);
 
 @constraint(tsp, two_degree[i in 1:n], sum(x[i, j] for j in 1:n) == 2);
 
@@ -104,67 +117,17 @@ tsp = Model(GLPK.Optimizer)
 # ## [Subtour Elimination](@id tsp_sec)
 # A major difficulty of the Traveling Salesperson Problem arises from the fact that we need to prevent *subtours*, i.e., several distinct Hamiltonian cycles existing on subgraphs of $G$.
 # Note that the previous parts of the model (listed above) *do not* guarantee that the solution will be free of subtours.
-# 
-# To this end, by $S$ we label a subset of vertices. Then, for each proper subset $S \subset V$, the following constraints guarantee that no subtour may occur.
+# To this end, by $S$ we label a subset of vertices.
+# Then, for each proper subset $S \subset V$, the following constraints guarantee that no subtour may occur.
 #
 # ```math
-# \sum_{i \in S} \sum_{j \in S, j \neq i} x_{ij} \leq \vert S \vert - 1 \quad \forall S \subset V
+# \sum_{i \in S} \sum_{j \in S, i < j} x_{ij} \leq \vert S \vert - 1 \quad \forall S \subset V
 # ```
+# These constraints have the disadvantage that we would require exponentially many of them as $\vert V \vert$  increases. 
+# Therefore, we will add these constraints not before needed and only when necessary.
 #
-# In general, we would require an exponential number of these subtour eliminations constraints as $\vert V \vert$ increases.
-# Therefore, in this model, we will add these constraints as **lazy constraints**, i.e., not before needed and only when necessary.
-# 
-# We do this through the callback `subtour_elimination()` below, which is only run whenever we encounter an integer-feasible solution.
-# Based on the edges that are currently in the solution, we identify the shortest cycle through the function `subtour()`.
-# Once the subtour has been identified, a corresponding subtour elimination constraint is added to the model.
-#
-# Note that, in principle, it would also be feasible to add all subtours (instead of just the shortest one) to the model.
-# However, preventing just the shortest cycle is often sufficient for breaking other subtours and will keep the model size smaller.
-
-function subtour_elimination(cb_data)
-    ## We only checkfor subtours when we encounter integer-feasible solutions
-    status = callback_node_status(cb_data, tsp)
-    if status == MOI.CALLBACK_NODE_STATUS_INTEGER
-
-        ## Load the callback data at the current node  
-        x_val = callback_value.(Ref(cb_data), x)
-
-        ## Write the current edges in a tuple list
-        edges = Tuple{Int,Int}[]
-        for i in 1:n
-            for j in 1:n
-                if (x_val[i, j] > 0.5)
-                    push!(edges, (i, j))
-                end
-            end
-        end
-
-        ## Get the shortest cycle from the list of edges
-        cycle = subtour(edges)
-
-        ## A subtour contains at least 2 locations and at most (n-1)
-        if length(cycle) > 1 && length(cycle) < n
-            subtour_edges = subtour_edges_helper(cycle)
-            con = @build_constraint(
-                sum(x[e[1], e[2]] for e in subtour_edges) <= length(cycle) - 1
-            )
-            MOI.submit(tsp, MOI.LazyConstraint(cb_data), con)
-        end
-    end
-end
-
-# This helper function is used for constraint building above.
-function subtour_edges_helper(cycle)
-    subtour_edges = []
-    for i in 1:length(cycle)-1
-        push!(subtour_edges, [cycle[i], cycle[i+1]])
-    end
-    push!(subtour_edges, [cycle[length(cycle)], cycle[1]])
-    return subtour_edges
-end
-
-# Given a list of edges, the function `subtour()`, is programmed to identify the shortest subtour as follows.
-# Note that the resulting cycle is passed back to `subtour_elimination()`.
+# To search for violated constraints, based on the edges that are currently in the solution (i.e., those that have value $x_{ij} = 1$), we identify the shortest cycle through the function `subtour()`.
+# Whenever a subtour has been identified, a constraint corresponding to the form above can be added to the model.
 
 function subtour(edges)
     ## A list of all unvisited vertices
@@ -209,35 +172,146 @@ function subtour(edges)
     return cycle
 end
 
-# All that is left to do is to run the model.
-# To do this, we need to make sure that **LazyConstraints** are enabled and that the proper **Callback** is passed.
-# It is easy to verify that the final solution consists of several distinct subtours, when commenting the following line.
+# Let us declare a helper function `selected_edges()` that will be repeatedly used in what follows.
 
-MOI.set(tsp, MOI.LazyConstraintCallback(), subtour_elimination)
+function selected_edges(x)
+    edges = Tuple{Int,Int}[]
+    for i in 1:n
+        for j in 1:n
+            if (value(x[i, j]) > 0.5)
+                push!(edges, (i, j))
+            end
+        end
+    end
+    return edges
+end
 
-# **CAREFUL**: When using GPLK in conjunction with callbacks, the simple rounding heuristic (`sr_heur`) needs to be turned *off*.
-# Otherwise, the final solution will be infeasible, because the lazy constraint callback is not involved.
-#
-# For more details, refer to: [https://discourse.julialang.org/t/solution-foun-by-heuristic-glpk/38772](https://discourse.julialang.org/t/solution-foun-by-heuristic-glpk/38772).
-set_optimizer_attribute(tsp, "sr_heur", GLPK.GLP_OFF)
-set_optimizer_attribute(tsp, "msg_lev", GLPK.GLP_MSG_ON)
+# An iterative way of eliminating subtours is the following.
+# However, it is reasonable to assume that this is not the most efficient way: Whenever a new subtour elimination constraint is added to the model, the optimization has to start from the very beginning.
+# That way, the solver will repeatedly discard useful information encountered during previous solves (e.g., all cuts, the incumbent solution, or lower bounds).
+
+# !!! info
+#     Note that, in principle, it would also be feasible to add all subtours (instead of just the shortest one) to the model.
+#     However, preventing just the shortest cycle is often sufficient for breaking other subtours and will keep the model size smaller.
 
 optimize!(tsp)
+time_iterated = solve_time(tsp);
+cycle = subtour(selected_edges(x))
+
+## Check for cycles, add the subtour elimination constraint,
+## and optimize until no more cycles exist
+while length(cycle) > 1 && length(cycle) < n
+    S = collect(
+        Iterators.filter(t -> t[1] < t[2], Iterators.product(cycle, cycle)),
+    )
+    @constraint(tsp, sum(x[t[1], t[2]] for t in S) <= length(cycle) - 1)
+    optimize!(tsp)
+    global time_iterated += solve_time(tsp)
+    global cycle = subtour(selected_edges(x))
+end
+
+info = (objective_value(tsp), time_iterated)
+@show(info)
+
+# A more sophisticated approach makes use of **lazy constraints**.
+# To be more precise, we do this through the callback `subtour_elimination()` below, which is only run whenever we encounter a new integer-feasible solution.
+# !!! warning
+#     We use `seen` as a `Dict()` to store if we have seen a particular lazy constraint (determined by a cycle) before.
+#     For performance reasons, when using `GLPK`, we must check if we have previously added a lazy constraint before, as `GLPK` does not check this before adding the constraint to the model.
+#     If we were to ignore this; identical constraints might be added repeatedly, causing performance to drop drastically.
+
+seen = Dict()
+
+function subtour_elimination(cb_data)
+    ## We only checkfor subtours when we encounter integer-feasible solutions
+    status = callback_node_status(cb_data, tsp)
+    if status == MOI.CALLBACK_NODE_STATUS_INTEGER
+
+        ## Load the callback data at the current node  
+        x_val = callback_value.(Ref(cb_data), x)
+
+        ## Write the current edges in a tuple list and identify the shortest  cycle
+        edges = selected_edges(x_val)
+        cycle = subtour(edges)
+        h = hash(sort(cycle))
+
+        if !(h in keys(seen))
+            ## A subtour contains at least 2 locations and at most (n-1)
+            if length(cycle) > 1 && length(cycle) < n
+                S = collect(
+                    Iterators.filter(
+                        t -> t[1] < t[2],
+                        Iterators.product(cycle, cycle),
+                    ),
+                )
+                con = @build_constraint(
+                    sum(x[t[1], t[2]] for t in S) <= length(cycle) - 1
+                )
+
+                MOI.submit(tsp, MOI.LazyConstraint(cb_data), con)
+                seen[h] = con
+            end
+        end
+    end
+end
+
+# For solving the model with lazy constraints, we need to make sure that `LazyConstraints` are enabled and that the proper `CallbackFunction()` passed.
+# Before we do this, we are going to quickly rebuild the model, such that previously added subtour elimination constraints are removed.
+
+tsp = Model(GLPK.Optimizer);
+set_optimizer_attribute(tsp, "sr_heur", GLPK.GLP_OFF)
+## set_optimizer_attribute(tsp, "msg_lev", GLPK.GLP_MSG_ON)
+
+@variable(tsp, x[i in 1:n, j in 1:n], Bin);
+
+@objective(tsp, Min, sum(x[i, j] * d[i, j] / 2 for i in 1:n for j in 1:n));
+
+@constraint(tsp, symmetry[i in 1:n, j in i:n, i!=j], x[i, j] == x[j, i]);
+
+@constraint(tsp, two_degree[i in 1:n], sum(x[i, j] for j in 1:n) == 2);
+
+@constraint(tsp, no_loop[i in 1:n], x[i, i] == 0);
+
+MOI.set(tsp, MOI.LazyConstraintCallback(), subtour_elimination)
+optimize!(tsp)
+time_lazy = solve_time(tsp);
+
+# !!! warning
+#     The following is a bit of a hack, as different solvers appear to treat lazy constraints internally very differently!
+#     While the following part is not necessary when using `Gurobi` as an Optimizer, in the case of `GLPK` things are different:
+#     in combination with the dict `lazy_constraints` introduced above, some lazy constraints may be ignored, even though they were explicitely added to the model.
+#     This might be remedied by removing the dict; however, then the optimization using lazy constraints will be very slow.
+#     Therefore, for use with `GLPK`,  after the first solution we will verify that all previously identified lazy constraints are actually respected, by adding them to the model and re-solving it.
+#     Note that this fix also works for the `sr_heur` issue discussed at the beginning of this document.
+
+cycle = subtour(selected_edges(x))
+while length(cycle) < n && length(cycle) > 1
+    for k in keys(seen)
+        add_constraint(tsp, seen[k])
+    end
+    #global lazy_constraints = Dict()
+    optimize!(tsp)
+    global time_lazy += solve_time(tsp)
+    global cycle = subtour(selected_edges(x))
+end
+
+info = (objective_value(tsp), time_lazy)
+@show(info)
+
+# When we observe the output, we can see that the objective value for both approaches is identical.
+# However, for the single instance of $n=75$ and the Optimizer `GLPK`, the solution time to find these solution is very different when using lazy constraints.
 
 # As a quick sanity check, we might visualize the optimal tour to verify that no subtour is present.
 
 plt = Plots.plot()
-for i in 1:n
-    for j in i:n
-        if (value.(x[i, j]) > 0.8)
-            Plots.plot!(
-                [X[i], X[j]],
-                [Y[i], Y[j]],
-                legend = false,
-                linecolor = :black,
-            )
-        end
-    end
+edges = selected_edges(x)
+for e in edges
+    Plots.plot!(
+        [X[e[1]], X[e[2]]],
+        [Y[e[1]], Y[e[2]]],
+        legend = false,
+        linecolor = :black,
+    )
 end
 Plots.plot!()
 

--- a/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
+++ b/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
@@ -102,7 +102,6 @@ end
 
 tsp = Model(GLPK.Optimizer);
 set_optimizer_attribute(tsp, "sr_heur", GLPK.GLP_OFF)
-## set_optimizer_attribute(tsp, "msg_lev", GLPK.GLP_MSG_ON)
 
 @variable(tsp, x[i in 1:n, j in 1:n], Bin);
 

--- a/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
+++ b/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
@@ -50,7 +50,7 @@ import Plots
 # \text{min } \sum_{i \in V}  \sum_{j \in V, i < j} d_{ij} x_{ij}
 # ```
 #
-# Note that it is also psosible to use the following objective function instead.
+# Note that it is also possible to use the following objective function instead.
 #
 # ```math
 # \text{min } \sum_{i \in V}  \sum_{j \in V} \dfrac{d_{ij} x_{ij}}{2}

--- a/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
+++ b/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
@@ -30,7 +30,6 @@
 
 
 using JuMP
-import Combinatorics
 import GLPK
 import LinearAlgebra
 import Random

--- a/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
+++ b/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
@@ -36,7 +36,7 @@ import Plots
 # 
 # Assume that we are given a complete graph $\mathcal{G}(V,E)$ where $V$ is the set of vertices (or cities) and $E$ is the set of edges (or roads). 
 # For each pair of vertices $i, j \in V, i \neq j$ the edge $(i,j) \in E$ is associated with a weight (or distance) $d_{ij} \in \mathbb{R}^+$.
-# For this Notebook, we assume the problem to be symmetric, i.e., $d_{ij} = d_{ji} \, \forall i,j \in V$.
+# For this tutorial, we assume the problem to be symmetric, i.e., $d_{ij} = d_{ji} \, \forall i,j \in V$.
 
 # In the Traveling Salesperson Problem, we are tasked with finding a tour with minimal length that visits every vertex exactly once and then returns to the point of origin, i.e., a *hamiltonian cycle* with minimal weight.
 # 

--- a/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
+++ b/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
@@ -34,6 +34,7 @@ import Combinatorics
 import GLPK
 import LinearAlgebra
 import Random
+import Plots
 
 
 # # Mathematical Formulation
@@ -116,14 +117,14 @@ tsp = Model(GLPK.Optimizer)
 
 
 function subtour_elimination(cb_data)
-    # We only checkfor subtours when we encounter integer-feasible solutions
+    ## We only checkfor subtours when we encounter integer-feasible solutions
     status = callback_node_status(cb_data, tsp)
     if status == MOI.CALLBACK_NODE_STATUS_INTEGER
 
-        # Load the callback data at the current node  
+        ## Load the callback data at the current node  
         x_val = callback_value.(Ref(cb_data), x)
 
-        # Write the current edges in a tuple list
+        ## Write the current edges in a tuple list
         edges = Tuple{Int,Int}[]
         for i = 1:n
             for j = 1:n
@@ -133,10 +134,10 @@ function subtour_elimination(cb_data)
             end
         end
 
-        # Get the shortest cycle from the list of edges
+        ## Get the shortest cycle from the list of edges
         cycle = subtour(edges)
 
-        # A subtour contains at least 2 locations and at most (n-1)
+        ## A subtour contains at least 2 locations and at most (n-1)
         if length(cycle) > 1 && length(cycle) < n
             subtour_edges = subtour_edges_helper(cycle)
             con = @build_constraint(sum(x[e[1], e[2]] for e in subtour_edges) <= length(cycle) - 1)
@@ -161,41 +162,41 @@ end
 
 
 function subtour(edges)
-    # A list of all unvisited vertices
+    ## A list of all unvisited vertices
     unvisited = Set(collect(1:n))
 
-    # Placeholder for the shortest subtour
+    ## Placeholder for the shortest subtour
     cycle = collect(1:n)
 
     while !(isempty(unvisited))
         thiscycle = []
         neighbors = unvisited
         while !(isempty(neighbors))
-            # Get the first item         
+            ## Get the first item         
             current = pop!(neighbors)
 
-            # Add it to the current cycle and remove it from unvisited
+            ## Add it to the current cycle and remove it from unvisited
             push!(thiscycle, current)
 
-            # If we are in the first iteration of the inner while loop,
-            # then the previous pop! already removed `current'
+            ## If we are in the first iteration of the inner while loop,
+            ## then the previous pop! already removed `current'
             if length(thiscycle) > 1
                 pop!(unvisited, current)
             end
 
-            # Get the index of all edges to which the current node is connected
+            ## Get the index of all edges to which the current node is connected
             index = findall(edges -> edges[1] == current, edges)
 
-            # Based on the index, add the neighbors
+            ## Based on the index, add the neighbors
             neighbors = []
             for i in index
                 append!(neighbors, edges[i][2])
             end
 
-            # We only consider neighbors that have not yet been visited
+            ## We only consider neighbors that have not yet been visited
             neighbors = intersect(neighbors, unvisited)
         end
-        # We always store the shortest cycle as subtour
+        ## We always store the shortest cycle as subtour
         if length(thiscycle) < length(cycle)
             cycle = thiscycle
         end
@@ -222,18 +223,15 @@ optimize!(tsp)
 
 # As a quick sanity check, we might visualize the optimal tour to verify that no subtour is present.
 
-
-using Plots
-
-plt = plot()
+plt = Plots.plot()
 for i = 1:n
     for j = i:n
         if (value.(x[i, j]) > 0.8)
-            plot!([X[i], X[j]], [Y[i], Y[j]], legend = false, linecolor = :black)
+            Plots.plot!([X[i], X[j]], [Y[i], Y[j]], legend = false, linecolor = :black)
         end
     end
 end
-plot!()
+Plots.plot!()
 
 
 # # References

--- a/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
+++ b/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
@@ -25,7 +25,7 @@
 # **Originally Contributed by**: Daniel Schermer
 # 
 # This notebook describes how to implement the Traveling Salesperson Problem in JuMP using lazy constraints that dynamically separate subtours.
-# To be more precise, we use lazy constraints to cut off feasible subtours only when necessary and not before needed.
+# To be more precise, we use lazy constraints to cut off infeasible subtours only when necessary and not before needed.
 # The model has been tested with Julia Version 1.7.0, JuMP.jl Version 0.22.1, and GLPK Version 0.15.2.
 
 

--- a/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
+++ b/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
@@ -41,7 +41,7 @@ import Random
 # Assume that we are given a complete graph $\mathcal{G}(V,E)$ where $V$ is the set of vertices and $E$ is the set of edges. 
 # For each pair of vertices $i, j \in V, i \neq j$ the edge $(i,j) \in E$ is associated with a distance (or weight) $d_{ij} \in \mathbb{R}^+$.
 # For the purpose of this Notebook, we assume the problem to be symmetric, i.e., $d_{ij} = d_{ji} \, \forall i,j \in V$.
-# In the Traveling Salesperson Problem, we are tasked with finding a tour with minimal length that visits every vertex exactly once and then returns to the point of origin, i.e., a hamiltonian cycle with minimal weight.
+# In the Traveling Salesperson Problem, we are tasked with finding a tour with minimal length that visits every vertex exactly once and then returns to the point of origin, i.e., a *hamiltonian cycle* with minimal weight.
 # 
 # In order to model the problem, we introduce a binary variable $x_{ij} \in \{0,1\} \; \forall i, j \in V$ that indicates if edge $(i,j)$ is part of the tour or not.
 # Using these variables, the Traveling Salesperson Problem can be modeled through the following Integer Linear Programming Formulation:
@@ -108,7 +108,7 @@ tsp = Model(GLPK.Optimizer)
 # $$ \sum_{i \in S} \sum_{j \in S, j \neq i} x_{ij} \leq \vert S \vert - 1 \quad \forall S \subset V $$
 # 
 # In general, we would require an exponential number of subtour eliminations constraints as $\vert V \vert$ increases.
-# Therefore, in this model, we will add these constraints as **lazy constraints** , i.e., not before needed and only when necessary.
+# Therefore, in this model, we will add these constraints as **lazy constraints**, i.e., not before needed and only when necessary.
 # 
 # We do this through the callback **subtour_elimination()** below, which is only run whenever we encounter an integer-feasible solution.
 # Based on the edges that are currently in the solution, we identify the shortest cycle through the function **subtour()**.
@@ -121,12 +121,7 @@ function subtour_elimination(cb_data)
     if status == MOI.CALLBACK_NODE_STATUS_INTEGER
 
         # Load the callback data at the current node  
-        x_val = zeros(n, n)
-        for i = 1:n
-            for j = 1:n
-                x_val[i, j] = callback_value(cb_data, x[i, j])
-            end
-        end
+        x_val = callback_value.(Ref(cb_data), x)
 
         # Write the current edges in a tuple list
         edges = Tuple{Int,Int}[]
@@ -228,7 +223,7 @@ optimize!(tsp)
 # As a quick sanity check, we might visualize the optimal tour to verify that no subtour is present.
 
 
-import Plots
+using Plots
 
 plt = plot()
 for i = 1:n

--- a/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
+++ b/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
@@ -43,7 +43,8 @@ import Plots
 # Using these variables, the Traveling Salesperson Problem can be modeled as the following Integer Linear Programming Formulation.
 # 
 # ## [Objective Function](@id tsp_objective)
-# The objective consists in minimizing the weighted edges (due to the assumed symmetry, the second sum only contains $i<j$).
+
+# The objective is to minimize the length of the tour (due to the assumed symmetry, the second sum only contains $i<j$).
 #
 # ```math
 # \text{min } \sum_{i \in V}  \sum_{j \in V, i < j} d_{ij} x_{ij}

--- a/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
+++ b/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
@@ -77,8 +77,6 @@ import Plots
 # x_{ii} = 0 \quad \forall i \in V
 # ```
 #
-#
-# ## [Subtour Elimination](@id tsp_sec)
 # A major difficulty of the Traveling Salesperson Problem arises from the fact that we need to prevent *subtours*, i.e., several distinct Hamiltonian cycles existing on subgraphs of $G$.
 # Note that the previous parts of the model (listed above) *do not* guarantee that the solution will be free of subtours.
 # To this end, by $S$ we label a subset of vertices.

--- a/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
+++ b/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
@@ -40,7 +40,7 @@ import Plots
 # In the Traveling Salesperson Problem, we are tasked with finding a tour with minimal length that visits every vertex exactly once and then returns to the point of origin, i.e., a *hamiltonian cycle* with minimal weight.
 # 
 # To model the problem, we introduce a binary variable $x_{ij} \in \{0,1\} \; \forall i, j \in V$ that indicates if edge $(i,j)$ is part of the tour or not.
-# Using these variables, the Traveling Salesperson Problem can be modeled through the following Integer Linear Programming Formulation.
+# Using these variables, the Traveling Salesperson Problem can be modeled as the following Integer Linear Programming Formulation.
 # 
 # ## [Objective Function](@id tsp_objective)
 # The objective consists in minimizing the weighted edges (due to the assumed symmetry, the second sum only contains $i<j$).

--- a/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
+++ b/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
@@ -76,7 +76,7 @@ import Plots
 # x_{ij} = x_{ji} \quad \forall i,j \in V.
 # ```
 
-# Second, or each vertex $i$, exactly two edges must be selected that connect it
+# Second, for each vertex $i$, exactly two edges must be selected that connect it
 # to other vertices $j$ in the graph $G$:
 # ```math
 # \sum_{j \in V} x_{ij} = 2 \quad \forall i \in V.
@@ -99,7 +99,7 @@ import Plots
 # \sum_{i \in S} \sum_{j \in S, i < j} x_{ij} \leq \vert S \vert - 1 \quad \forall S \subset V.
 # ```
 
-# Problematicaly, we require exponentially many of these constraints as
+# Problematically, we require exponentially many of these constraints as
 # $\vert V \vert$ increases. Therefore, we will add these constraints only when
 # necessary.
 
@@ -108,8 +108,8 @@ import Plots
 # There are two ways we can eliminate subtours in JuMP, both of which will be
 # shown in what follows:
 # - iteratively solving a new model that incorporates previously identified
-#   subtours
-# - adding violated subtours as *lazy constraints*.
+#   subtours,
+# - or adding violated subtours as *lazy constraints*.
 
 # ### Data
 

--- a/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
+++ b/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
@@ -1,5 +1,4 @@
-
-# Copyright (c) 2019 Arpit Bhatia and contributors                               #src
+# Copyright (c) 2022 Daniel Schermer and contributors                            #src
 #                                                                                #src
 # Permission is hereby granted, free of charge, to any person obtaining a copy   #src
 # of this software and associated documentation files (the "Software"), to deal  #src
@@ -201,9 +200,7 @@ cycle = subtour(selected_edges(x))
 ## Check for cycles, add the subtour elimination constraint,
 ## and optimize until no more cycles exist
 while length(cycle) > 1 && length(cycle) < n
-    S = collect(
-        Iterators.filter(t -> t[1] < t[2], Iterators.product(cycle, cycle)),
-    )
+    S = [(i, j) for (i, j) in Iterators.product(cycle, cycle) if i < j]
     @constraint(tsp, sum(x[t[1], t[2]] for t in S) <= length(cycle) - 1)
     optimize!(tsp)
     global time_iterated += solve_time(tsp)

--- a/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
+++ b/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
@@ -57,7 +57,8 @@ import Plots
 # ```
 #
 # ## [Constraints](@id tsp_constraints)
-# For the formulation of our problem, we need four classes of constraints which we will discuss in what follows.
+
+# There are four classes of constraints in our formulation.
 # Due to the presumed symmetry, the following constraints must hold.
 #
 # ```math

--- a/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
+++ b/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
@@ -23,7 +23,7 @@
 # 
 # **Originally Contributed by**: Daniel Schermer
 # 
-# This notebook describes how to implement the Traveling Salesperson Problem in JuMP using solver-independent lazy constraints that dynamically separate subtours.
+# This tutorial describes how to implement the [Traveling Salesperson Problem](https://en.wikipedia.org/wiki/Travelling_salesman_problem) in JuMP using solver-independent lazy constraints that dynamically separate subtours.
 # To be more precise, we use lazy constraints to cut off infeasible subtours only when necessary and not before needed.
 
 using JuMP

--- a/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
+++ b/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
@@ -39,7 +39,7 @@ import Plots
 
 # In the Traveling Salesperson Problem, we are tasked with finding a tour with minimal length that visits every vertex exactly once and then returns to the point of origin, i.e., a *hamiltonian cycle* with minimal weight.
 # 
-# In order to model the problem, we introduce a binary variable $x_{ij} \in \{0,1\} \; \forall i, j \in V$ that indicates if edge $(i,j)$ is part of the tour or not.
+# To model the problem, we introduce a binary variable $x_{ij} \in \{0,1\} \; \forall i, j \in V$ that indicates if edge $(i,j)$ is part of the tour or not.
 # Using these variables, the Traveling Salesperson Problem can be modeled through the following Integer Linear Programming Formulation.
 # 
 # ## [Objective Function](@id tsp_objective)


### PR DESCRIPTION
This notebook shows how to implement the Traveling Salesperson Problem in JuMP, using lazy constraints that dynamically separate subtours. To be more precise, we use lazy constraints to cut off feasible subtours only when necessary and not before needed.

The model has been tested with Julia Version 1.7.0, JuMP.jl Version 0.22.1, Gurobi.jl Version 0.10.1 (Solver Version 9.5), and GLPK Version 0.15.2. The implementation uses GLPK and a JuMP solver-independent callback.