### PR TITLE
Fix variable bounds passed as Rational{Int}(Inf)

### DIFF
--- a/src/variables.jl
+++ b/src/variables.jl
@@ -138,7 +138,7 @@ struct VariableInfo{S,T,U,V}
         if has_fix && !_isfinite(fixed_value)
             error("Unable to fix variable to $(fixed_value)")
         end
-        return new{S,T,U,V}(
+        return new{typeof(lower_bound),typeof(upper_bound),U,V}(
             has_lb,
             lower_bound,
             has_ub,

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -1025,6 +1025,15 @@ function test_Model_error_messages(::Any, ::Any)
     return
 end
 
+function test_rational_inf_bounds()
+    model = Model()
+    u = Rational{Int}(Inf)
+    @variable(model, -u <= x <= u)
+    @test has_lower_bound(x) == false
+    @test has_upper_bound(x) == false
+    return
+end
+
 function runtests()
     for name in names(@__MODULE__; all = true)
         if !startswith("$(name)", "test_")

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -1025,8 +1025,8 @@ function test_Model_error_messages(::Any, ::Any)
     return
 end
 
-function test_rational_inf_bounds()
-    model = Model()
+function test_rational_inf_bounds(ModelType, ::Any)
+    model = ModelType()
     u = Rational{Int}(Inf)
     @variable(model, -u <= x <= u)
     @test has_lower_bound(x) == false


### PR DESCRIPTION
Closes #2894 

cc @schillic this fixes the problem, but I'd still advise you to not use Rational coefficients (until JuMP officially supports them), and to not add `Inf` bounds. They're both slightly misleading as to what will actually happen, compared to what someone reading the code might think will happen.