### PR TITLE
Fix min and max in NLP expressions

### DIFF
--- a/src/_Derivatives/types.jl
+++ b/src/_Derivatives/types.jl
@@ -32,7 +32,7 @@ export NodeData
 # for COMPARISON, index is into lost of comparison operators
 # for EXTRA, index is extension specific
 
-const operators = [:+, :-, :*, :^, :/, :ifelse, :max, :min]
+const operators = [:+, :-, :*, :^, :/, :ifelse]
 const USER_OPERATOR_ID_START = length(operators) + 1
 
 const operator_to_id = Dict{Symbol,Int}()

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -189,9 +189,10 @@ function test_multivariate_max()
     @variable(m, x)
     @NLobjective(m, Min, max(0, x))
     nlp = NLPEvaluator(m)
-    MOI.initialize(nlp, [:Grad])
+    MOI.initialize(nlp, [:ExprGraph])
     @test MOI.eval_objective(nlp, [-1.0]) == 0.0
     @test MOI.eval_objective(nlp, [1.0]) == 1.0
+    @test MOI.objective_expr(nlp) == :(max(0.0, x[$(index(x))]))
     return
 end
 
@@ -200,9 +201,10 @@ function test_multivariate_min()
     @variable(m, x)
     @NLobjective(m, Max, min(0, x))
     nlp = NLPEvaluator(m)
-    MOI.initialize(nlp, [:Grad])
+    MOI.initialize(nlp, [:ExprGraph])
     @test MOI.eval_objective(nlp, [-1.0]) == -1.0
     @test MOI.eval_objective(nlp, [1.0]) == 0.0
+    @test MOI.objective_expr(nlp) == :(min(0.0, x[$(index(x))]))
     return
 end
 

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -184,6 +184,28 @@ function test_multivariate_register_splat_existing()
     @test_throws err @NLexpression(model, ex, f(x...))
 end
 
+function test_multivariate_max()
+    m = Model()
+    @variable(m, x)
+    @NLobjective(m, Min, max(0, x))
+    nlp = NLPEvaluator(m)
+    MOI.initialize(nlp, [:Grad])
+    @test MOI.eval_objective(nlp, [-1.0]) == 0.0
+    @test MOI.eval_objective(nlp, [1.0]) == 1.0
+    return
+end
+
+function test_multivariate_min()
+    m = Model()
+    @variable(m, x)
+    @NLobjective(m, Max, min(0, x))
+    nlp = NLPEvaluator(m)
+    MOI.initialize(nlp, [:Grad])
+    @test MOI.eval_objective(nlp, [-1.0]) == -1.0
+    @test MOI.eval_objective(nlp, [1.0]) == 0.0
+    return
+end
+
 @testset "Auto-register-univariate" begin
     test_univariate_error()
     test_univariate_error_existing()
@@ -203,6 +225,8 @@ end
     test_multivariate_register_warn()
     test_multivariate_register_splat()
     test_multivariate_register_splat_existing()
+    test_multivariate_max()
+    test_multivariate_min()
 end
 
 @testset "Nonlinear" begin

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -1110,16 +1110,6 @@ end
         @test JuMP._Derivatives.eval_univariate_2nd_deriv(id, x, y) == 0.0
     end
 
-    @testset "Unsupported function max" begin
-        model = Model()
-        @variable(model, x >= 0)
-        @NLobjective(model, Min, max(x, 2 * x))
-        d = JuMP.NLPEvaluator(model)
-        MOI.initialize(d, Symbol[])
-        x = [2.0]
-        @test_throws ErrorException MOI.eval_objective(d, x)
-    end
-
     @testset "Re-register univariate" begin
         model = Model()
         @variable(model, x >= 0)


### PR DESCRIPTION
Closes #2841 

I don't know if we had explicit support for these at some point, but we don't anymore. However, the automatic function registration works with a useful warning.

```Julia
julia> using JuMP

julia> m = Model()
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: NO_OPTIMIZER
Solver name: No optimizer attached.

julia> @variable(m, x)
x

julia> @NLobjective(m, Min, max(0, x))
┌ Warning: Function max automatically registered with 2 arguments.
│ 
│ Calling the function with a different number of arguments will result in an
│ error.
│ 
│ While you can safely ignore this warning, we recommend that you manually
│ register the function as follows:
│ ```Julia
│ model = Model()
│ register(model, :max, 2, max; autodiff = true)
│ ```
└ @ JuMP ~/.julia/dev/JuMP/src/parse_nlp.jl:21

julia> nlp = NLPEvaluator(m)
An NLPEvaluator with available features:
  * :Grad
  * :Jac
  * :JacVec
  * :ExprGraph

julia> MOI.initialize(nlp, [:Grad])

julia> @test MOI.eval_objective(nlp, [-1.0]) == 0.0
Test Passed

julia> @test MOI.eval_objective(nlp, [1.0]) == 1.0
Test Passed
```