### PR TITLE
[docs] fix start value in max_cut_sdp

### DIFF
--- a/docs/src/tutorials/conic/max_cut_sdp.jl
+++ b/docs/src/tutorials/conic/max_cut_sdp.jl
@@ -31,7 +31,12 @@ function solve_max_cut_sdp(num_vertex, weights)
     model = Model(SCS.Optimizer)
     set_silent(model)
     # Start with X as the identity matrix to avoid numerical issues.
-    @variable(model, X[i = 1:num_vertex, j = 1:num_vertex], PSD, start = i == j)
+    @variable(
+        model,
+        X[i = 1:num_vertex, j = 1:num_vertex],
+        PSD,
+        start = (i == j ? 1.0 : 0.0),
+    )
     @objective(model, Max, 1 / 4 * LinearAlgebra.dot(laplacian, X))
     @constraint(model, LinearAlgebra.diag(X) .== 1)
     optimize!(model)

--- a/docs/src/tutorials/conic/max_cut_sdp.jl
+++ b/docs/src/tutorials/conic/max_cut_sdp.jl
@@ -30,7 +30,7 @@ function solve_max_cut_sdp(num_vertex, weights)
     ## Solve the SDP relaxation
     model = Model(SCS.Optimizer)
     set_silent(model)
-    # Start with X as the identity matrix to avoid numerical issues.
+    ## Start with X as the identity matrix to avoid numerical issues.
     @variable(
         model,
         X[i = 1:num_vertex, j = 1:num_vertex],

--- a/docs/src/tutorials/conic/max_cut_sdp.jl
+++ b/docs/src/tutorials/conic/max_cut_sdp.jl
@@ -30,7 +30,8 @@ function solve_max_cut_sdp(num_vertex, weights)
     ## Solve the SDP relaxation
     model = Model(SCS.Optimizer)
     set_silent(model)
-    @variable(model, X[1:num_vertex, 1:num_vertex], PSD)
+    # Start with X as the identity matrix to avoid numerical issues.
+    @variable(model, X[i=1:num_vertex, j=1:num_vertex], PSD, start = (i == j))
     @objective(model, Max, 1 / 4 * LinearAlgebra.dot(laplacian, X))
     @constraint(model, LinearAlgebra.diag(X) .== 1)
     optimize!(model)

--- a/docs/src/tutorials/conic/max_cut_sdp.jl
+++ b/docs/src/tutorials/conic/max_cut_sdp.jl
@@ -31,7 +31,7 @@ function solve_max_cut_sdp(num_vertex, weights)
     model = Model(SCS.Optimizer)
     set_silent(model)
     # Start with X as the identity matrix to avoid numerical issues.
-    @variable(model, X[i=1:num_vertex, j=1:num_vertex], PSD, start = (i == j))
+    @variable(model, X[i = 1:num_vertex, j = 1:num_vertex], PSD, start = i == j)
     @objective(model, Max, 1 / 4 * LinearAlgebra.dot(laplacian, X))
     @constraint(model, LinearAlgebra.diag(X) .== 1)
     optimize!(model)


### PR DESCRIPTION
SCS v0.8.2 added the primal and dual warm starts, which caused a small numerical issue in the solution. (The resulting X matrix has eigen values of -1e-10, which breaks our hack at a cholesky factorization.)

The solution is to warm-start from the identify matrix, but I'll take a look at SCS to see if we need to modify how we are passing the default warm-starts.