### PR TITLE
Prep for v0.23

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuMP"
 uuid = "4076af6c-e467-56ae-b986-b466b2749572"
 repo = "https://github.com/jump-dev/JuMP.jl.git"
-version = "1.0.0-DEV"
+version = "0.23.0"
 
 [deps]
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ embedded in [Julia](https://julialang.org/). You can find out more about us by
 visiting [jump.dev](https://jump.dev).
 
 
-**Latest Release**: [![version](https://juliahub.com/docs/JuMP/DmXqY/0.22.3/version.svg)](https://juliahub.com/ui/Packages/JuMP/DmXqY/0.22.3) (`release-0.22` branch):
+**Latest Release**: [![version](https://juliahub.com/docs/JuMP/DmXqY/0.23.0/version.svg)](https://juliahub.com/ui/Packages/JuMP/DmXqY/0.23.0) (`release-0.23` branch):
   * Installation via the Julia package manager:
     * `import Pkg; Pkg.add("JuMP")`
   * Get help:

--- a/docs/src/developers/roadmap.md
+++ b/docs/src/developers/roadmap.md
@@ -5,53 +5,6 @@ community. The JuMP developers have compiled this roadmap document to
 share their plans and goals. Contributions to roadmap issues are especially
 invited.
 
-## JuMP 1.0
-
-JuMP 1.0 will be ready to release roughly when all of these tasks are completed.
-Some but not all of these tasks are summarized in the
-[JuMP 1.0 milestone](https://github.com/jump-dev/JuMP.jl/milestone/12).
-
-- Create a website for JuMP (**Done**: [jump.dev](https://jump.dev))
-- Deprecate the JuliaOpt organization and move repositories to the
-  [JuMP-dev](https://github.com/JuMP-dev) organization (**Done**)
-- Address major regressions from JuMP 0.18
-  - Performance ([#1403](https://github.com/jump-dev/JuMP.jl/issues/1403),
-                 [#1654](https://github.com/jump-dev/JuMP.jl/issues/1654),
-                 [#1607](https://github.com/jump-dev/JuMP.jl/issues/1607))
-  - Callbacks (**Done**: see `examples/callbacks.jl`)
-  - Column generation syntax (**Done**: see `examples/cutting_stock_column_generation.jl`)
-  - Support for second-order cones in Gurobi, CPLEX, and Xpress (**Done**)
-- Fix issues that we promised MOI would fix
-  - Checking feasibility of solutions (**Done**: [#2466](https://github.com/jump-dev/JuMP.jl/pull/2466))
-  - Accessing IIS (**Done**: see [Conflicts](@ref))
-  - Accessing multiple results from solvers (**Done**: [Gurobi#392](https://github.com/jump-dev/Gurobi.jl/pull/392))
-  - Dual warm-starts (**Done**: [#2214](https://github.com/jump-dev/JuMP.jl/pull/2214))
-- Address "easy" usability issues
-  - Line numbers in error messages (**Done**: [#2276](https://github.com/jump-dev/JuMP.jl/pull/2276))
-  - LP sensitivity summary (**Done**: see [Sensitivity analysis for LP](@ref))
-  - Inferred element types for collections in macros (**Done**: [#2070](https://github.com/jump-dev/JuMP.jl/pull/2070))
-  - Expose solver-independent options from JuMP (**Done**: see [`set_silent`](@ref) etc.)
-- Improve the documentation ([#1062](https://github.com/jump-dev/JuMP.jl/issues/1062))
-  - Separate how-to, concept explanation, and technical reference following the
-    [Divio recommendations](https://www.divio.com/blog/documentation/) (**Done**)
-  - Fully integrate [JuMPTutorials](https://github.com/jump-dev/JuMPTutorials.jl)
-    with JuMP's documentation (**Done**)
-- Developer experience
-  - Get JuMP's unit tests running faster. See [#1745](https://github.com/jump-dev/JuMP.jl/pull/1745). (**Done**)
-- All solvers should complete the transition to MOI (**Done**)
-- Provide packages for installing Bonmin and Couenne (**Done**)
-- [MathOptFormat](https://github.com/odow/MathOptFormat.jl) 1.0 (**Done**)
-
-## MOI 1.0
-
 ```@meta
-# TODO: List MOI 1.0 items here.
-```
-
-## Beyond JuMP 1.0
-
-```@meta
-# TODO: Copy over list of items not tied to JuMP 1.0. These should have more
-# elaborate explanations so that potential contributors know what we mean,
-# i.e., a few sentences each or a link to a document/issue.
+# TODO: the roadmap should be re-written for the post-JuMP 1.0 world.
 ```

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -1,6 +1,54 @@
 # Release notes
 
-## Version 0.22.3 (February 10, 2021)
+## Version 0.23.0 (February 25, 2022)
+
+**JuMP v0.23.0 is a breaking release. It is also a release-candidate for JuMP
+v1.0.0. That is, if no issues are found with the v0.23.0 release, then it will
+be re-tagged as v1.0.0.**
+
+- Breaking changes:
+  - Julia 1.6 is now the minimum supported version
+  - All previously deprecated functionality has been removed
+  - `PrintMode`, `REPLMode` and `IJuliaMode` have been removed in favor of the
+    MIME types `MIME"text/plain"` and `MIME"text/latex"`. Replace instances of
+    `::Type{REPLMode}` with `::MIME"text/plain"`, `REPLMode` with
+    `MIME("text/plain")`, `::Type{IJuliaMode}` with `::MIME"text/latex"`, and
+    `IJuliaMode` with `MIME("text/latex")`.
+  - Functions containing the `nl_` acronym have been renamed to the more
+    explicit `nonlinear_`. For example, `num_nl_constraints` is now
+    `num_nonlinear_constraints` and `set_NL_objective` is now
+    `set_nonlinear_objective`. Calls to the old functions throw an error
+    explaining the new name.
+  - `SymMatrixSpace` has been renamed to `SymmetricMatrixSpace`
+- New features:
+  - Added `nonlinear_dual_start_value` and `set_nonlinear_dual_start_value`
+  - Added preliminary support for `Complex` coefficient types
+- Bug fixes:
+  - Fixed a bug in `solution_summary`
+- Documentation, maintenance:
+  - MILP examples have been migrated from GLPK to HiGHS
+  - Fixed various typos
+  - Improved section on setting constraint start values
+
+### Troubleshooting problems when updating
+
+If you experience problems when updating, you are likely using previously
+deprecated functionality. (By default, Julia does not warn when you use
+deprecated features.)
+
+To find the deprecated features you are using, start Julia with `--depwarn=yes`:
+```
+$ julia --depwarn=yes
+```
+Then install JuMP v0.22.3:
+```julia
+julia> using Pkg
+julia> pkg"add JuMP@0.22.3"
+```
+And then run your code. Apply any suggestions, or search the release notes below
+for advice on updating a specific deprecated feature.
+
+## Version 0.22.3 (February 10, 2022)
 
 - New features:
   - There are no new features in this release.
@@ -17,7 +65,7 @@
   - Updated documentation to MOI v0.10.8
   - Updated JuliaFormatter to v0.22.2
 
-## Version 0.22.2 (January 10, 2021)
+## Version 0.22.2 (January 10, 2022)
 
 - New features:
   - The function `all_nl_constraints` now returns all nonlinear constraints

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -8,6 +8,7 @@ be re-tagged as v1.0.0.**
 
 - Breaking changes:
   - Julia 1.6 is now the minimum supported version
+  - MathOptInterface has been updated to v1.0.0
   - All previously deprecated functionality has been removed
   - `PrintMode`, `REPLMode` and `IJuliaMode` have been removed in favor of the
     MIME types `MIME"text/plain"` and `MIME"text/latex"`. Replace instances of


### PR DESCRIPTION
As discussed on the monthly call, v0.23 is being tagged as a RC for JuMP 1.0.