### PR TITLE
Fix solution_summary with empty model

### DIFF
--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -77,7 +77,7 @@ julia> solution_summary(model, verbose=true)
     y[a] : 1.00000e+00
     y[b] : 1.00000e+00
   Dual solution :
-    c1 : 1.71429+00
+    c1 : 1.71429e+00
 
 * Work counters
   Solve time (sec)   : 3.86953e-04

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -37,7 +37,7 @@ Subject to
 
 [`solution_summary`](@ref) can be used for checking the summary of the optimization solutions.
 
-```jldoctest solutions; filter=r"[0-9]+.[0-9]+"
+```jldoctest solutions; filter=r"[0-9]+.[0-9]+[\+-]e[0-9]+"
 julia> solution_summary(model)
 * Solver : HiGHS
 
@@ -49,12 +49,12 @@ julia> solution_summary(model)
   "kOptimal"
 
 * Candidate solution
-  Objective value      : -205.14285714285714
-  Objective bound      : -0.0
-  Dual objective value : -205.1428571428571
+  Objective value      : -2.05143e+02
+  Objective bound      : -0.00000e+00
+  Dual objective value : -2.05143e+02
 
 * Work counters
-  Solve time (sec)   : 0.00068
+  Solve time (sec)   : 3.86953e-04
 
 julia> solution_summary(model, verbose=true)
 * Solver : HiGHS
@@ -69,18 +69,18 @@ julia> solution_summary(model, verbose=true)
   "kOptimal"
 
 * Candidate solution
-  Objective value      : -205.14285714285714
-  Objective bound      : -0.0
-  Dual objective value : -205.1428571428571
+  Objective value      : -2.05143e+02
+  Objective bound      : -0.00000e+00
+  Dual objective value : -2.05143e+02
   Primal solution :
-    x : 15.428571428571429
-    y[a] : 1.0
-    y[b] : 1.0
+    x : 1.54286e+01
+    y[a] : 1.00000e+00
+    y[b] : 1.00000e+00
   Dual solution :
-    c1 : 1.7142857142857142
+    c1 : 1.57143+00
 
 * Work counters
