### PR TITLE
Fix passing nothing to start kwarg

### DIFF
--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1106,12 +1106,12 @@ function _moi_constrain_variable(moi_backend::MOI.ModelLike, index, info)
     if info.integer
         _moi_add_constraint(moi_backend, index, MOI.Integer())
     end
-    if info.has_start
+    if info.has_start && info.start !== nothing
         MOI.set(
             moi_backend,
             MOI.VariablePrimalStart(),
             index,
-            Float64(info.start),
+            convert(Float64, info.start),
         )
     end
 end

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -1044,6 +1044,13 @@ function test_Model_ConstraintRef(ModelType, ::Any)
     return
 end
 
+function test_start_value_nothing(ModelType, ::Any)
+    model = ModelType()
+    @variable(model, x, start = nothing)
+    @test start_value(x) === nothing
+    return
+end
+
 function runtests()
     for name in names(@__MODULE__; all = true)
         if !startswith("$(name)", "test_")


### PR DESCRIPTION
Came up here: https://discourse.julialang.org/t/setting-start-values-for-only-some-indicies-of-a-bileveljump-variable/81160/2