### PR TITLE
[docs] Add introduction sections to tutorials

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -3,4 +3,5 @@ latex_build/
 src/examples/*.md
 src/examples/*/*.md
 src/tutorials/*/*.md
+!src/tutorials/*/introduction.md
 src/moi/

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -104,6 +104,7 @@ const _PAGES = [
             "tutorials/getting_started/design_patterns_for_larger_models.md",
         ],
         "Linear programs" => [
+            "tutorials/linear/introduction.md",
             "tutorials/linear/tips_and_tricks.md",
             "tutorials/linear/diet.md",
             "tutorials/linear/cannery.md",
@@ -123,6 +124,7 @@ const _PAGES = [
             "tutorials/linear/callbacks.md",
         ],
         "Nonlinear programs" => [
+            "tutorials/nonlinear/introduction.md",
             "tutorials/nonlinear/tips_and_tricks.md",
             "tutorials/nonlinear/portfolio.md",
             "tutorials/nonlinear/qcp.md",
@@ -134,6 +136,7 @@ const _PAGES = [
             "tutorials/nonlinear/querying_hessians.md",
         ],
         "Conic programs" => [
+            "tutorials/conic/introduction.md",
             "tutorials/conic/tips_and_tricks.md",
             "tutorials/conic/logistic_regression.md",
             "tutorials/conic/cluster.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -56,7 +56,11 @@ function _include_sandbox(filename)
 end
 
 function _literate_directory(dir)
-    rm.(_file_list(dir, dir, ".md"))
+    for filename in _file_list(dir, dir, ".md")
+        if !endswith(filename, "introduction.md")
+            rm(filename)
+        end
+    end
     for filename in _file_list(dir, dir, ".jl")
         # `include` the file to test it before `#src` lines are removed. It is
         # in a testset to isolate local variables between files.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -100,6 +100,7 @@ const _PAGES = [
     "Introduction" => ["index.md", "should_i_use.md", "installation.md"],
     "Tutorials" => [
         "Getting started" => [
+            "tutorials/getting_started/introduction.md",
             "tutorials/getting_started/getting_started_with_julia.md",
             "tutorials/getting_started/getting_started_with_JuMP.md",
             "tutorials/getting_started/getting_started_with_sets_and_indexing.md",

--- a/docs/src/tutorials/conic/introduction.md
+++ b/docs/src/tutorials/conic/introduction.md
@@ -6,7 +6,7 @@ nonlinearities. They have the form:
 ```math
 \begin{align}
     & \min_{x \in \mathbb{R}^n} & f_0(x) \\
-    & \;\;\text{s.t.} & f_i(x) \in \mathcal{S}_i & \;\; i = 1 \ldots m
+    & \;\;\text{s.t.} & f_j(x) \in \mathcal{S}_j & \;\; j = 1 \ldots m
 \end{align}
 ```
 
@@ -18,7 +18,7 @@ some (or all) of the decision variables take discrete values.
 JuMP supports a range of conic solvers, although support differs on what types
 of cones each solver supports. In the list of [Supported solvers](@ref), "SOCP"
 denotes solvers supporting second-order cones and "SDP" denotes solvers
-supporting semi-definite cones. In addition, solvers such as SCS and Mosek have
+supporting semidefinite cones. In addition, solvers such as SCS and Mosek have
 support for the exponential cone. Moreover, due to the bridging system in
 MathOptInterface, many of these solvers support a much wider range of exotic
 cones than they natively support. Solvers supporting discrete variables start
@@ -38,7 +38,7 @@ will help you know where to look for certain things.
  * The [Tips and tricks](@ref conic_tips_and_tricks) tutorial contains a
    number of helpful reformulations and tricks you can use when modeling
    conic programs. Look here if you are stuck trying to formulate a problem
-   as a nonlinear program.
+   as a conic program.
  * The remaining tutorials are less verbose and styled in the form of short code
    examples. These tutorials have less explanation, but may contain useful
    code snippets, particularly if they are similar to a problem you are trying

--- a/docs/src/tutorials/conic/introduction.md
+++ b/docs/src/tutorials/conic/introduction.md
@@ -1,0 +1,44 @@
+# Introduction
+
+[Conic programs](https://en.wikipedia.org/wiki/Conic_optimization) are a class
+of convex nonlinear optimization problems which use cones to represent the
+nonlinearities. They have the form:
+```math
+\begin{align}
+    & \min_{x \in \mathbb{R}^n} & f_0(x)\\
+    & \;\;\text{s.t.} & f_i(x) in \mathcal{S}_i & i = 1 \ldots m
+\end{align}
+```
+
+Mixed-integer conic programs (MICPs) are extensions of conic programs in which
+some (or all) of the decision variables take discrete values.
+
+## How to choose a solver
+
+JuMP supports a range of conic solvers, although support differs on what types
+of cones each solver supports. In the list of [Supported solvers](@ref), "SOCP"
+denotes solvers supporting second-order cones and "SDP" denotes solvers
+supporting semi-definite cones. In addition, solvers such as SCS and Mosek have
+support for the exponential cone. Moreover, due to the bridging system in
+MathOptInterface, many of these solvers support a much wider range of exotic
+cones than they natively support. Solvers supporting discrete variables start
+with "(MI)" in the list of [Supported solvers](@ref).
+
+## How this section is structured
+
+Having a high-level overview of how this part of the documentation is structured
+will help you know where to look for certain things.
+
+ * Tutorial-style worked examples present a problem in words, then formulate it
+   in mathematics, and then solve it in JuMP. This usually involves some sort of
+   visualization of the solution. Start here if you are new to JuMP.
+   * [Experiment design](@ref)
+   * [Logistic regression](@ref)
+ * The [Tips and tricks](@ref conic_tips_and_tricks) tutorial contains a
+   number of helpful reformulations and tricks you can use when modeling
+   conic programs. Look here if you are stuck trying to formulate a problem
+   as a nonlinear program.
+ * The remaining tutorials are less verbose and styled in the form of short code
+   examples. These tutorials have less explanation, but may contain useful
+   code snippets, particularly if they are similar to a problem you are trying
+   to solve.

--- a/docs/src/tutorials/conic/introduction.md
+++ b/docs/src/tutorials/conic/introduction.md
@@ -5,8 +5,8 @@ of convex nonlinear optimization problems which use cones to represent the
 nonlinearities. They have the form:
 ```math
 \begin{align}
-    & \min_{x \in \mathbb{R}^n} & f_0(x)\\
-    & \;\;\text{s.t.} & f_i(x) in \mathcal{S}_i & i = 1 \ldots m
+    & \min_{x \in \mathbb{R}^n} & f_0(x) \\
+    & \;\;\text{s.t.} & f_i(x) \in \mathcal{S}_i & \;\; i = 1 \ldots m
 \end{align}
 ```
 
@@ -24,14 +24,15 @@ MathOptInterface, many of these solvers support a much wider range of exotic
 cones than they natively support. Solvers supporting discrete variables start
 with "(MI)" in the list of [Supported solvers](@ref).
 
-## How this section is structured
+## How these tutorials are structured
 
 Having a high-level overview of how this part of the documentation is structured
 will help you know where to look for certain things.
 
- * Tutorial-style worked examples present a problem in words, then formulate it
-   in mathematics, and then solve it in JuMP. This usually involves some sort of
-   visualization of the solution. Start here if you are new to JuMP.
+ * The following tutorials are worked examples that present a problem in words,
+   then formulate it in mathematics, and then solve it in JuMP. This usually
+   involves some sort of visualization of the solution. Start here if you are
+   new to JuMP.
    * [Experiment design](@ref)
    * [Logistic regression](@ref)
  * The [Tips and tricks](@ref conic_tips_and_tricks) tutorial contains a

--- a/docs/src/tutorials/conic/tips_and_tricks.jl
+++ b/docs/src/tutorials/conic/tips_and_tricks.jl
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  #src
 # SOFTWARE.                                                                      #src
 
-# # Tips and Tricks
+# # [Tips and Tricks](@id conic_tips_and_tricks)
 
 # **Originally Contributed by**: Arpit Bhatia
 

--- a/docs/src/tutorials/getting_started/introduction.md
+++ b/docs/src/tutorials/getting_started/introduction.md
@@ -16,11 +16,11 @@ will help you know where to look for certain things.
    * [Getting started with sets and indexing](@ref)
    * [Getting started with data and plotting](@ref)
  * Julia has a reputation for being "fast." Unfortunately, it is also easy to
-   write _slow_ Julia code. The [Performance tips](@ref) contains a number of
+   write _slow_ Julia code. [Performance tips](@ref) contains a number of
    important tips on how to improve the performance of models you write in JuMP.
- * The [Design patterns for larger models](@ref) is a more advanced tutorial
+ * [Design patterns for larger models](@ref) is a more advanced tutorial
    that is aimed at users writing large JuMP models. It's in the "Getting
    started" section to give you an early preview of how JuMP makes it easy to
-   structure larger models. However, if you are new to JuMP you may want to skip
+   structure larger models. If you are new to JuMP you may want to skip
    or briefly skim this tutorial, and come back to it once you have written a
    few JuMP models.

--- a/docs/src/tutorials/getting_started/introduction.md
+++ b/docs/src/tutorials/getting_started/introduction.md
@@ -1,0 +1,26 @@
+# Introduction
+
+The purpose of these "Getting started" tutorials is to teach new users the
+basics of Julia and JuMP.
+
+## How these tutorials are structured
+
+Having a high-level overview of how this part of the documentation is structured
+will help you know where to look for certain things.
+
+ * The "Getting started with ..." tutorials are basic introductions to different
+   aspects of JuMP and Julia. If you are new to JuMP and Julia, start by reading
+   them in the following order:
+   * [Getting started with Julia](@ref)
+   * [Getting started with JuMP](@ref)
+   * [Getting started with sets and indexing](@ref)
+   * [Getting started with data and plotting](@ref)
+ * Julia has a reputation for being "fast." Unfortunately, it is also easy to
+   write _slow_ Julia code. The [Performance tips](@ref) contains a number of
+   important tips on how to improve the performance of models you write in JuMP.
+ * The [Design patterns for larger models](@ref) is a more advanced tutorial
+   that is aimed at users writing large JuMP models. It's in the "Getting
+   started" section to give you an early preview of how JuMP makes it easy to
+   structure larger models. However, if you are new to JuMP you may want to skip
+   or briefly skim this tutorial, and come back to it once you have written a
+   few JuMP models.

--- a/docs/src/tutorials/linear/introduction.md
+++ b/docs/src/tutorials/linear/introduction.md
@@ -1,0 +1,52 @@
+# Introduction
+
+[Linear programs (LPs)](https://en.wikipedia.org/wiki/Linear_programming) are a
+fundamental class of optimization problems:
+```math
+\begin{align}
+    & \min_{x \in \mathbb{R}^n} & \sum\limits_{i=1}^n c_i x_i
+    \\
+    & \;\;\text{s.t.} & l_j \le \sum\limits_{i=1}^n a_{ij} x_i \le u_j & j = 1 \ldots m
+    & & l_i \le x_i \le u_i.
+\end{align}
+```
+The most important thing to note is that all terms are of the form
+`coefficient * variable`, and that there are no nonlinear terms or
+multiplications between variables.
+
+Mixed-integer linear programs (MILPs) are extensions of linear programs in which
+some (or all) of the decision variables take discrete values.
+
+## How to choose a solver
+
+Almost all solvers support linear programs; look for "LP" in the list of
+[Supported solvers](@ref). However, fewer solvers support mixed-integer linear
+programs. Solvers supporting discrete variables start with "(MI)" in the list of
+[Supported solvers](@ref).
+
+## How this section is structured
+
+Having a high-level overview of how this part of the documentation is structured
+will help you know where to look for certain things.
+
+ * Tutorial-style worked examples present a problem in words, then formulate it
+   in mathematics, and then solve it in JuMP. This usually involves some sort of
+   visualization of the solution. Start here if you are new to JuMP.
+   * [The diet problem](@ref)
+   * [The cannery problem](@ref)
+   * [The facility location problem](@ref)
+   * [Financial modeling problems](@ref)
+   * [Network flow problems](@ref)
+   * [N-Queens](@ref)
+   * [Sudoku](@ref)
+ * The [Tips and tricks](@ref linear_tips_and_tricks) tutorial contains a number
+   of helpful reformulations and tricks you can use when modeling linear
+   programs. Look here if you are stuck trying to formulate a problem as a
+   linear program.
+ * The [Callbacks](@ref callbacks_tutorial) tutorial explains how to write a
+   variety of solver-independent callbacks. Look here if you want to write a
+   callback.
+ * The remaining tutorials are less verbose and styled in the form of short code
+   examples. These tutorials have less explanation, but may contain useful
+   code snippets, particularly if they are similar to a problem you are trying
+   to solve.

--- a/docs/src/tutorials/linear/introduction.md
+++ b/docs/src/tutorials/linear/introduction.md
@@ -1,13 +1,12 @@
 # Introduction
 
 [Linear programs (LPs)](https://en.wikipedia.org/wiki/Linear_programming) are a
-fundamental class of optimization problems:
+fundamental class of optimization problems of the form:
 ```math
 \begin{align}
-    & \min_{x \in \mathbb{R}^n} & \sum\limits_{i=1}^n c_i x_i
-    \\
-    & \;\;\text{s.t.} & l_j \le \sum\limits_{i=1}^n a_{ij} x_i \le u_j & j = 1 \ldots m
-    & & l_i \le x_i \le u_i.
+    \min_{x \in \mathbb{R}^n} & \sum\limits_{i=1}^n c_i x_i \\
+    \;\;\text{s.t.} & l_j \le \sum\limits_{i=1}^n a_{ij} x_i \le u_j & j = 1 \ldots m \\
+    & l_i \le x_i \le u_i & i = 1 \ldots n.
 \end{align}
 ```
 The most important thing to note is that all terms are of the form
@@ -24,14 +23,15 @@ Almost all solvers support linear programs; look for "LP" in the list of
 programs. Solvers supporting discrete variables start with "(MI)" in the list of
 [Supported solvers](@ref).
 
-## How this section is structured
+## How these tutorials are structured
 
 Having a high-level overview of how this part of the documentation is structured
 will help you know where to look for certain things.
 
- * Tutorial-style worked examples present a problem in words, then formulate it
-   in mathematics, and then solve it in JuMP. This usually involves some sort of
-   visualization of the solution. Start here if you are new to JuMP.
+ * The following tutorials are worked examples that present a problem in words,
+   then formulate it in mathematics, and then solve it in JuMP. This usually
+   involves some sort of visualization of the solution. Start here if you are
+   new to JuMP.
    * [The diet problem](@ref)
    * [The cannery problem](@ref)
    * [The facility location problem](@ref)

--- a/docs/src/tutorials/linear/tips_and_tricks.jl
+++ b/docs/src/tutorials/linear/tips_and_tricks.jl
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  #src
 # SOFTWARE.                                                                      #src
 
-# # Tips and tricks
+# # [Tips and tricks](@id linear_tips_and_tricks)
 
 # **Originally Contributed by**: Arpit Bhatia
 

--- a/docs/src/tutorials/nonlinear/introduction.md
+++ b/docs/src/tutorials/nonlinear/introduction.md
@@ -1,0 +1,52 @@
+# Introduction
+
+[Nonlinear programs (NLPs)](https://en.wikipedia.org/wiki/Nonlinear_programming)
+are a class of optimization problems in which some of the constraints or the
+objective function are nonlinear:
+```math
+\begin{align}
+    & \min_{x \in \mathbb{R}^n} & f_0(x)\\
+    & \;\;\text{s.t.} & l_j \le \sum\limits_{i=1}^n a_{ij} x_i \le u_j & j = 1 \ldots m
+    & & l_i \le x_i \le u_i.
+\end{align}
+```
+
+Mixed-integer nonlinear linear programs (MINLPs) are extensions of nonlinear
+programs in which some (or all) of the decision variables take discrete values.
+
+## How to choose a solver
+
+JuMP supports a range of nonlinear solvers; look for "NLP" in the list
+of [Supported solvers](@ref). However, very few solvers support mixed-integer
+nonlinear linear programs. Solvers supporting discrete variables start with
+"(MI)" in the list of [Supported solvers](@ref).
+
+If the only nonlinearities in your model are quadratic terms (that is,
+multiplication between two decision variables), you can also use second-order
+cone solvers, which are indicated by "SOCP." In most cases, these solvers are
+restricted to convex quadratic problems and will error if you pass a nonconvex
+quadratic function; however, Gurobi has the ability to solve nonconvex quadratic
+terms.
+
+## How this section is structured
+
+Having a high-level overview of how this part of the documentation is structured
+will help you know where to look for certain things.
+
+ * Tutorial-style worked examples present a problem in words, then formulate it
+   in mathematics, and then solve it in JuMP. This usually involves some sort of
+   visualization of the solution. Start here if you are new to JuMP.
+   * [Rocket Control](@ref)
+   * [Optimal control for a Space Shuttle reentry trajectory](@ref)
+   * [Quadratic portfolio optimization](@ref)
+ * The [Tips and tricks](@ref nonlinear_tips_and_tricks) tutorial contains a
+   number of helpful reformulations and tricks you can use when modeling
+   nonlinear programs. Look here if you are stuck trying to formulate a problem
+   as a nonlinear program.
+ * The [Computing Hessians](@ref) is an advanced tutorial which explains how to
+   compute the Hessian of the Lagrangian of a nonlinear program. This is useful
+   only in particular cases.
+ * The remaining tutorials are less verbose and styled in the form of short code
+   examples. These tutorials have less explanation, but may contain useful
+   code snippets, particularly if they are similar to a problem you are trying
+   to solve.

--- a/docs/src/tutorials/nonlinear/introduction.md
+++ b/docs/src/tutorials/nonlinear/introduction.md
@@ -6,7 +6,7 @@ objective function are nonlinear:
 ```math
 \begin{align}
     \min_{x \in \mathbb{R}^n} & f_0(x) \\
-    \;\;\text{s.t.} & l_j \le \sum\limits_{i=1}^n a_{ij} x_i \le u_j & j = 1 \ldots m \\
+    \;\;\text{s.t.} & l_j \le f_j(x) \le u_j & j = 1 \ldots m \\
     & l_i \le x_i \le u_i & i = 1 \ldots n.
 \end{align}
 ```

--- a/docs/src/tutorials/nonlinear/introduction.md
+++ b/docs/src/tutorials/nonlinear/introduction.md
@@ -5,9 +5,9 @@ are a class of optimization problems in which some of the constraints or the
 objective function are nonlinear:
 ```math
 \begin{align}
-    & \min_{x \in \mathbb{R}^n} & f_0(x)\\
-    & \;\;\text{s.t.} & l_j \le \sum\limits_{i=1}^n a_{ij} x_i \le u_j & j = 1 \ldots m
-    & & l_i \le x_i \le u_i.
+    \min_{x \in \mathbb{R}^n} & f_0(x) \\
+    \;\;\text{s.t.} & l_j \le \sum\limits_{i=1}^n a_{ij} x_i \le u_j & j = 1 \ldots m \\
+    & l_i \le x_i \le u_i & i = 1 \ldots n.
 \end{align}
 ```
 
@@ -28,14 +28,15 @@ restricted to convex quadratic problems and will error if you pass a nonconvex
 quadratic function; however, Gurobi has the ability to solve nonconvex quadratic
 terms.
 
-## How this section is structured
+## How these tutorials are structured
 
 Having a high-level overview of how this part of the documentation is structured
 will help you know where to look for certain things.
 
- * Tutorial-style worked examples present a problem in words, then formulate it
-   in mathematics, and then solve it in JuMP. This usually involves some sort of
-   visualization of the solution. Start here if you are new to JuMP.
+ * The following tutorials are worked examples that present a problem in words,
+   then formulate it in mathematics, and then solve it in JuMP. This usually
+   involves some sort of visualization of the solution. Start here if you are
+   new to JuMP.
    * [Rocket Control](@ref)
    * [Optimal control for a Space Shuttle reentry trajectory](@ref)
    * [Quadratic portfolio optimization](@ref)

--- a/docs/src/tutorials/nonlinear/tips_and_tricks.jl
+++ b/docs/src/tutorials/nonlinear/tips_and_tricks.jl
@@ -3,7 +3,7 @@
 # v.2.0. If a copy of the MPL was not distributed with this file, You can       #src
 # obtain one at https://mozilla.org/MPL/2.0/.                                   #src
 
-# # Tips and tricks
+# # [Tips and tricks](@id nonlinear_tips_and_tricks)
 
 # This example collates some tips and tricks you can use when formulating
 # nonlinear programs. It uses the following packages:


### PR DESCRIPTION
I think we've always missed some intro parts to these tutorials. At some point, we should expand on some intro modeling theory. We get a lot of users who try things like solving MINLPs with Ipopt, for example.

Preview https://jump.dev/JuMP.jl/previews/PR2850/