-  Solve time (sec)   : 0.00068
+  Solve time (sec)   : 3.86953e-04
 ```
 
 ## Why did the solver stop?

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -37,7 +37,7 @@ Subject to
 
 [`solution_summary`](@ref) can be used for checking the summary of the optimization solutions.
 
-```jldoctest solutions; filter=r"[0-9]+.[0-9]+[\+-]e[0-9]+"
+```jldoctest solutions; filter=r"[0-9]+\.[0-9]+e[\+\-][0-9]+"
 julia> solution_summary(model)
 * Solver : HiGHS
 

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -77,7 +77,7 @@ julia> solution_summary(model, verbose=true)
     y[a] : 1.00000e+00
     y[b] : 1.00000e+00
   Dual solution :
-    c1 : 1.57143+00
+    c1 : 1.71429+00
 
 * Work counters
   Solve time (sec)   : 3.86953e-04

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -689,6 +689,9 @@ Return the reason why the solver stopped in its own words (i.e., the
 MathOptInterface model attribute `RawStatusString`).
 """
 function raw_status(model::Model)
+    if MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
+        return "optimize not called"
+    end
     return MOI.get(model, MOI.RawStatusString())
 end
 

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -202,5 +202,8 @@ Return the number of results available to query after a call to
 [`optimize!`](@ref).
 """
 function result_count(model::Model)::Int
+    if termination_status(model) == MOI.OPTIMIZE_NOT_CALLED
+        return 0
+    end
     return MOI.get(model, MOI.ResultCount())
 end

--- a/src/solution_summary.jl
+++ b/src/solution_summary.jl
@@ -211,6 +211,6 @@ end
 _print_if_not_missing(io, header, ::Missing) = nothing
 _print_if_not_missing(io, header, value::Int) = println(io, header, value)
 function _print_if_not_missing(io, header, value::Real)
-    println(io, header, Printf.@sprintf("%.5f", value))
+    println(io, header, Printf.@sprintf("%.5e", value))
     return
 end

--- a/src/solution_summary.jl
+++ b/src/solution_summary.jl
@@ -126,11 +126,9 @@ function _show_candidate_solution_summary(io::IO, summary::_SolutionSummary)
     if summary.verbose && summary.has_values
         println(io, "  Primal solution :")
         for variable_name in sort(collect(keys(summary.primal_solution)))
-            println(
+            _print_if_not_missing(
                 io,
-                "    ",
-                variable_name,
-                " : ",
+                "    $(variable_name) : ",
                 summary.primal_solution[variable_name],
             )
         end
@@ -138,11 +136,9 @@ function _show_candidate_solution_summary(io::IO, summary::_SolutionSummary)
     if summary.verbose && summary.has_duals
         println(io, "  Dual solution :")
         for constraint_name in sort(collect(keys(summary.dual_solution)))
-            println(
+            _print_if_not_missing(
                 io,
-                "    ",
-                constraint_name,
-                " : ",
+                "    $(constraint_name) : ",
                 summary.dual_solution[constraint_name],
             )
         end

--- a/src/solution_summary.jl
+++ b/src/solution_summary.jl
@@ -156,7 +156,7 @@ function _show_work_counters_summary(io::IO, summary::_SolutionSummary)
     _print_if_not_missing(
         io,
         "  Solve time (sec)   : ",
-        Printf.@sprintf("%.5f", summary.solve_time),
+        summary.solve_time,
     )
     _print_if_not_missing(
         io,
@@ -209,4 +209,8 @@ function _try_get(f, model)
 end
 
 _print_if_not_missing(io, header, ::Missing) = nothing
-_print_if_not_missing(io, header, value) = println(io, header, value)
+_print_if_not_missing(io, header, value::Int) = println(io, header, value)
+function _print_if_not_missing(io, header, value::Real)
+    println(io, header, Printf.@sprintf("%.5f", value))
+    return
+end

--- a/test/solution_summary.jl
+++ b/test/solution_summary.jl
@@ -76,12 +76,12 @@ end
   "solver specific string"
 
 * Candidate solution
-  Objective value      : -1.0
-  Objective bound      : 3.0
-  Dual objective value : -1.0
+  Objective value      : -1.00000e+00
+  Objective bound      : 3.00000e+00
+  Dual objective value : -1.00000e+00
 
 * Work counters
-  Solve time (sec)   : 5.00000
+  Solve time (sec)   : 5.00000e+00
   Simplex iterations : 3
   Barrier iterations : 2
   Node count         : 1
@@ -102,16 +102,16 @@ end
   "solver specific string"
 
 * Candidate solution
-  Objective value      : -1.0
-  Objective bound      : 3.0
-  Dual objective value : -1.0
+  Objective value      : -1.00000e+00
+  Objective bound      : 3.00000e+00
+  Dual objective value : -1.00000e+00
   Primal solution :
     x : 1.0
     y : 0.0
   Dual solution :
 
 * Work counters
-  Solve time (sec)   : 5.00000
+  Solve time (sec)   : 5.00000e+00
   Simplex iterations : 3
   Barrier iterations : 2
   Node count         : 1

--- a/test/solution_summary.jl
+++ b/test/solution_summary.jl
@@ -106,8 +106,8 @@ end
   Objective bound      : 3.00000e+00
   Dual objective value : -1.00000e+00
   Primal solution :
-    x : 1.0
-    y : 0.0
+    x : 1.00000e+00
+    y : 0.00000e+00
   Dual solution :
 
 * Work counters

--- a/test/solution_summary.jl
+++ b/test/solution_summary.jl
@@ -6,6 +6,24 @@
 using JuMP
 using Test
 
+@testset "Empty model" begin
+    model = Model()
+    @test sprint(show, solution_summary(model)) == """
+* Solver : No optimizer attached.
+
+* Status
+  Termination status : OPTIMIZE_NOT_CALLED
+  Primal status      : NO_SOLUTION
+  Dual status        : NO_SOLUTION
+  Message from the solver:
+  "optimize not called"
+
+* Candidate solution
+
+* Work counters
+"""
+end
+
 @testset "Print solution summary" begin
     model = Model()
     @variable(model, x <= 2.0)


### PR DESCRIPTION
Calling `solution_summary` on an empty model exposed a few issues.

Closes https://github.com/jump-dev/MathOptInterface.jl/pull/1747