### PR TITLE
Change "a" to "an"

### DIFF
--- a/docs/src/should_i_use.md
+++ b/docs/src/should_i_use.md
@@ -65,7 +65,7 @@ Packages in Julia compose well. It's common for people to pick two unrelated
 packages and use them in conjunction to create novel behavior. JuMP isn't one of
 those packages.
 
-If you want to optimize a ordinary differential equation from
+If you want to optimize an ordinary differential equation from
 [DifferentialEquations.jl](https://github.com/SciML/DifferentialEquations.jl)
 or tune a neural network from [Flux.jl](https://github.com/FluxML/Flux.jl),
 consider using other packages such as:


### PR DESCRIPTION
Just a small grammatical tweak.
Instead of "If you want to optimize a ordinary differential equation..." I changed to "If you want to optimize an ordinary differential equation" which is just changing the "a" to an "an" indefinite article.