### PR TITLE
[breaking] remove PrintMode instead of explicit MIME types

### DIFF
--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -1403,7 +1403,7 @@ function Base.show(io::IO, wrapper::_ParameterPrintWrapper)
         end
     end
     # No named parameter; use a generic name.
-    if wrapper.mode == IJuliaMode
+    if wrapper.mode == MIME("text/latex")
         print(io, "parameter_{$(p.index)}")
     else
         print(io, "parameter[$(p.index)]")
@@ -1417,7 +1417,7 @@ mutable struct _SubexpressionPrintWrapper
 end
 
 function Base.show(io::IO, s::_SubexpressionPrintWrapper)
-    if s.mode == IJuliaMode
+    if s.mode == MIME("text/latex")
         print(io, "subexpression_{$(s.idx)}")
     else
         print(io, "subexpression[$(s.idx)]")
@@ -1436,7 +1436,7 @@ function _tape_to_expr(
     user_operators::_Derivatives.UserOperatorRegistry,
     generic_variable_names::Bool,
     splat_subexpressions::Bool,
-    print_mode = REPLMode,
+    print_mode = MIME("text/plain"),
 )
     children_arr = rowvals(adj)
 

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -777,8 +777,8 @@ function test_Nonliteral_exponents_in_constraint()
 end
 
 function test_AffExpr_in_macros()
-    eq = JuMP._math_symbol(REPLMode, :eq)
-    ge = JuMP._math_symbol(REPLMode, :geq)
+    eq = JuMP._math_symbol(MIME("text/plain"), :eq)
+    ge = JuMP._math_symbol(MIME("text/plain"), :geq)
 
     model = Model()
     @variable(model, x)
@@ -795,8 +795,8 @@ function test_AffExpr_in_macros()
 end
 
 function test_constraints()
-    eq = JuMP._math_symbol(REPLMode, :eq)
-    ge = JuMP._math_symbol(REPLMode, :geq)
+    eq = JuMP._math_symbol(MIME("text/plain"), :eq)
+    ge = JuMP._math_symbol(MIME("text/plain"), :geq)
     model = Model()
     @variable(model, x)
     @variable(model, y[1:3])


### PR DESCRIPTION
Closes #2814 

This is breaking for a few JuMP extensions. But it should just be a small find-and-replace of 
 * `::Type{REPLMode}` -> `::MIME"text/plain"`
 * `REPLMode` -> `MIME("text/plain")`
 *  `::Type{IJuliaMode}` -> `::MIME"text/latex"`
 * `IJuliaMode` -> `MIME("text/latex")`.

Using MIME types make it clearer what is happening (we use IJuliaMode in more than just IJulia), and it's also more extensible to other printing types in future.