### PR TITLE
Pluralized macros return tuples

### DIFF
--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -421,6 +421,7 @@ julia> @constraints(model, begin
            2x <= 1
            c, x >= -1
        end)
+(2 x ≤ 1.0, c : x ≥ -1.0)
 
 julia> print(model)
 Feasibility
@@ -428,6 +429,8 @@ Subject to
  c : x ≥ -1.0
  2 x ≤ 1.0
 ```
+The [`@constraints`](@ref) macro returns a tuple of the constraints that were
+defined.
 
 ## [Duality](@id constraint_duality)
 

--- a/docs/src/manual/variables.md
+++ b/docs/src/manual/variables.md
@@ -955,6 +955,7 @@ julia> @variables(model, begin
            y[i=1:2] >= i, (start = i, base_name = "Y_$i")
            z, Bin
        end)
+(x, VariableRef[Y_1[1], Y_2[2]], z)
 
 julia> print(model)
 Feasibility
@@ -963,6 +964,8 @@ Subject to
  Y_2[2] ≥ 2.0
  z binary
 ```
+The [`@variables`](@ref) macro returns a tuple of the variables that were
+defined.
 
 !!! note
     Keyword arguments must be contained within parentheses.

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1143,6 +1143,8 @@ Adds groups of constraints at once, in the same fashion as the
 The model must be the first argument, and multiple constraints can be added on
 multiple lines wrapped in a `begin ... end` block.
 
+The macro returns a tuple containing the constraints that were defined.
+
 # Examples
 
 ```julia
@@ -1162,6 +1164,8 @@ Adds multiple variables to model at once, in the same fashion as the
 
 The model must be the first argument, and multiple variables can be added on
 multiple lines wrapped in a `begin ... end` block.
+
+The macro returns a tuple containing the variables that were defined.
 
 # Examples
 
@@ -1184,8 +1188,10 @@ end)
 Adds multiple expressions to model at once, in the same fashion as the
 [`@expression`](@ref) macro.
 
-The model must be the first argument, and multiple variables can be added on
+The model must be the first argument, and multiple expressions can be added on
 multiple lines wrapped in a `begin ... end` block.
+
+The macro returns a tuple containing the expressions that were defined.
 
 # Examples
 
@@ -1219,12 +1225,14 @@ end)
 @doc """
      @NLparameters(model, args...)
 
- Create and return multiple nonlinear parameters attached to model `model`, in the same fashion as
- [`@NLparameter`](@ref) macro.
+Create and return multiple nonlinear parameters attached to model `model`, in
+the same fashion as [`@NLparameter`](@ref) macro.
 
- The model must be the first argument, and multiple parameters can be added on
- multiple lines wrapped in a `begin ... end` block. Distinct parameters need to be placed
- on separate lines as in the following example.
+The model must be the first argument, and multiple parameters can be added on
+multiple lines wrapped in a `begin ... end` block. Distinct parameters need to
+be placed on separate lines as in the following example.
+
+The macro returns a tuple containing the parameters that were defined.
 
 # Example
 ```jldoctest; setup=:(using JuMP)
@@ -1246,8 +1254,10 @@ value(x)
 Adds multiple nonlinear constraints to model at once, in the same fashion as
 the [`@NLconstraint`](@ref) macro.
 
-The model must be the first argument, and multiple variables can be added on
+The model must be the first argument, and multiple constraints can be added on
 multiple lines wrapped in a `begin ... end` block.
+
+The macro returns a tuple containing the constraints that were defined.
 
 # Examples
 
@@ -1265,8 +1275,10 @@ end)
 Adds multiple nonlinear expressions to model at once, in the same fashion as the
 [`@NLexpression`](@ref) macro.
 
-The model must be the first argument, and multiple variables can be added on
+The model must be the first argument, and multiple expressions can be added on
 multiple lines wrapped in a `begin ... end` block.
+
+The macro returns a tuple containing the expressions that were defined.
 
 # Examples
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1077,7 +1077,7 @@ function _pluralize_macro(mac, sym)
             end
             @assert isa(x.args[1], LineNumberNode)
             lastline = x.args[1]
-            code = Expr(:vect)
+            code = Expr(:tuple)
             for it in x.args
                 if isa(it, LineNumberNode)
                     lastline = it

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -858,12 +858,12 @@ function test_Plural_returns()
         x
         y[1:2]
     end)
-    @test vars == [x, y]
+    @test vars == (x, y)
     eqs = @constraints(model, begin
         E_x, x == 0
         E_y[i=1:2], y[i] == 0
     end)
-    @test eqs == [E_x, E_y]
+    @test eqs == (E_x, E_y)
     return
 end
 

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -861,7 +861,7 @@ function test_Plural_returns()
     @test vars == (x, y)
     eqs = @constraints(model, begin
         E_x, x == 0
-        E_y[i=1:2], y[i] == 0
+        E_y[i = 1:2], y[i] == 0
     end)
     @test eqs == (E_x, E_y)
     return

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -852,6 +852,21 @@ function test_Plural_failures()
     return
 end
 
+function test_Plural_returns()
+    model = Model()
+    vars = @variables(model, begin
+        x
+        y[1:2]
+    end)
+    @test vars == [x, y]
+    eqs = @constraints(model, begin
+        E_x, x == 0
+        E_y[i=1:2], y[i] == 0
+    end)
+    @test eqs == [E_x, E_y]
+    return
+end
+
 function test_Empty_summation_in_constraints()
     model = Model()
     @variable(model, x)


### PR DESCRIPTION
Closes #2837
Pluralized macros (e.g. @variables) now return vectors of whatever the 'singular' macros return.

E.g. the following new tests pass:
    vars = @variables(model, begin
        x
        y[1:2]
    end)
    @test vars == [x, y]
    eqs = @constraints(model, begin
        E_x, x == 0
        E_y[i=1:2], y[i] == 0
    end)
    @test eqs == [E_x, E_y]