### PR TITLE
Add checked autodiff for user-defined functions

### DIFF
--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -1925,7 +1925,7 @@ function _UserFunctionEvaluator(
 ) where {T}
     g = x -> f(x...)
     cfg = ForwardDiff.GradientConfig(g, zeros(T, dimension))
-    ∇f = function(out, y)
+    ∇f = function (out, y)
         try
             ForwardDiff.gradient!(out, g, y, cfg)
         catch err
@@ -1996,7 +1996,7 @@ function _validate_register_assumptions(
 end
 
 function _checked_derivative(f::F, s) where {F}
-    return function(x)
+    return function (x)
         try
             return ForwardDiff.derivative(f, x)
         catch err

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -1321,6 +1321,24 @@ function test_user_defined_function_checked_error_univariate()
     return
 end
 
+function test_user_defined_function_checked_error_univariate_other_error()
+    function f(x)
+        if typeof(x) != Float64
+            error("not differentiable")
+        end
+        return (x - 1)^2
+    end
+    model = Model()
+    @variable(model, x)
+    register(model, :f, 1, f; autodiff = true)
+    @NLobjective(model, Min, f(x))
+    nlp = NLPEvaluator(model)
+    MOI.initialize(nlp, Symbol[:Grad])
+    err = ErrorException("not differentiable")
+    @test_throws(err, MOI.eval_objective_gradient(nlp, [NaN], [2.0]))
+    return
+end
+
 function test_user_defined_function_checked_error_univariate()
     f(x) = (x - 1)^2
     function ∇f(x)

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -1315,7 +1315,7 @@ function test_user_defined_function_checked_error_univariate()
     @test g == [-2.0]
     err = ErrorException(
         "JuMP's autodiff of the user-defined function f failed with a " *
-         "MethodError.\n\n$(JuMP._FORWARD_DIFF_METHOD_ERROR_HELPER)",
+        "MethodError.\n\n$(JuMP._FORWARD_DIFF_METHOD_ERROR_HELPER)",
     )
     @test_throws(err, MOI.eval_objective_gradient(nlp, g, [2.0]))
     return
@@ -1343,7 +1343,7 @@ function test_user_defined_function_checked_error_univariate()
     @test H == [2.0]
     err = ErrorException(
         "JuMP's autodiff of the user-defined function f failed with a " *
-         "MethodError.\n\n$(JuMP._FORWARD_DIFF_METHOD_ERROR_HELPER)",
+        "MethodError.\n\n$(JuMP._FORWARD_DIFF_METHOD_ERROR_HELPER)",
     )
     @test_throws(
         err,
@@ -1373,7 +1373,7 @@ function test_user_defined_function_checked_error_multivariate()
     @test g == [-2.0, 1.0]
     err = ErrorException(
         "JuMP's autodiff of the user-defined function f failed with a " *
-         "MethodError.\n\n$(JuMP._FORWARD_DIFF_METHOD_ERROR_HELPER)",
+        "MethodError.\n\n$(JuMP._FORWARD_DIFF_METHOD_ERROR_HELPER)",
     )
     @test_throws(err, MOI.eval_objective_gradient(nlp, g, [2.0, 1.0]))
     return


### PR DESCRIPTION
@ccoffrin's other suggestion in #2910 

Closes #2910

TODOs
 - [x] Benchmark
 - [x] Tests

Assume we wrote a weird function that's only differentiable on part of it's domain:
````Julia
julia> using JuMP

julia> import Ipopt

julia> function f(x)
           if x >= 1
               y = zeros(1)
               y[1] = (x - 1)^2
               return y[1]
           else
               return (x - 1)^2
           end
       end
f (generic function with 1 method)

julia> model = Model(Ipopt.Optimizer)
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: EMPTY_OPTIMIZER
Solver name: Ipopt

julia> @variable(model, x >= 0)
x

julia> @NLobjective(model, Min, f(x))
┌ Warning: Function f automatically registered with 1 arguments.
│ 
│ Calling the function with a different number of arguments will result in an
│ error.
│ 
│ While you can safely ignore this warning, we recommend that you manually
│ register the function as follows:
│ ```Julia
│ model = Model()
│ register(model, :f, 1, f; autodiff = true)
│ ```
└ @ JuMP ~/.julia/dev/JuMP/src/parse_nlp.jl:21

julia> optimize!(model)

******************************************************************************
This program contains Ipopt, a library for large-scale nonlinear optimization.
 Ipopt is released as open source code under the Eclipse Public License (EPL).
         For more information visit https://github.com/coin-or/Ipopt
******************************************************************************

This is Ipopt version 3.14.4, running with linear solver MUMPS 5.4.1.

Number of nonzeros in equality constraint Jacobian...:        0
Number of nonzeros in inequality constraint Jacobian.:        0
Number of nonzeros in Lagrangian Hessian.............:        1

Total number of variables............................:        1
                     variables with only lower bounds:        1
                variables with lower and upper bounds:        0
                     variables with only upper bounds:        0
Total number of equality constraints.................:        0
Total number of inequality constraints...............:        0
        inequality constraints with only lower bounds:        0
   inequality constraints with lower and upper bounds:        0
        inequality constraints with only upper bounds:        0

iter    objective    inf_pr   inf_du lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls
   0  9.8010002e-01 0.00e+00 2.98e+00  -1.0 0.00e+00    -  0.00e+00 0.00e+00   0
   1  7.6134183e-01 0.00e+00 1.76e+00  -1.0 1.17e-01    -  3.61e-01 1.00e+00f  1
ERROR: JuMP's autodiff of the user-defined function f failed with a MethodError.

Common reasons for this include:

 * the function assumes `Float64` will be passed as input, it must work for any
   generic `Real` type.
 * the function allocates temporary storage using `zeros(3)` or similar. This
   defaults to `Float64`, so use `zeros(T, 3)` instead.

As an example, instead of:
```julia
function my_function(x::Float64...)
    y = zeros(length(x))
    for i in 1:length(x)
        y[i] = x[i]^2
    end
    return sum(y)
end
```
use:
```julia
function my_function(x::T...) where {T<:Real}
    y = zeros(T, length(x))
    for i in 1:length(x)
        y[i] = x[i]^2
    end
    return sum(y)
end
```

Review the stacktrace below for more information, but it can often be hard to
understand why and where your function is failing. You can also debug this
outside of JuMP as follows:
```julia
import ForwardDiff

# If the input dimension is 1
x = 1.0
my_function(a) = a^2
ForwardDiff.derivative(my_function, x)

# If the input dimension is more than 1
x = [1.0, 2.0]
my_function(a, b) = a^2 + b^2
ForwardDiff.gradient(x -> my_function(x...), x)
```

Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:33
  [2] _intercept_ForwardDiff_MethodError(#unused#::MethodError, s::Symbol)
    @ JuMP ~/.julia/dev/JuMP/src/nlp.jl:1914
  [3] (::JuMP.var"#139#140"{typeof(f), Symbol})(x::Float64)
    @ JuMP ~/.julia/dev/JuMP/src/nlp.jl:2003
  [4] eval_and_check_return_type(func::Function, RetType::Type, args::Float64)
    @ JuMP._Derivatives ~/.julia/dev/JuMP/src/_Derivatives/forward.jl:5
  [5] forward_eval(storage::Vector{Float64}, partials_storage::Vector{Float64}, nd::Vector{JuMP._Derivatives.NodeData}, adj::SparseArrays.SparseMatrixCSC{Bool, Int64}, const_values::Vector{Float64}, parameter_values::Vector{Float64}, x_values::Vector{Float64}, subexpression_values::Vector{Float64}, user_input_buffer::Vector{Float64}, user_output_buffer::Vector{Float64}, user_operators::JuMP._Derivatives.UserOperatorRegistry)
    @ JuMP._Derivatives ~/.julia/dev/JuMP/src/_Derivatives/forward.jl:213
  [6] _forward_eval_all(d::NLPEvaluator, x::Vector{Float64})
    @ JuMP ~/.julia/dev/JuMP/src/nlp.jl:773
  [7] macro expansion
    @ ~/.julia/dev/JuMP/src/nlp.jl:826 [inlined]
  [8] macro expansion
    @ ./timing.jl:287 [inlined]
  [9] eval_objective(d::NLPEvaluator, x::Vector{Float64})
    @ JuMP ~/.julia/dev/JuMP/src/nlp.jl:824
 [10] _eval_objective(model::Ipopt.Optimizer, x::Vector{Float64})
    @ Ipopt ~/.julia/packages/Ipopt/M2QE8/src/MOI_wrapper.jl:821
 [11] (::Ipopt.var"#eval_f_cb#3"{Ipopt.Optimizer})(x::Vector{Float64})
    @ Ipopt ~/.julia/packages/Ipopt/M2QE8/src/MOI_wrapper.jl:1081
 [12] _Eval_F_CB(n::Int32, x_ptr::Ptr{Float64}, x_new::Int32, obj_value::Ptr{Float64}, user_data::Ptr{Nothing})
    @ Ipopt ~/.julia/packages/Ipopt/M2QE8/src/C_wrapper.jl:33
 [13] IpoptSolve(prob::Ipopt.IpoptProblem)
    @ Ipopt ~/.julia/packages/Ipopt/M2QE8/src/C_wrapper.jl:433
 [14] optimize!(model::Ipopt.Optimizer)
    @ Ipopt ~/.julia/packages/Ipopt/M2QE8/src/MOI_wrapper.jl:1225
 [15] optimize!
    @ ~/.julia/packages/MathOptInterface/FHFUH/src/Bridges/bridge_optimizer.jl:348 [inlined]
 [16] optimize!
    @ ~/.julia/packages/MathOptInterface/FHFUH/src/MathOptInterface.jl:81 [inlined]
 [17] optimize!(m::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.Bridges.LazyBridgeOptimizer{Ipopt.Optimizer}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}})
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/FHFUH/src/Utilities/cachingoptimizer.jl:313
 [18] optimize!(model::Model; ignore_optimize_hook::Bool, kwargs::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ JuMP ~/.julia/dev/JuMP/src/optimizer_interface.jl:161
 [19] optimize!(model::Model)
    @ JuMP ~/.julia/dev/JuMP/src/optimizer_interface.jl:143
 [20] top-level scope
    @ REPL[8]:1

caused by: MethodError: no method matching extract_derivative(::Type{ForwardDiff.Tag{typeof(f), Float64}}, ::String)
Closest candidates are:
  extract_derivative(::Type{T}, ::ForwardDiff.Dual) where T at /Users/oscar/.julia/packages/ForwardDiff/PBzup/src/derivative.jl:81
  extract_derivative(::Type{T}, ::Real) where T at /Users/oscar/.julia/packages/ForwardDiff/PBzup/src/derivative.jl:82
  extract_derivative(::Type{T}, ::AbstractArray) where T at /Users/oscar/.julia/packages/ForwardDiff/PBzup/src/derivative.jl:83
Stacktrace:
  [1] derivative
    @ ~/.julia/packages/ForwardDiff/PBzup/src/derivative.jl:14 [inlined]
  [2] (::JuMP.var"#139#140"{typeof(f), Symbol})(x::Float64)
    @ JuMP ~/.julia/dev/JuMP/src/nlp.jl:2001
  [3] eval_and_check_return_type(func::Function, RetType::Type, args::Float64)
    @ JuMP._Derivatives ~/.julia/dev/JuMP/src/_Derivatives/forward.jl:5
  [4] forward_eval(storage::Vector{Float64}, partials_storage::Vector{Float64}, nd::Vector{JuMP._Derivatives.NodeData}, adj::SparseArrays.SparseMatrixCSC{Bool, Int64}, const_values::Vector{Float64}, parameter_values::Vector{Float64}, x_values::Vector{Float64}, subexpression_values::Vector{Float64}, user_input_buffer::Vector{Float64}, user_output_buffer::Vector{Float64}, user_operators::JuMP._Derivatives.UserOperatorRegistry)
    @ JuMP._Derivatives ~/.julia/dev/JuMP/src/_Derivatives/forward.jl:213
  [5] _forward_eval_all(d::NLPEvaluator, x::Vector{Float64})
    @ JuMP ~/.julia/dev/JuMP/src/nlp.jl:773
  [6] macro expansion
    @ ~/.julia/dev/JuMP/src/nlp.jl:826 [inlined]
  [7] macro expansion
    @ ./timing.jl:287 [inlined]
  [8] eval_objective(d::NLPEvaluator, x::Vector{Float64})
    @ JuMP ~/.julia/dev/JuMP/src/nlp.jl:824
  [9] _eval_objective(model::Ipopt.Optimizer, x::Vector{Float64})
    @ Ipopt ~/.julia/packages/Ipopt/M2QE8/src/MOI_wrapper.jl:821
 [10] (::Ipopt.var"#eval_f_cb#3"{Ipopt.Optimizer})(x::Vector{Float64})
    @ Ipopt ~/.julia/packages/Ipopt/M2QE8/src/MOI_wrapper.jl:1081
 [11] _Eval_F_CB(n::Int32, x_ptr::Ptr{Float64}, x_new::Int32, obj_value::Ptr{Float64}, user_data::Ptr{Nothing})
    @ Ipopt ~/.julia/packages/Ipopt/M2QE8/src/C_wrapper.jl:33
 [12] IpoptSolve(prob::Ipopt.IpoptProblem)
    @ Ipopt ~/.julia/packages/Ipopt/M2QE8/src/C_wrapper.jl:433
 [13] optimize!(model::Ipopt.Optimizer)
    @ Ipopt ~/.julia/packages/Ipopt/M2QE8/src/MOI_wrapper.jl:1225
 [14] optimize!
    @ ~/.julia/packages/MathOptInterface/FHFUH/src/Bridges/bridge_optimizer.jl:348 [inlined]
 [15] optimize!
    @ ~/.julia/packages/MathOptInterface/FHFUH/src/MathOptInterface.jl:81 [inlined]
 [16] optimize!(m::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.Bridges.LazyBridgeOptimizer{Ipopt.Optimizer}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}})
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/FHFUH/src/Utilities/cachingoptimizer.jl:313
 [17] optimize!(model::Model; ignore_optimize_hook::Bool, kwargs::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ JuMP ~/.julia/dev/JuMP/src/optimizer_interface.jl:161
 [18] optimize!(model::Model)
    @ JuMP ~/.julia/dev/JuMP/src/optimizer_interface.jl:143
 [19] top-level scope
    @ REPL[8]:1
````