### PR TITLE
Improve minimal ellipses SDP demonstration

### DIFF
--- a/docs/src/tutorials/conic/min_ellipse.jl
+++ b/docs/src/tutorials/conic/min_ellipse.jl
@@ -77,7 +77,6 @@ function minimal_ellipse(As, bs, cs)
 
     @assert termination_status(mdl) == OPTIMAL
     @assert primal_status(mdl) == FEASIBLE_POINT
-    @assert isapprox(objective_value(mdl), 0.132413, atol=1e-4)
 
     # Restore original parameterization
     P = sqrt(value.(Psqr))
@@ -86,6 +85,8 @@ function minimal_ellipse(As, bs, cs)
 end
 
 P, q = minimal_ellipse(As, bs, cs)
+@assert isapprox(P, [0.423694 -0.039639; -0.039639 0.316316], atol=1e-4)
+@assert isapprox(q, [-0.396177, -0.021368], atol=1e-4)
 
 # Plot results
 pl = plot(size=(600,600))
@@ -93,9 +94,9 @@ thetas = range(0, 2pi+0.05, step=0.05)
 
 for (A, b, c) in zip(As, bs, cs)
     sqrtA = sqrt(A)
-    b̃ = sqrtA\b
+    b_tilde = sqrtA\b
     alpha = b' * (A\b) - c
-    rhs = hcat(sqrt(alpha) * cos.(thetas) .- b̃[1], sqrt(alpha) * sin.(thetas) .- b̃[2])
+    rhs = hcat(sqrt(alpha) * cos.(thetas) .- b_tilde[1], sqrt(alpha) * sin.(thetas) .- b_tilde[2])
     ellipse = sqrtA\rhs'
     plot!(pl, ellipse[1, :], ellipse[2, :], label=nothing, c=:navy)
 end

--- a/docs/src/tutorials/conic/min_ellipse.jl
+++ b/docs/src/tutorials/conic/min_ellipse.jl
@@ -30,8 +30,8 @@ using Plots
 using Test
 
 function example_minimal_ellipse()
