### PR TITLE
[docs] fix typo in design patterns tutorial

### DIFF
--- a/docs/src/tutorials/getting_started/design_patterns_for_larger_models.jl
+++ b/docs/src/tutorials/getting_started/design_patterns_for_larger_models.jl
@@ -68,7 +68,7 @@ value.(x)
 #  * the solution, `x[i]`, is hard to interpret without knowing the order in
 #    which we provided the data.
 
-# ## Wrap the model in a fuction
+# ## Wrap the model in a function
 
 # A good next step is to wrap your model in a function. This is useful for a few
 # reasons:


### PR DESCRIPTION
Found by @geoffleyland:  I guess no one else reads the headers.