### PR TITLE
[docs] improve section on constraint start values

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -142,6 +142,7 @@ const _PAGES = [
         ],
         "Conic programs" => [
             "tutorials/conic/introduction.md",
+            "tutorials/conic/start_values.md",
             "tutorials/conic/tips_and_tricks.md",
             "tutorials/conic/logistic_regression.md",
             "tutorials/conic/cluster.md",

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -737,7 +737,7 @@ julia> dual_start_value(con)
 
 To take the solution from the last solve and use it as the starting point for a
 new solve, use a function like this:
-```@example
+```@repl
 using JuMP, SCS
 function set_optimal_start_values(model::Model)
     variable_primal = Dict(x => value(x) for x in all_variables(model))
@@ -760,9 +760,9 @@ function set_optimal_start_values(model::Model)
     end
     return
 end
-model = Model(SCS.Optimizer)
-@variable(model, x[1:3] >= 0)
-@constraint(model, sum(x) <= 1)
+model = Model(SCS.Optimizer);
+@variable(model, x[1:3] >= 0);
+@constraint(model, sum(x) <= 1);
 optimize!(model)
 set_optimal_start_values(model)
 using Test # hide

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -735,42 +735,9 @@ julia> dual_start_value(con)
  3.0
 ```
 
-To take the solution from the last solve and use it as the starting point for a
-new solve, use a function like this:
-```@repl
-using JuMP, SCS
-function set_optimal_start_values(model::Model)
-    variable_primal = Dict(x => value(x) for x in all_variables(model))
-    constraint_solution = Dict()
-    for (F, S) in list_of_constraint_types(model)
-        try
-            for ci in all_constraints(model, F, S)
-                constraint_solution[ci] = (value(ci), dual(ci))
-            end
-        catch
-            # Something went wrong, so skip this constraint type.
-        end
-    end
-    for (x, primal_start) in variable_primal
-        set_start_value(x, primal_start)
-    end
-    for (ci, (primal_start, dual_start)) in constraint_solution
-        set_start_value(ci, primal_start)
-        set_dual_start_value(ci, dual_start)
-    end
-    return
-end
-model = Model(SCS.Optimizer);
-@variable(model, x[1:3] >= 0);
-@constraint(model, sum(x) <= 1);
-optimize!(model)
-set_optimal_start_values(model)
-using Test # hide
-@test termination_status(model) == OPTIMIZE_NOT_CALLED # hide
-optimize!(model)
-```
-Note how the second call to `optimize!` terminates after a single iteration
-because it is warm-started from the optimal solution.
+!!! tip
+    For more information, check out the [Primal and dual warm-starts](@ref)
+    tutorial.
 
 ## Constraint containers
 

--- a/docs/src/tutorials/conic/robust_uncertainty.jl
+++ b/docs/src/tutorials/conic/robust_uncertainty.jl
@@ -42,7 +42,7 @@ function example_robust_uncertainty()
         Γ1(𝛿 / 2, N) * LinearAlgebra.norm(c) +
         sqrt((1 - ɛ) / ɛ) *
         sqrt(LinearAlgebra.dot(c, (Σhat + Γ2(𝛿 / 2, N) * I) * c))
-    Test.@test objective_value(model) ≈ exact atol = 1e-3
+    Test.@test objective_value(model) ≈ exact atol = 1e-2
     return
 end
 

--- a/docs/src/tutorials/conic/start_values.jl
+++ b/docs/src/tutorials/conic/start_values.jl
@@ -55,20 +55,28 @@ end
 
 # To test our function, we use the following linear program:
 
-model = Model(SCS.Optimizer)
-@variable(model, x[1:3] >= 0)
-@constraint(model, sum(x) <= 1)
-@objective(model, Max, sum(i * x[i] for i in 1:3))
-optimize!(model);
+function main()
+    model = Model(SCS.Optimizer)
+    @variable(model, x[1:3] >= 0)
+    @constraint(model, sum(x) <= 1)
+    @objective(model, Max, sum(i * x[i] for i in 1:3))
+    optimize!(model)
+    set_optimal_start_values(model)
+    optimize!(model)
+    return
+end
 
-# By looking at the log, we can see that SCS took 11 iterations to find the
-# optimal solution. Now we set the optimal solution as our starting point:
+main()
 
-set_optimal_start_values(model)
+# By looking at the log (not shown in Documenter due to a bug), we can see that
+# SCS took 100 iterations to find the optimal solution. Now we set the optimal
+# solution as our starting point:
+
+# set_optimal_start_values(model)
 
 # and we re-optimize:
 
-optimize!(model);
+# optimize!(model)
 
 # Now the optimization terminates after 0 iterations because our starting point
 # is already optimal.

--- a/docs/src/tutorials/conic/start_values.jl
+++ b/docs/src/tutorials/conic/start_values.jl
@@ -59,8 +59,7 @@ model = Model(SCS.Optimizer)
 @variable(model, x[1:3] >= 0)
 @constraint(model, sum(x) <= 1)
 @objective(model, Max, sum(i * x[i] for i in 1:3))
-optimize!(model)
-nothing
+optimize!(model);
 
 # By looking at the log, we can see that SCS took 11 iterations to find the
 # optimal solution. Now we set the optimal solution as our starting point:
@@ -69,8 +68,7 @@ set_optimal_start_values(model)
 
 # and we re-optimize:
 
-optimize!(model)
-nothing
+optimize!(model);
 
 # Now the optimization terminates after 0 iterations because our starting point
 # is already optimal.

--- a/docs/src/tutorials/conic/start_values.jl
+++ b/docs/src/tutorials/conic/start_values.jl
@@ -65,11 +65,11 @@ optimize!(model)
 # SCS took 100 iterations to find the optimal solution. Now we set the optimal
 # solution as our starting point:
 
-# set_optimal_start_values(model)
+set_optimal_start_values(model)
 
 # and we re-optimize:
 
-# optimize!(model)
+optimize!(model)
 
 # Now the optimization terminates after 0 iterations because our starting point
 # is already optimal.

--- a/docs/src/tutorials/conic/start_values.jl
+++ b/docs/src/tutorials/conic/start_values.jl
@@ -55,18 +55,11 @@ end
 
 # To test our function, we use the following linear program:
 
-function main()
-    model = Model(SCS.Optimizer)
-    @variable(model, x[1:3] >= 0)
-    @constraint(model, sum(x) <= 1)
-    @objective(model, Max, sum(i * x[i] for i in 1:3))
-    optimize!(model)
-    set_optimal_start_values(model)
-    optimize!(model)
-    return
-end
-
-main()
+model = Model(SCS.Optimizer)
+@variable(model, x[1:3] >= 0)
+@constraint(model, sum(x) <= 1)
+@objective(model, Max, sum(i * x[i] for i in 1:3))
+optimize!(model)
 
 # By looking at the log (not shown in Documenter due to a bug), we can see that
 # SCS took 100 iterations to find the optimal solution. Now we set the optimal

--- a/docs/src/tutorials/conic/start_values.jl
+++ b/docs/src/tutorials/conic/start_values.jl
@@ -60,6 +60,7 @@ model = Model(SCS.Optimizer)
 @constraint(model, sum(x) <= 1)
 @objective(model, Max, sum(i * x[i] for i in 1:3))
 optimize!(model)
+nothing
 
 # By looking at the log, we can see that SCS took 11 iterations to find the
 # optimal solution. Now we set the optimal solution as our starting point:
@@ -69,6 +70,7 @@ set_optimal_start_values(model)
 # and we re-optimize:
 
 optimize!(model)
+nothing
 
 # Now the optimization terminates after 0 iterations because our starting point
 # is already optimal.

--- a/docs/src/tutorials/conic/start_values.jl
+++ b/docs/src/tutorials/conic/start_values.jl
@@ -1,0 +1,74 @@
+# Copyright 2017, Iain Dunning, Joey Huchette, Miles Lubin, and contributors    #src
+# This Source Code Form is subject to the terms of the Mozilla Public License   #src
+# v.2.0. If a copy of the MPL was not distributed with this file, You can       #src
+# obtain one at https://mozilla.org/MPL/2.0/.                                   #src
+
+# # Primal and dual warm-starts
+
+# Some conic solvers have the ability to set warm-starts for the primal and dual
+# solution. This can improve performance, particularly if you are repeatedly
+# solving a sequence of related problems.
+
+# In this tutorial, we demonstrate how to write a function that sets the primal
+# and dual starts as the optimal solution stored in a model. It is intended to
+# be a starting point for which you can modify if you want to do something
+# similar in your own code.
+
+# This tutorial uses the following packages:
+
+using JuMP
+import SCS
+
+# The main component of this tutorial is the following function. The most
+# important observation is that we cache all of the solution values first, and
+# then we modify the model second. (Alternating between querying a value and
+# modifying the model is not allowed in JuMP.)
+
+function set_optimal_start_values(model::Model)
+    ## Store a mapping of the variable primal solution
+    variable_primal = Dict(x => value(x) for x in all_variables(model))
+    ## In the following, we loop through every constraint and store a mapping
+    ## from the constraint index to a tuple containing the primal and dual
+    ## solutions.
+    constraint_solution = Dict()
+    for (F, S) in list_of_constraint_types(model)
+        ## We add a try-catch here because some constraint types might not
+        ## support getting the primal or dual solution.
+        try
+            for ci in all_constraints(model, F, S)
+                constraint_solution[ci] = (value(ci), dual(ci))
+            end
+        catch
+            @info("Something went wrong getting $F-in-$S. Skipping")
+        end
+    end
+    ## Now we can loop through our cached solutions and set the starting values.
+    for (x, primal_start) in variable_primal
+        set_start_value(x, primal_start)
+    end
+    for (ci, (primal_start, dual_start)) in constraint_solution
+        set_start_value(ci, primal_start)
+        set_dual_start_value(ci, dual_start)
+    end
+    return
+end
+
+# To test our function, we use the following linear program:
+
+model = Model(SCS.Optimizer)
+@variable(model, x[1:3] >= 0)
+@constraint(model, sum(x) <= 1)
+@objective(model, Max, sum(i * x[i] for i in 1:3))
+optimize!(model)
+
+# By looking at the log, we can see that SCS took 11 iterations to find the
+# optimal solution. Now we set the optimal solution as our starting point:
+
+set_optimal_start_values(model)
+
+# and we re-optimize:
+
+optimize!(model)
+
+# Now the optimization terminates after 0 iterations because our starting point
+# is already optimal.


### PR DESCRIPTION
Closes #2836

I decided that it just needed some documentation. There are too many edge-cases for a useful function in JuMP.

- [ ] Also experimenting with an `@example` block here, but will need to check how it looks in the preview: https://jump.dev/JuMP.jl/previews/PR2861/manual/constraints/#Start-values

hmm. It didn't produce any output:
![image](https://user-images.githubusercontent.com/8177701/152454285-3280c82b-c4bf-4729-a296-994735d80564.png)