-    # Input ellipses, parameterized as
-    # x' A x + 2 b' x + c ≤ 0
+    ## Input ellipses, parameterized as
+    ## x' A x + 2 b' x + c ≤ 0
     As = [
         [1.2576 -0.3873; -0.3873 0.3467],
         [1.4125 -2.1777; -2.1777 6.7775],

--- a/docs/src/tutorials/conic/min_ellipse.jl
+++ b/docs/src/tutorials/conic/min_ellipse.jl
@@ -15,9 +15,9 @@
 
 # ````
 #       maximize   log(det(P))
-      
+
 #     subject to   t[i] ≥ 0, i = 1 ... m
-    
+
 #                  [ P^2 - t[i] A[i]   P q - t[i] b[i]       0
 #                    P q - t[i] b[i]    -1 - t[i] c[i]    (P q)'
 #                                 0              (P q)   - P^2   ]    PSD, i = 1 ... m
@@ -27,78 +27,101 @@
 using JuMP
 using SCS
 using Plots
+using Test
 
-# Input ellipses, parameterized as
-# x' A x + 2 b' x + c ≤ 0
-As = [
+function example_minimal_ellipse()
+    # Input ellipses, parameterized as
+    # x' A x + 2 b' x + c ≤ 0
+    As = [
         [1.2576 -0.3873; -0.3873 0.3467],
         [1.4125 -2.1777; -2.1777 6.7775],
-        [1.7018  0.8141;  0.8141 1.7538],
+        [1.7018 0.8141; 0.8141 1.7538],
         [0.9742 -0.7202; -0.7202 1.5444],
         [0.6798 -0.1424; -0.1424 0.6871],
-        [0.1796 -0.1423; -0.1423 2.6181]
+        [0.1796 -0.1423; -0.1423 2.6181],
     ]
-bs = [
-        [ 0.2722,  0.1969],
-        [-1.228 , -0.0521],
-        [-0.4049,  1.5713],
-        [ 0.0265,  0.5623],
+    bs = [
+        [0.2722, 0.1969],
+        [-1.228, -0.0521],
+        [-0.4049, 1.5713],
+        [0.0265, 0.5623],
         [-0.4301, -1.0157],
-        [-0.3286,  0.557 ]
+        [-0.3286, 0.557],
     ]
-cs = [0.1831, 0.3295, 0.2077, 0.2362, 0.3284, 0.4931]
+    cs = [0.1831, 0.3295, 0.2077, 0.2362, 0.3284, 0.4931]
 
-function minimal_ellipse(As, bs, cs)
-    # Build the model under the change of variables
+    ## Build the model under the change of variables
     #       Psqr = P^2
     #    q_tilde = Pq
-    mdl = Model(SCS.Optimizer)
+    model = Model(SCS.Optimizer)
 
     m = length(As)
     n, _ = size(first(As))
 
-    @variable(mdl, Psqr[1:n, 1:n], PSD)
-    @variable(mdl, tau[1:m] ≥ 0)
-    @variable(mdl, q_tilde[1:n])
-    @variable(mdl, logdetP)
-    @constraint(mdl, [logdetP; [Psqr[i, j] for i in 1:n for j in i:n]] in MOI.RootDetConeTriangle(n))
+    @variable(model, Psqr[1:n, 1:n], PSD)
+    @variable(model, tau[1:m] ≥ 0)
+    @variable(model, q_tilde[1:n])
+    @variable(model, logdetP)
+    @constraint(
+        model,
+        [logdetP; [Psqr[i, j] for i in 1:n for j in i:n]] in MOI.RootDetConeTriangle(n)
+    )
 
     for (A, b, c, t) in zip(As, bs, cs, tau)
-        @constraint(mdl,
-            -[      Psqr - t*A     q_tilde - t*b    zeros(n,n)  ;
-                (q_tilde - t*b)'        -1 - t*c      q_tilde'  ;
-                     zeros(n,n)          q_tilde        -Psqr    ]
-            in PSDCone())
+        if !(isreal(A) && transpose(A) == A)
+            @error "Input matrices need to be real, symmetric matrices."
+        end
+        
+        @constraint(
+            model,
+            -[
+                Psqr-t*A q_tilde-t*b zeros(n, n)
+                (q_tilde - t * b)' -1-t*c q_tilde'
+                zeros(n, n) q_tilde -Psqr
+            ] in PSDCone()
+        )
     end
 
-    @objective(mdl, Max, logdetP)
+    @objective(model, Max, logdetP)
 
-    optimize!(mdl)
+    optimize!(model)
 
-    @assert termination_status(mdl) == OPTIMAL
-    @assert primal_status(mdl) == FEASIBLE_POINT
+    @test termination_status(model) == OPTIMAL
+    @test primal_status(model) == FEASIBLE_POINT
 
     # Restore original parameterization
     P = sqrt(value.(Psqr))
-    q = P\value.(q_tilde)
+    q = P \ value.(q_tilde)
+
+    @test isapprox(P, [0.423694 -0.039639; -0.039639 0.316316], atol = 1e-4)
+    @test isapprox(q, [-0.396177, -0.021368], atol = 1e-4)
+
+    # Plot results
+    pl = plot(size = (600, 600))
+    thetas = range(0, 2pi + 0.05, step = 0.05)
+
+    for (A, b, c) in zip(As, bs, cs)
+        sqrtA = sqrt(A)
+        b_tilde = sqrtA \ b
+        alpha = b' * (A \ b) - c
+        rhs = hcat(
+            sqrt(alpha) * cos.(thetas) .- b_tilde[1],
+            sqrt(alpha) * sin.(thetas) .- b_tilde[2],
+        )
+        ellipse = sqrtA \ rhs'
+        plot!(pl, ellipse[1, :], ellipse[2, :], label = nothing, c = :navy)
+    end
+
+    plot!(
+        pl,
+        [tuple(P \ ([cos(theta), sin(theta)] - q)...) for theta in thetas],
+        c = :crimson,
+        label = nothing,
+    )
+
+    display(pl)
+
     return P, q
 end
 
-P, q = minimal_ellipse(As, bs, cs)
-@assert isapprox(P, [0.423694 -0.039639; -0.039639 0.316316], atol=1e-4)
-@assert isapprox(q, [-0.396177, -0.021368], atol=1e-4)
-
-# Plot results
-pl = plot(size=(600,600))
-thetas = range(0, 2pi+0.05, step=0.05)
-
-for (A, b, c) in zip(As, bs, cs)
-    sqrtA = sqrt(A)
-    b_tilde = sqrtA\b
-    alpha = b' * (A\b) - c
-    rhs = hcat(sqrt(alpha) * cos.(thetas) .- b_tilde[1], sqrt(alpha) * sin.(thetas) .- b_tilde[2])
-    ellipse = sqrtA\rhs'
-    plot!(pl, ellipse[1, :], ellipse[2, :], label=nothing, c=:navy)
-end
-
-plot!(pl,[tuple(P\([cos(theta), sin(theta)] - q) ...) for theta in thetas], c=:crimson, label=nothing)
+example_minimal_ellipse()

--- a/docs/src/tutorials/conic/min_ellipse.jl
+++ b/docs/src/tutorials/conic/min_ellipse.jl
@@ -51,8 +51,8 @@ function example_minimal_ellipse()
     cs = [0.1831, 0.3295, 0.2077, 0.2362, 0.3284, 0.4931]
 
     ## Build the model under the change of variables
-    #       Psqr = P^2
-    #    q_tilde = Pq
+    ##       Psqr = P^2
+    ##    q_tilde = Pq
     model = Model(SCS.Optimizer)
 
     m = length(As)
@@ -71,7 +71,7 @@ function example_minimal_ellipse()
         if !(isreal(A) && transpose(A) == A)
             @error "Input matrices need to be real, symmetric matrices."
         end
-        
+
         @constraint(
             model,
             -[
@@ -89,14 +89,14 @@ function example_minimal_ellipse()
     @test termination_status(model) == OPTIMAL
     @test primal_status(model) == FEASIBLE_POINT
 
-    # Restore original parameterization
+    ## Restore original parameterization
     P = sqrt(value.(Psqr))
     q = P \ value.(q_tilde)
 
     @test isapprox(P, [0.423694 -0.039639; -0.039639 0.316316], atol = 1e-4)
     @test isapprox(q, [-0.396177, -0.021368], atol = 1e-4)
 
-    # Plot results
+    ## Plot results
     pl = plot(size = (600, 600))
     thetas = range(0, 2pi + 0.05, step = 0.05)
 

--- a/docs/src/tutorials/conic/min_ellipse.jl
+++ b/docs/src/tutorials/conic/min_ellipse.jl
@@ -3,48 +3,101 @@
 # v.2.0. If a copy of the MPL was not distributed with this file, You can       #src
 # obtain one at https://mozilla.org/MPL/2.0/.                                   #src
 
-# # Minimum ellipses
+# # Minimal ellipses
 
-# This example is from the Boyd & Vandenberghe book "Convex Optimization". Given
-# a set of ellipses centered on the origin
-#
-#     E(A) = { u | u^T inv(A) u <= 1 }
-#
-# find a "minimal" ellipse that contains the provided ellipses.
-#
-# We can formulate this as an SDP:
-#
-#     minimize    trace(WX)
-#     subject to  X >= A_i,    i = 1,...,m
-#                 X PSD
-#
-# where W is a PD matrix of weights to choose between different solutions.
+# This example comes from section 8.4.1 of the book *Convex Optimization* (Boyd and Vandenberghe, 2004).
+
+# Given a set of `m` ellipses `E(A, b, c) = { x : x' A x + 2 b' x + c ≤ 0 }`, we find the ellipse of smallest area that encloses the given ellipses.
+
+# It is convenient to parameterize as the ellipse `{ x : || Px + q || ≤ 1 }`.
+
+# Then the optimal `P` and `q` are given by the convex program
+
+# ````
+#       maximize   log(det(P))
+      
+#     subject to   t[i] ≥ 0, i = 1 ... m
+    
+#                  [ P^2 - t[i] A[i]   P q - t[i] b[i]       0
+#                    P q - t[i] b[i]    -1 - t[i] c[i]    (P q)'
+#                                 0              (P q)   - P^2   ]    PSD, i = 1 ... m
+# ````
+# with helper variables `t[i]`. 
 
 using JuMP
-import LinearAlgebra
-import SCS
-import Test
+using SCS
+using Plots
 
-function example_min_ellipse()
-    ## We will use three ellipses: two "simple" ones, and a random one.
-    As = [
-        [2.0 0.0; 0.0 1.0],
-        [1.0 0.0; 0.0 3.0],
-        [2.86715 1.60645; 1.60645 1.12639],
+# Input ellipses, parameterized as
+# x' A x + 2 b' x + c ≤ 0
+As = [
+        [1.2576 -0.3873; -0.3873 0.3467],
+        [1.4125 -2.1777; -2.1777 6.7775],
+        [1.7018  0.8141;  0.8141 1.7538],
+        [0.9742 -0.7202; -0.7202 1.5444],
+        [0.6798 -0.1424; -0.1424 0.6871],
+        [0.1796 -0.1423; -0.1423 2.6181]
     ]
-    ## We change the weights to see different solutions, if they exist
-    weights = [1.0 0.0; 0.0 1.0]
-    model = Model(SCS.Optimizer)
-    set_silent(model)
-    @variable(model, X[i = 1:2, j = 1:2], PSD)
-    @objective(model, Min, LinearAlgebra.tr(weights * X))
-    @constraint(model, [As_i in As], X >= As_i, PSDCone())
-    optimize!(model)
-    Test.@test termination_status(model) == OPTIMAL
-    Test.@test primal_status(model) == FEASIBLE_POINT
-    Test.@test objective_value(model) ≈ 6.46236 atol = 1e-4
-    Test.@test value.(X) ≈ [3.1651 0.8022; 0.8022 3.2972] atol = 1e-4
-    return
+bs = [
+        [ 0.2722,  0.1969],
+        [-1.228 , -0.0521],
+        [-0.4049,  1.5713],
+        [ 0.0265,  0.5623],
+        [-0.4301, -1.0157],
+        [-0.3286,  0.557 ]
+    ]
+cs = [0.1831, 0.3295, 0.2077, 0.2362, 0.3284, 0.4931]
+
+function minimal_ellipse(As, bs, cs)
+    # Build the model under the change of variables
+    #       Psqr = P^2
+    #    q_tilde = Pq
+    mdl = Model(SCS.Optimizer)
+
+    m = length(As)
+    n, _ = size(first(As))
+
+    @variable(mdl, Psqr[1:n, 1:n], PSD)
+    @variable(mdl, tau[1:m] ≥ 0)
+    @variable(mdl, q_tilde[1:n])
+    @variable(mdl, logdetP)
+    @constraint(mdl, [logdetP; [Psqr[i, j] for i in 1:n for j in i:n]] in MOI.RootDetConeTriangle(n))
+
+    for (A, b, c, t) in zip(As, bs, cs, tau)
+        @constraint(mdl,
+            -[      Psqr - t*A     q_tilde - t*b    zeros(n,n)  ;
+                (q_tilde - t*b)'        -1 - t*c      q_tilde'  ;
+                     zeros(n,n)          q_tilde        -Psqr    ]
+            in PSDCone())
+    end
+
+    @objective(mdl, Max, logdetP)
+
+    optimize!(mdl)
+
+    @assert termination_status(mdl) == OPTIMAL
+    @assert primal_status(mdl) == FEASIBLE_POINT
+    @assert isapprox(objective_value(mdl), 0.132413, atol=1e-4)
+
+    # Restore original parameterization
+    P = sqrt(value.(Psqr))
+    q = P\value.(q_tilde)
+    return P, q
 end
 
-example_min_ellipse()
+P, q = minimal_ellipse(As, bs, cs)
+
+# Plot results
+pl = plot(size=(600,600))
+thetas = range(0, 2pi+0.05, step=0.05)
+
+for (A, b, c) in zip(As, bs, cs)
+    sqrtA = sqrt(A)
+    b̃ = sqrtA\b
+    alpha = b' * (A\b) - c
+    rhs = hcat(sqrt(alpha) * cos.(thetas) .- b̃[1], sqrt(alpha) * sin.(thetas) .- b̃[2])
+    ellipse = sqrtA\rhs'
+    plot!(pl, ellipse[1, :], ellipse[2, :], label=nothing, c=:navy)
+end
+
+plot!(pl,[tuple(P\([cos(theta), sin(theta)] - q) ...) for theta in thetas], c=:crimson, label=nothing)


### PR DESCRIPTION
This PR improves the "Minimum ellipses" demonstration in the documentation:
- Fixed the objective function to use the log determinant of the matrix instead of the trace.
   (Logdet is correct, but  the `MOI.RootDetConeTriangle` interface wasn't working at the time the previous version of this demo was created, so the author used trace as an approximation.)
- Allow input ellipses that aren't centered at the origin.
- Add section number to textbook reference. 
- Add graphical output.
- Change title from "Minimum ellipses" to "Minimal ellipses."

See [this discussion](https://discourse.julialang.org/t/jump-docs-on-sdp-replace-logdet-with-tr-is-this-correct/79324) on Discourse.