### PR TITLE
Fix printing of im coefficient

### DIFF
--- a/src/print.jl
+++ b/src/print.jl
@@ -47,7 +47,13 @@ Base.print(io::IO, model::AbstractModel) = _print_model(io, model)
 _is_zero_for_printing(coef) = abs(coef) < 1e-10 * oneunit(coef)
 
 # Whether something is one or not for the purposes of printing it.
-_is_one_for_printing(coef) = _is_zero_for_printing(abs(coef) - oneunit(coef))
+function _is_one_for_printing(coef::Real)
+    _is_zero_for_printing(abs(coef) - oneunit(coef))
+end
+
+function _is_one_for_printing(coef::Complex)
+    _is_one_for_printing(real(coef)) && _is_zero_for_printing(imag(coef))
+end
 
 function _is_zero_for_printing(coef::Complex)
     return _is_zero_for_printing(real(coef)) &&

--- a/src/print.jl
+++ b/src/print.jl
@@ -47,12 +47,12 @@ Base.print(io::IO, model::AbstractModel) = _print_model(io, model)
 _is_zero_for_printing(coef) = abs(coef) < 1e-10 * oneunit(coef)
 
 # Whether something is one or not for the purposes of printing it.
-function _is_one_for_printing(coef::Real)
-    _is_zero_for_printing(abs(coef) - oneunit(coef))
+function _is_one_for_printing(coef)
+    return _is_zero_for_printing(abs(coef) - oneunit(coef))
 end
 
 function _is_one_for_printing(coef::Complex)
-    _is_one_for_printing(real(coef)) && _is_zero_for_printing(imag(coef))
+    return _is_one_for_printing(real(coef)) && _is_zero_for_printing(imag(coef))
 end
 
 function _is_zero_for_printing(coef::Complex)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -65,6 +65,8 @@ function test_complex_print()
     @variable(model, x)
     y = (1 + 2im) * x + 1
     @test sprint(show, y) == "(1.0 + 2.0im) x + (1.0 + 0.0im)"
+    y = im * x
+    @test sprint(show, y) == "(0.0 + 1.0im) x"
     return
 end
 


### PR DESCRIPTION
Before this PR, `im * x` would just print as `x`.