### PR TITLE
Add Penbmi in solver list

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -125,6 +125,7 @@ The link in the `Solver` column is the corresponding Julia package.
 | [OSQP](https://osqp.org/)                                                      | [OSQP.jl](https://github.com/oxfordcontrol/OSQP.jl)                              |        | Apache   | LP, QP                    |
 | [PATH](http://pages.cs.wisc.edu/~ferris/path.html)                             | [PATHSolver.jl](https://github.com/chkwon/PATHSolver.jl)                 |        | MIT      | MCP                       |
 | [Pavito.jl](https://github.com/jump-dev/Pavito.jl)                             |                                                                                  |        | MPL-2    | (MI)NLP                   |
+| [Penbmi](http://www.penopt.com/penbmi.html)                                    | [Penopt.jl](https://github.com/jump-dev/Penopt.jl/)                              |        | Comm.    | Bilinear SDP              |
 | [ProxSDP.jl](https://github.com/mariohsouto/ProxSDP.jl)                        |                                                                                  |        | MIT      | LP, SOCP, SDP             |
 | [SCIP](https://scipopt.org/)                                                   | [SCIP.jl](https://github.com/scipopt/SCIP.jl)                            |        | ZIB      | (MI)LP, (MI)NLP           |
 | [SCS](https://github.com/cvxgrp/scs)                                           | [SCS.jl](https://github.com/jump-dev/SCS.jl)                                     |        | MIT      | LP, SOCP, SDP             |


### PR DESCRIPTION
The class is commonly referred to as BMI which stands for Bilinear Matrix Inequality to contrast with LMI which stands for Linear Matrix Inequality which basically SDP.
One could say that SDP refers to the format with linear constraints and SDP variables while LMI stands for the dual form with free variables and `Vector{AffExpr}`-in-`PSDCone` constraints.
For consistency with the rest of the acronym of the column, I used "Bilinear SDP".

cc @kocvara @mstingl-fau