### PR TITLE
Add complex and real affine expressions

### DIFF
--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -385,9 +385,9 @@ function add_to_expression!(aff::GenericAffExpr{C,V}, new_var::V) where {C,V}
 end
 
 function add_to_expression!(
-    aff::GenericAffExpr{C,V},
-    other::GenericAffExpr{C,V},
-) where {C,V}
+    aff::GenericAffExpr{S,V},
+    other::GenericAffExpr{T,V},
+) where {S,T,V}
     # Note: merge!() doesn't appear to call sizehint!(). Is this important?
     merge!(+, aff.terms, other.terms)
     aff.constant += other.constant

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -2,6 +2,8 @@ module TestComplexNumberSupport
 
 using JuMP
 using Test
+import MutableArithmetics
+const MA = MutableArithmetics
 
 function runtests()
     for name in names(@__MODULE__; all = true)
@@ -48,6 +50,19 @@ function test_complex_aff_expr_convert()
     @test typeof(y_int) == GenericAffExpr{Complex{Int},VariableRef}
     @test y_int == y
     @test_throws InexactError convert(AffExpr, y)
+    return
+end
+
+function test_complex_add_aff()
+    model = Model()
+    @variable(model, x)
+    real_aff = 3x - 1
+    complex_aff = (1 + 2im) * x + 1
+    @test complex_aff == MA.@rewrite((1 + 2im) * x + 1)
+    @test complex_aff == MA.@rewrite(1 + (1 + 2im) * x)
+    @test complex_aff == MA.@rewrite(1 + (2im) * x + x)
+    @test real_aff + complex_aff == complex_aff + real_aff
+    @test real_aff - complex_aff == -(complex_aff - real_aff)
     return
 end
 


### PR DESCRIPTION
Before this PR, there was:
```julia
julia> 1 * x + im * x
ERROR: MethodError: no method matching +(::AffExpr, ::GenericAffExpr{ComplexF64, VariableRef})
Closest candidates are:
  +(::Any, ::Any, ::Any, ::Any...) at ~/packages/julias/julia-1.7.2/share/julia/base/operators.jl:655
  +(::Union{MathOptInterface.ScalarAffineFunction{T}, MathOptInterface.ScalarQuadraticFunction{T}}, ::T) where T at ~/.julia/packages/MathOptInterface/eoIu0/src/Utilities/functions.jl:1787
  +(::GenericAffExpr{C, V}, ::GenericAffExpr{C, V}) where {C, V<:AbstractJuMPScalar} at ~/.julia/dev/JuMP/src/operators.jl:217
  ...
Stacktrace:
 [1] top-level scope
   @ REPL[8]:1

julia> im * x - 1 * x
ERROR: MethodError: no method matching -(::GenericAffExpr{ComplexF64, VariableRef}, ::AffExpr)
Closest candidates are:
  -(::Union{MathOptInterface.ScalarAffineFunction{T}, MathOptInterface.ScalarQuadraticFunction{T}}, ::T) where T at ~/.julia/packages/MathOptInterface/eoIu0/src/Utilities/functions.jl:1799
  -(::GenericAffExpr{C, V}, ::GenericAffExpr{C, V}) where {C, V<:AbstractJuMPScalar} at ~/.julia/dev/JuMP/src/operators.jl:236
  -(::GenericAffExpr{C, V}, ::V) where {C, V<:AbstractVariableRef} at ~/.julia/dev/JuMP/src/operators.jl:190
  ...
Stacktrace:
 [1] top-level scope
   @ REPL[13]:1
```