### PR TITLE
RFC: JuliaFormatter: use format_docstrings = true

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -3,6 +3,7 @@
 
 always_for_in = true
 always_use_return = true
+format_docstrings = true
 margin = 80
 remove_extra_newlines = true
 separate_kwargs_with_semicolon = true

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           using Pkg
           # If you update the version, also update the style guide docs.
-          Pkg.add(PackageSpec(name="JuliaFormatter", version="1"))
+          Pkg.add(PackageSpec(name="JuliaFormatter", version="1.0.2"))
           using JuliaFormatter
           format("src", verbose=true)
           format("test", verbose=true)

--- a/docs/src/tutorials/applications/power_systems.jl
+++ b/docs/src/tutorials/applications/power_systems.jl
@@ -483,6 +483,7 @@ A user-defined thermal cost function in pure-Julia! You can include
 nonlinearities, and even things like control flow.
 
 !!! warning
+    
     It's still up to you to make sure that the function has a meaningful
     derivative.
 """

--- a/docs/src/tutorials/getting_started/design_patterns_for_larger_models.jl
+++ b/docs/src/tutorials/getting_started/design_patterns_for_larger_models.jl
@@ -529,30 +529,28 @@ Solve the knapsack problem and return the optimal primal solution
 
 ## Arguments
 
- * `optimizer` : an object that can be passed to `JuMP.Model` to construct a new
-   JuMP model.
- * `data_filename` : the filename of a JSON file containing the data for the
-   problem.
- * `config` : an object to control the type of knapsack model constructed.
-   Valid options are:
-    * `BinaryKnapsackConfig()`
-    * `IntegerKnapsackConfig()`
+  - `optimizer` : an object that can be passed to `JuMP.Model` to construct a
+    new JuMP model.
+  - `data_filename` : the filename of a JSON file containing the data for the
+    problem.
+  - `config` : an object to control the type of knapsack model constructed.
+    Valid options are:
+
+      + `BinaryKnapsackConfig()`
+      + `IntegerKnapsackConfig()`
 
 ## Returns
 
- * If an optimal solution exists: a `JuMP.DenseAxisArray` that maps the `String`
-   name of each object to the number of objects to pack into the knapsack.
- * Otherwise, `nothing`, indicating that the problem does not have an optimal
-   solution.
+  - If an optimal solution exists: a `JuMP.DenseAxisArray` that maps the `String`
+    name of each object to the number of objects to pack into the knapsack.
+  - Otherwise, `nothing`, indicating that the problem does not have an optimal
+    solution.
 
 ## Examples
 
 ```julia
-solution = solve_knapsack(
-    HiGHS.Optimizer,
-    "path/to/data.json",
-    BinaryKnapsackConfig(),
-)
+solution =
+    solve_knapsack(HiGHS.Optimizer, "path/to/data.json", BinaryKnapsackConfig())
 ```
 
 ```julia

--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -179,6 +179,7 @@ and the given axes. Exactly `N` axes must be provided, and their lengths must
 match `size(data)` in the corresponding dimensions.
 
 # Example
+
 ```jldoctest; setup=:(using JuMP)
 julia> array = JuMP.Containers.DenseAxisArray([1 2; 3 4], [:a, :b], 2:3)
 2-dimensional DenseAxisArray{Int64,2,...} with index sets:
@@ -210,8 +211,10 @@ Construct an uninitialized DenseAxisArray with element-type `T` indexed over the
 given axes.
 
 # Example
+
 ```jldoctest; setup=:(using JuMP)
 julia> array = JuMP.Containers.DenseAxisArray{Float64}(undef, [:a, :b], 1:2);
+
 
 julia> fill!(array, 1.0)
 2-dimensional DenseAxisArray{Float64,2,...} with index sets:

--- a/src/Containers/macro.jl
+++ b/src/Containers/macro.jl
@@ -183,28 +183,28 @@ end
 Helper function for macros to construct container objects.
 
 !!! warning
+    
     This function is for advanced users implementing JuMP extensions. See
     [`container_code`](@ref) for more details.
 
 ## Arguments
 
- * `_error`: a function that takes a `String` and throws an error, potentially
-   annotating the input string with extra information such as from which macro
-   it was thrown from. Use `error` if you do not want a modified error message.
- * `expr`: an `Expr` that specifies the container, e.g.,
-   `:(x[i = 1:3, [:red, :blue], k = S; i + k <= 6])`
+  - `_error`: a function that takes a `String` and throws an error, potentially
+    annotating the input string with extra information such as from which macro
+    it was thrown from. Use `error` if you do not want a modified error message.
+  - `expr`: an `Expr` that specifies the container, e.g.,
+    `:(x[i = 1:3, [:red, :blue], k = S; i + k <= 6])`
 
 ## Returns
 
  1. `index_vars`: a `Vector{Any}` of names for the index variables, e.g.,
     `[:i, gensym(), :k]`. These may also be expressions, like `:((i, j))` from a
     call like `:(x[(i, j) in S])`.
+
  2. `indices`: an iterator over the indices, e.g.,
+    
     ```julia
-    Containers.NestedIterators(
-        (1:3, [:red, :blue], S),
-        (i, _, k) -> i + k <= 6,
-    )
+    Containers.NestedIterators((1:3, [:red, :blue], S), (i, _, k) -> i + k <= 6)
     ```
 
 ## Examples
@@ -254,18 +254,19 @@ in conjunction with [`build_ref_sets`](@ref).
 
 ## Arguments
 
- * `index_vars::Vector{Any}`: a vector of names for the indices of the
-   container. These may also be expressions, like `:((i, j))` from a
-   call like `:(x[(i, j) in S])`.
- * `indices::Expr`: an expression that evaluates to an iterator of the indices.
- * `code`: an expression or literal constant for the value to be stored in the
-   container as a function of the named `index_vars`.
- * `requested_container`: passed to the third argument of [`container`](@ref).
-   For built-in JuMP types, choose one of `:Array`, `:DenseAxisArray`,
-   `:SparseAxisArray`, or `:Auto`. For a user-defined container, this expression
-   must evaluate to the correct type.
+  - `index_vars::Vector{Any}`: a vector of names for the indices of the
+    container. These may also be expressions, like `:((i, j))` from a
+    call like `:(x[(i, j) in S])`.
+  - `indices::Expr`: an expression that evaluates to an iterator of the indices.
+  - `code`: an expression or literal constant for the value to be stored in the
+    container as a function of the named `index_vars`.
+  - `requested_container`: passed to the third argument of [`container`](@ref).
+    For built-in JuMP types, choose one of `:Array`, `:DenseAxisArray`,
+    `:SparseAxisArray`, or `:Auto`. For a user-defined container, this expression
+    must evaluate to the correct type.
 
 !!! warning
+    
     In most cases, you should `esc(code)` before passing it to `container_code`.
 
 ## Examples
@@ -273,16 +274,11 @@ in conjunction with [`build_ref_sets`](@ref).
 ```jldoctest; setup=:(using JuMP)
 julia> macro foo(ref_sets, code)
            index_vars, indices = Containers.build_ref_sets(error, ref_sets)
-           return Containers.container_code(
-               index_vars,
-               indices,
-               esc(code),
-               :Auto,
-            )
+           return Containers.container_code(index_vars, indices, esc(code), :Auto)
        end
 @foo (macro with 1 method)
 
-julia> @foo(x[i=1:2, j=["A", "B"]], j^i)
+julia> @foo(x[i = 1:2, j = ["A", "B"]], j^i)
 2-dimensional DenseAxisArray{String,2,...} with index sets:
     Dimension 1, Base.OneTo(2)
     Dimension 2, ["A", "B"]
@@ -333,6 +329,7 @@ Same as above but the container is assigned to the variable of name `ref`.
 The type of container can be controlled by the `container` keyword.
 
 !!! note
+    
     When the index set is explicitly given as `1:n` for any expression `n`, it
     is transformed to `Base.OneTo(n)` before being given to [`container`](@ref).
 
@@ -349,6 +346,7 @@ julia> I = 1:3
 1:3
 
 julia> Containers.@container(x[i = I, j = I], i + j);
+
 
 julia> x
 2-dimensional DenseAxisArray{Int64,2,...} with index sets:

--- a/src/Containers/nested_iterator.jl
+++ b/src/Containers/nested_iterator.jl
@@ -16,13 +16,16 @@ Construct a `NestedIterator` using [`nested`](@ref).
 ## Example
 
 If `length(iterators) == 3`:
+
 ```julia
 x = NestedIterator(iterators, condition)
 for (i1, i2, i3) in x
     # produces (i1, i2, i3)
 end
 ```
+
 is the same as
+
 ```julia
 for i1 in iterators[1]()
     for i2 in iterator[2](i1)

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -76,11 +76,15 @@ attributes using [`set_optimizer_attribute`](@ref).
 ```julia
 model = Model(
     optimizer_with_attributes(
-        Gurobi.Optimizer, "Presolve" => 0, "OutputFlag" => 1
-    )
+        Gurobi.Optimizer,
+        "Presolve" => 0,
+        "OutputFlag" => 1,
+    ),
 )
 ```
+
 is equivalent to:
+
 ```julia
 model = Model(Gurobi.Optimizer)
 set_optimizer_attribute(model, "Presolve", 0)
@@ -194,12 +198,14 @@ See [`set_optimizer`](@ref) for the description of the `optimizer_factory` and
 ## Examples
 
 Create a model with the optimizer set to `Ipopt`:
+
 ```julia
 model = Model(Ipopt.Optimizer)
 ```
 
 Pass an anonymous function which creates a `Gurobi.Optimizer`, and disable
 bridges:
+
 ```julia
 env = Gurobi.Env()
 model = Model(() -> Gurobi.Optimizer(env); add_bridges = false)
@@ -225,14 +231,14 @@ outside of [`backend`](@ref) and no bridges are automatically applied to
 The absence of a cache reduces the memory footprint but, it is important to bear
 in mind the following implications of creating models using this *direct* mode:
 
-* When [`backend`](@ref) does not support an operation, such as modifying
-  constraints or adding variables/constraints after solving, an error is
-  thrown. For models created using the [`Model`](@ref) constructor, such
-  situations can be dealt with by storing the modifications in a cache and
-  loading them into the optimizer when `optimize!` is called.
-* No constraint bridging is supported by default.
-* The optimizer used cannot be changed the model is constructed.
-* The model created cannot be copied.
+  - When [`backend`](@ref) does not support an operation, such as modifying
+    constraints or adding variables/constraints after solving, an error is
+    thrown. For models created using the [`Model`](@ref) constructor, such
+    situations can be dealt with by storing the modifications in a cache and
+    loading them into the optimizer when `optimize!` is called.
+  - No constraint bridging is supported by default.
+  - The optimizer used cannot be changed the model is constructed.
+  - The model created cannot be copied.
 """
 function direct_model(backend::MOI.ModelLike)
     @assert MOI.is_empty(backend)
@@ -264,10 +270,12 @@ model = direct_model(
         Gurobi.Optimizer,
         "Presolve" => 0,
         "OutputFlag" => 1,
-    )
+    ),
 )
 ```
+
 is equivalent to:
+
 ```julia
 model = direct_model(Gurobi.Optimizer())
 set_optimizer_attribute(model, "Presolve", 0)
@@ -287,11 +295,11 @@ Base.broadcastable(model::Model) = Ref(model)
 Return the lower-level MathOptInterface model that sits underneath JuMP. This
 model depends on which operating mode JuMP is in (see [`mode`](@ref)).
 
- * If JuMP is in `DIRECT` mode (i.e., the model was created using
-   [`direct_model`](@ref)), the backend will be the optimizer passed to
-   [`direct_model`](@ref).
- * If JuMP is in `MANUAL` or `AUTOMATIC` mode, the backend is a
-   `MOI.Utilities.CachingOptimizer`.
+  - If JuMP is in `DIRECT` mode (i.e., the model was created using
+    [`direct_model`](@ref)), the backend will be the optimizer passed to
+    [`direct_model`](@ref).
+  - If JuMP is in `MANUAL` or `AUTOMATIC` mode, the backend is a
+    `MOI.Utilities.CachingOptimizer`.
 
 **This function should only be used by advanced users looking to access
 low-level MathOptInterface or solver-specific functionality.**
@@ -335,6 +343,7 @@ Second, the `unsafe_backend` may be empty, or lack some modifications made to
 the JuMP model. Thus, before calling `unsafe_backend` you should first call
 [`MOI.Utilities.attach_optimizer`](@ref) to ensure that the backend is
 synchronized with the JuMP model.
+
 ```julia
 MOI.Utilities.attach_optimizer(model)
 inner = unsafe_backend(model)
@@ -354,13 +363,16 @@ Instead of `unsafe_backend`, create a model using [`direct_model`](@ref) and
 call [`backend`](@ref) instead.
 
 For example, instead of:
+
 ```julia
 model = Model(HiGHS.Optimizer)
 @variable(model, x >= 0)
 MOI.Utilities.attach_optimizer(model)
 highs = unsafe_backend(model)
 ```
+
 Use:
+
 ```julia
 model = direct_model(HiGHS.Optimizer())
 @variable(model, x >= 0)
@@ -533,9 +545,11 @@ that are present in the model.
 
 Each node in the hyper-graph corresponds to a variable, constraint, or objective
 type.
-  * Variable nodes are indicated by `[ ]`
-  * Constraint nodes are indicated by `( )`
-  * Objective nodes are indicated by `| |`
+
+  - Variable nodes are indicated by `[ ]`
+  - Constraint nodes are indicated by `( )`
+  - Objective nodes are indicated by `| |`
+
 The number inside each pair of brackets is an index of the node in the
 hyper-graph.
 
@@ -650,6 +664,7 @@ expression can be created with the same key.
 
 Note that this will not delete the object `model[key]`; it will just remove the
 reference at `model[key]`. To delete the object, use
+
 ```julia
 delete(model, model[key])
 unregister(model, key)
@@ -678,6 +693,7 @@ julia> num_variables(model)
 1
 
 julia> unregister(model, :x)
+
 
 julia> @variable(model, x)
 x
@@ -750,10 +766,10 @@ those passed to [`optimize!`](@ref).
 
 ## Notes
 
- * The optimize hook should generally modify the model, or some external state
-   in some way, and then call `optimize!(model; ignore_optimize_hook = true)` to
-   optimize the problem, bypassing the hook.
- * Use `set_optimize_hook(model, nothing)` to unset an optimize hook.
+  - The optimize hook should generally modify the model, or some external state
+    in some way, and then call `optimize!(model; ignore_optimize_hook = true)` to
+    optimize the problem, bypassing the hook.
+  - Use `set_optimize_hook(model, nothing)` to unset an optimize hook.
 
 ## Examples
 
@@ -840,7 +856,9 @@ Given a list of `attribute => value` pairs, calls
 model = Model(Ipopt.Optimizer)
 set_optimizer_attributes(model, "tol" => 1e-4, "max_iter" => 100)
 ```
+
 is equivalent to:
+
 ```julia
 model = Model(Ipopt.Optimizer)
 set_optimizer_attribute(model, "tol", 1e-4)

--- a/src/_Derivatives/subexpressions.jl
+++ b/src/_Derivatives/subexpressions.jl
@@ -40,9 +40,9 @@ as the uninitialized vector, or by explicitly computing the full
 
 ## Notes
 
-* It is important to not use recursion here, because expressions may have
-  arbitrary levels of nesting!
-* This function assumes `subexpressions` is acyclic.
+  - It is important to not use recursion here, because expressions may have
+    arbitrary levels of nesting!
+  - This function assumes `subexpressions` is acyclic.
 """
 function _topological_sort(
     starts,
@@ -100,11 +100,11 @@ Topologically sort the subexpression needed to evaluate `main_expressions`.
 
 Returns two things:
 
- * A `Vector{Int}` containing the ordered list of subexpression-indices that
-   need to be evaluated to compute all `main_expressions`
- * A `Vector{Vector{Int}}`, containing a list of ordered lists of
-   subexpression-indices that need to be evaluated to compute
-   `main_expressions[i]`.
+  - A `Vector{Int}` containing the ordered list of subexpression-indices that
+    need to be evaluated to compute all `main_expressions`
+  - A `Vector{Vector{Int}}`, containing a list of ordered lists of
+    subexpression-indices that need to be evaluated to compute
+    `main_expressions[i]`.
 
 **Warning:** This doesn't handle cyclic expressions! But this should be fine
 because we can't compute them in JuMP anyway.

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -115,9 +115,9 @@ An expression type representing an affine expression of the form:
 
 ## Fields
 
- * `.constant`: the constant `c` in the expression.
- * `.terms`: an `OrderedDict`, with keys of `VarType` and values of `CoefType`
-   describing the sparse vector `a`.
+  - `.constant`: the constant `c` in the expression.
+  - `.terms`: an `OrderedDict`, with keys of `VarType` and values of `CoefType`
+    describing the sparse vector `a`.
 """
 mutable struct GenericAffExpr{CoefType,VarType} <: AbstractJuMPScalar
     constant::CoefType
@@ -142,6 +142,7 @@ Create a [`GenericAffExpr`](@ref) by passing a constant and a vector of pairs.
 ```jldoctest; setup=:(using JuMP; model = Model(); @variable(model, x))
 julia> GenericAffExpr(1.0, [x => 1.0])
 x + 1
+```
 """
 function GenericAffExpr(constant::V, kv::AbstractArray{Pair{K,V}}) where {K,V}
     return GenericAffExpr{V,K}(constant, _new_ordered_dict(K, V, kv))
@@ -158,6 +159,7 @@ arguments.
 ```jldoctest; setup=:(using JuMP; model = Model(); @variable(model, x))
 julia> GenericAffExpr(1.0, x => 1.0)
 x + 1
+```
 """
 function GenericAffExpr(
     constant::V,
@@ -392,15 +394,15 @@ end
 
 Updates `expression` *in place* to `expression + (*)(terms...)`. This is
 typically much more efficient than `expression += (*)(terms...)`. For example,
-`add_to_expression!(expression, a, b)` produces the same result as `expression
-+= a*b`, and `add_to_expression!(expression, a)` produces the same result as
-`expression += a`.
+`add_to_expression!(expression, a, b)` produces the same result as
+`expression += a*b`, and `add_to_expression!(expression, a)` produces the same
+result as `expression += a`.
 
 Only a few methods are defined, mostly for internal use, and only for the cases
 when (1) they can be implemented efficiently and (2) `expression` is capable of
-storing the result. For example, `add_to_expression!(::AffExpr, ::VariableRef,
-::VariableRef)` is not defined because a `GenericAffExpr` cannot store the
-product of two variables.
+storing the result. For example,
+`add_to_expression!(::AffExpr, ::VariableRef, ::VariableRef)` is not defined
+because a `GenericAffExpr` cannot store the product of two variables.
 """
 function add_to_expression! end
 

--- a/src/copy.jl
+++ b/src/copy.jl
@@ -12,6 +12,7 @@ data of the new model `new_model`.
 A method should be added for any JuMP extension storing data in the `ext` field.
 
 !!! warning
+    
     Do not engage in type piracy by implementing this method for types of `data`
     that you did not define! JuMP extensions should store types that they
     define in `model.ext`, rather than regular Julia types.
@@ -112,6 +113,7 @@ will have to be provided to the new model in the [`optimize!`](@ref) call.
 In the following example, a model `model` is constructed with a variable `x` and
 a constraint `cref`. It is then copied into a model `new_model` with the new
 references assigned to `x_new` and `cref_new`.
+
 ```julia
 model = Model()
 @variable(model, x)
@@ -207,6 +209,7 @@ will have to be provided to the new model in the [`optimize!`](@ref) call.
 In the following example, a model `model` is constructed with a variable `x` and
 a constraint `cref`. It is then copied into a model `new_model` with the new
 references assigned to `x_new` and `cref_new`.
+
 ```julia
 model = Model()
 @variable(model, x)
@@ -247,6 +250,7 @@ two constraints `cref` and `cref2`. This model has no solution, as the two
 constraints are mutually exclusive. The solver is asked to compute a conflict
 with [`compute_conflict!`](@ref). The parts of `model` participating in the
 conflict are then copied into a model `new_model`.
+
 ```julia
 model = Model() # You must use a solver that supports conflict refining/IIS
 # computation, like CPLEX or Gurobi

--- a/src/feasibility_checker.jl
+++ b/src/feasibility_checker.jl
@@ -32,19 +32,21 @@ Euclidean distance in the corresponding set.
 
 ## Notes
 
- * If `skip_missing = true`, constraints containing variables that are not in
-   `point` will be ignored.
- * If `skip_missing = false` and a partial primal solution is provided, an error
-   will be thrown.
- * If no point is provided, the primal solution from the last time the model was
-   solved is used.
+  - If `skip_missing = true`, constraints containing variables that are not in
+    `point` will be ignored.
+  - If `skip_missing = false` and a partial primal solution is provided, an error
+    will be thrown.
+  - If no point is provided, the primal solution from the last time the model was
+    solved is used.
 
 ## Examples
 
 ```jldoctest; setup=:(using JuMP)
 julia> model = Model();
 
+
 julia> @variable(model, 0.5 <= x <= 1);
+
 
 julia> primal_feasibility_report(model, Dict(x => 0.2))
 Dict{Any,Float64} with 1 entry:
@@ -89,7 +91,9 @@ argument instead of a dictionary as the second argument.
 ```jldoctest; setup=:(using JuMP)
 julia> model = Model();
 
+
 julia> @variable(model, 0.5 <= x <= 1);
+
 
 julia> primal_feasibility_report(model) do v
            return value(v)

--- a/src/lp_sensitivity2.jl
+++ b/src/lp_sensitivity2.jl
@@ -25,12 +25,12 @@ Base.getindex(s::SensitivityReport, x::VariableRef) = s.objective[x]
 Given a linear program `model` with a current optimal basis, return a
 [`SensitivityReport`](@ref) object, which maps:
 
- - Every variable reference to a tuple `(d_lo, d_hi)::Tuple{Float64,Float64}`,
-   explaining how much the objective coefficient of the corresponding variable
-   can change by, such that the original basis remains optimal.
- - Every constraint reference to a tuple `(d_lo, d_hi)::Tuple{Float64,Float64}`,
-   explaining how much the right-hand side of the corresponding constraint can
-   change by, such that the basis remains optimal.
+  - Every variable reference to a tuple `(d_lo, d_hi)::Tuple{Float64,Float64}`,
+    explaining how much the objective coefficient of the corresponding variable
+    can change by, such that the original basis remains optimal.
+  - Every constraint reference to a tuple `(d_lo, d_hi)::Tuple{Float64,Float64}`,
+    explaining how much the right-hand side of the corresponding constraint can
+    change by, such that the basis remains optimal.
 
 Both tuples are relative, rather than absolute. So given a objective coefficient
 of `1.0` and a tuple `(-0.5, 0.5)`, the objective coefficient can range

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -169,14 +169,18 @@ Converts a sense symbol to a set `set` such that
 ## Example
 
 Once a custom set is defined you can directly create a JuMP constraint with it:
+
 ```jldoctest operator_to_set; setup = :(using JuMP)
 julia> struct CustomSet{T} <: MOI.AbstractScalarSet
            value::T
        end
 
+
 julia> Base.copy(x::CustomSet) = CustomSet(x.value)
 
+
 julia> model = Model();
+
 
 julia> @variable(model, x)
 x
@@ -187,14 +191,18 @@ x ∈ CustomSet{Float64}(1.0)
 
 However, there might be an appropriate sign that could be used in order to
 provide a more convenient syntax:
+
 ```jldoctest operator_to_set
 julia> JuMP.operator_to_set(::Function, ::Val{:⊰}) = CustomSet(0.0)
 
+
 julia> MOIU.shift_constant(set::CustomSet, value) = CustomSet(set.value + value)
+
 
 julia> cref = @constraint(model, x ⊰ 1)
 x ∈ CustomSet{Float64}(1.0)
 ```
+
 Note that the whole function is first moved to the right-hand side, then the
 sign is transformed into a set with zero constant and finally the constant is
 moved to the set with `MOIU.shift_constant`.
@@ -279,26 +287,29 @@ The entry-point for all constraint-related parsing.
 
 ## Arguments
 
- * The `_error` function is passed everywhere to provide better error messages
- * `expr` comes from the `@constraint` macro. There are two possibilities:
-    * `@constraint(model, expr)`
-    * `@constraint(model, name[args], expr)`
-   In both cases, `expr` is the main component of the constraint.
+  - The `_error` function is passed everywhere to provide better error messages
+
+  - `expr` comes from the `@constraint` macro. There are two possibilities:
+    
+      + `@constraint(model, expr)`
+      + `@constraint(model, name[args], expr)`
+        In both cases, `expr` is the main component of the constraint.
 
 ## Supported syntax
 
 JuMP currently supports the following `expr` objects:
- * `lhs <= rhs`
- * `lhs == rhs`
- * `lhs >= rhs`
- * `l <= body <= u`
- * `u >= body >= l`
- * `lhs ⟂ rhs`
- * `lhs in rhs`
- * `lhs ∈ rhs`
- * `z => {constraint}`
- * `!z => {constraint}`
-as well as all broadcasted variants.
+
+  - `lhs <= rhs`
+  - `lhs == rhs`
+  - `lhs >= rhs`
+  - `l <= body <= u`
+  - `u >= body >= l`
+  - `lhs ⟂ rhs`
+  - `lhs in rhs`
+  - `lhs ∈ rhs`
+  - `z => {constraint}`
+  - `!z => {constraint}`
+    as well as all broadcasted variants.
 
 ## Extensions
 
@@ -316,6 +327,7 @@ Implement this method to intercept the parsing of an expression with head
 `head`.
 
 !!! warning
+    
     Extending the constraint macro at parse time is an advanced operation and
     has the potential to interfere with existing JuMP syntax. Please discuss
     with the [developer chatroom](https://gitter.im/JuliaOpt/jump-dev) before
@@ -323,29 +335,29 @@ Implement this method to intercept the parsing of an expression with head
 
 ## Arguments
 
- * `_error`: a function that accepts a `String` and throws the string as an
-   error, along with some descriptive information of the macro from which it was
-   thrown.
- * `head`: the `.head` field of the `Expr` to intercept
- * `args...`: the `.args` field of the `Expr`.
+  - `_error`: a function that accepts a `String` and throws the string as an
+    error, along with some descriptive information of the macro from which it was
+    thrown.
+  - `head`: the `.head` field of the `Expr` to intercept
+  - `args...`: the `.args` field of the `Expr`.
 
 ## Returns
 
 This function must return:
 
- * `is_vectorized::Bool`: whether the expression represents a broadcasted
-   expression like `x .<= 1`
- * `parse_code::Expr`: an expression containing any setup or rewriting code that
-   needs to be called before `build_constraint`
- * `build_code::Expr`: an expression that calls `build_constraint(` or
-   `build_constraint.(` depending on `is_vectorized`.
+  - `is_vectorized::Bool`: whether the expression represents a broadcasted
+    expression like `x .<= 1`
+  - `parse_code::Expr`: an expression containing any setup or rewriting code that
+    needs to be called before `build_constraint`
+  - `build_code::Expr`: an expression that calls `build_constraint(` or
+    `build_constraint.(` depending on `is_vectorized`.
 
 ## Existing implementations
 
 JuMP currently implements:
 
-   * `::Val{:call}`, which forwards calls to [`parse_constraint_call`](@ref)
-   * `::Val{:comparison}`, which handles the special case of `l <= body <= u`.
+  - `::Val{:call}`, which forwards calls to [`parse_constraint_call`](@ref)
+  - `::Val{:comparison}`, which handles the special case of `l <= body <= u`.
 
 See also: [`parse_constraint_call`](@ref), [`build_constraint`](@ref)
 """
@@ -430,6 +442,7 @@ Implement this method to intercept the parsing of a `:call` expression with
 operator `op`.
 
 !!! warning
+    
     Extending the constraint macro at parse time is an advanced operation and
     has the potential to interfere with existing JuMP syntax. Please discuss
     with the [developer chatroom](https://gitter.im/JuliaOpt/jump-dev) before
@@ -437,21 +450,21 @@ operator `op`.
 
 ## Arguments
 
- * `_error`: a function that accepts a `String` and throws the string as an
-   error, along with some descriptive information of the macro from which it was
-   thrown.
- * `is_vectorized`: a boolean to indicate if `op` should be broadcast or not
- * `op`: the first element of the `.args` field of the `Expr` to intercept
- * `args...`: the `.args` field of the `Expr`.
+  - `_error`: a function that accepts a `String` and throws the string as an
+    error, along with some descriptive information of the macro from which it was
+    thrown.
+  - `is_vectorized`: a boolean to indicate if `op` should be broadcast or not
+  - `op`: the first element of the `.args` field of the `Expr` to intercept
+  - `args...`: the `.args` field of the `Expr`.
 
 ## Returns
 
 This function must return:
 
- * `parse_code::Expr`: an expression containing any setup or rewriting code that
-   needs to be called before `build_constraint`
- * `build_code::Expr`: an expression that calls `build_constraint(` or
-   `build_constraint.(` depending on `is_vectorized`.
+  - `parse_code::Expr`: an expression containing any setup or rewriting code that
+    needs to be called before `build_constraint`
+  - `build_code::Expr`: an expression that calls `build_constraint(` or
+    `build_constraint.(` depending on `is_vectorized`.
 
 See also: [`parse_constraint_head`](@ref), [`build_constraint`](@ref)
 """
@@ -710,6 +723,7 @@ end
     )
 
 Returns the code for the macro `@constraint args...` of syntax
+
 ```julia
 @constraint(model, con, extra_arg, kw_args...)      # single constraint
 @constraint(model, ref, con, extra_arg, kw_args...) # group of constraints
@@ -858,42 +872,43 @@ Add a group of constraints described by the expression `expr` parametrized by
 
 The expression `expr` can either be
 
-* of the form `func in set` constraining the function `func` to belong to the
-  set `set` which is either a [`MOI.AbstractSet`](https://jump.dev/MathOptInterface.jl/v0.6.2/apireference.html#Sets-1)
-  or one of the JuMP shortcuts [`SecondOrderCone`](@ref),
-  [`RotatedSecondOrderCone`](@ref) and [`PSDCone`](@ref), e.g.
-  `@constraint(model, [1, x-1, y-2] in SecondOrderCone())` constrains the norm
-  of `[x-1, y-2]` be less than 1;
-* of the form `a sign b`, where `sign` is one of `==`, `≥`, `>=`, `≤` and
-  `<=` building the single constraint enforcing the comparison to hold for the
-  expression `a` and `b`, e.g. `@constraint(m, x^2 + y^2 == 1)` constrains `x`
-  and `y` to lie on the unit circle;
-* of the form `a ≤ b ≤ c` or `a ≥ b ≥ c` (where `≤` and `<=` (resp. `≥` and
-  `>=`) can be used interchangeably) constraining the paired the expression
-  `b` to lie between `a` and `c`;
-* of the forms `@constraint(m, a .sign b)` or
-  `@constraint(m, a .sign b .sign c)` which broadcast the constraint creation to
-  each element of the vectors.
+  - of the form `func in set` constraining the function `func` to belong to the
+    set `set` which is either a [`MOI.AbstractSet`](https://jump.dev/MathOptInterface.jl/v0.6.2/apireference.html#Sets-1)
+    or one of the JuMP shortcuts [`SecondOrderCone`](@ref),
+    [`RotatedSecondOrderCone`](@ref) and [`PSDCone`](@ref), e.g.
+    `@constraint(model, [1, x-1, y-2] in SecondOrderCone())` constrains the norm
+    of `[x-1, y-2]` be less than 1;
+  - of the form `a sign b`, where `sign` is one of `==`, `≥`, `>=`, `≤` and
+    `<=` building the single constraint enforcing the comparison to hold for the
+    expression `a` and `b`, e.g. `@constraint(m, x^2 + y^2 == 1)` constrains `x`
+    and `y` to lie on the unit circle;
+  - of the form `a ≤ b ≤ c` or `a ≥ b ≥ c` (where `≤` and `<=` (resp. `≥` and
+    `>=`) can be used interchangeably) constraining the paired the expression
+    `b` to lie between `a` and `c`;
+  - of the forms `@constraint(m, a .sign b)` or
+    `@constraint(m, a .sign b .sign c)` which broadcast the constraint creation to
+    each element of the vectors.
 
 The recognized keyword arguments in `kw_args` are the following:
 
-* `base_name`: Sets the name prefix used to generate constraint names. It
-  corresponds to the constraint name for scalar constraints, otherwise, the
-  constraint names are set to `base_name[...]` for each index `...` of the axes
-  `axes`.
-* `container`: Specify the container type.
-* `set_string_name::Bool = true`: control whether to set the
-  [`MOI.ConstraintName`](@ref) attribute. Passing `set_string_name = false` can
-  improve performance.
+  - `base_name`: Sets the name prefix used to generate constraint names. It
+    corresponds to the constraint name for scalar constraints, otherwise, the
+    constraint names are set to `base_name[...]` for each index `...` of the axes
+    `axes`.
+  - `container`: Specify the container type.
+  - `set_string_name::Bool = true`: control whether to set the
+    [`MOI.ConstraintName`](@ref) attribute. Passing `set_string_name = false` can
+    improve performance.
 
 ## Note for extending the constraint macro
 
 Each constraint will be created using
 `add_constraint(m, build_constraint(_error, func, set))` where
-* `_error` is an error function showing the constraint call in addition to the
-  error message given as argument,
-* `func` is the expression that is constrained
-* and `set` is the set in which it is constrained to belong.
+
+  - `_error` is an error function showing the constraint call in addition to the
+    error message given as argument,
+  - `func` is the expression that is constrained
+  - and `set` is the set in which it is constrained to belong.
 
 For `expr` of the first type (i.e. `@constraint(m, func in set)`), `func` and
 `set` are passed unchanged to `build_constraint` but for the other types, they
@@ -935,7 +950,14 @@ model = Model();
 @build_constraint(2x >= 1)
 
 # output
-ScalarConstraint{GenericAffExpr{Float64,VariableRef},MathOptInterface.GreaterThan{Float64}}(2 x, MathOptInterface.GreaterThan{Float64}(1.0))
+
+ScalarConstraint{
+    GenericAffExpr{Float64,VariableRef},
+    MathOptInterface.GreaterThan{Float64},
+}(
+    2x,
+    MathOptInterface.GreaterThan{Float64}(1.0),
+)
 ```
 """
 macro build_constraint(constraint_expr)
@@ -1232,6 +1254,7 @@ expression of JuMP variables.
 ## Examples
 
 To minimize the value of the variable `x`, do as follows:
+
 ```jldoctest @objective; setup = :(using JuMP)
 julia> model = Model()
 A JuMP Model
@@ -1249,6 +1272,7 @@ x
 ```
 
 To maximize the value of the affine expression `2x - 1`, do as follows:
+
 ```jldoctest @objective
 julia> @objective(model, Max, 2x - 1)
 2 x - 1
@@ -1256,6 +1280,7 @@ julia> @objective(model, Max, 2x - 1)
 
 To set a quadratic objective and set the objective sense programmatically, do
 as follows:
+
 ```jldoctest @objective
 julia> sense = MIN_SENSE
 MIN_SENSE::OptimizationSense = 0
@@ -1299,7 +1324,7 @@ immediately. Instead, returns the expression which can then be inserted in other
 constraints. For example:
 
 ```julia
-@expression(m, shared, sum(i*x[i] for i=1:5))
+@expression(m, shared, sum(i * x[i] for i in 1:5))
 @constraint(m, shared + y >= 5)
 @constraint(m, shared + z <= 10)
 ```
@@ -1308,13 +1333,13 @@ The `ref` accepts index sets in the same way as `@variable`, and those indices
 can be used in the construction of the expressions:
 
 ```julia
-@expression(m, expr[i=1:3], i*sum(x[j] for j=1:3))
+@expression(m, expr[i = 1:3], i * sum(x[j] for j in 1:3))
 ```
 
 Anonymous syntax is also supported:
 
 ```julia
-expr = @expression(m, [i=1:3], i*sum(x[j] for j=1:3))
+expr = @expression(m, [i = 1:3], i * sum(x[j] for j in 1:3))
 ```
 """
 macro expression(args...)
@@ -1385,18 +1410,19 @@ It should never be called by users of JuMP.
 
 ## Arguments
 
- * `_error`: a function to call instead of `error`. `_error` annotates the
-   error message with additional information for the user.
- * `info`: an instance of [`VariableInfo`](@ref). This has a variety of fields
-   relating to the variable such as `info.lower_bound` and `info.binary`.
- * `args`: optional additional positional arguments for extending the
-   [`@variable`](@ref) macro.
- * `kwargs`: optional keyword arguments for extending the [`@variable`](@ref)
-   macro.
+  - `_error`: a function to call instead of `error`. `_error` annotates the
+    error message with additional information for the user.
+  - `info`: an instance of [`VariableInfo`](@ref). This has a variety of fields
+    relating to the variable such as `info.lower_bound` and `info.binary`.
+  - `args`: optional additional positional arguments for extending the
+    [`@variable`](@ref) macro.
+  - `kwargs`: optional keyword arguments for extending the [`@variable`](@ref)
+    macro.
 
 See also: [`@variable`](@ref)
 
 !!! warning
+    
     Extensions should define a method with ONE positional argument to dispatch
     the call to a different method. Creating an extension that relies on
     multiple positional arguments leads to `MethodError`s if the user passes the
@@ -1407,22 +1433,28 @@ See also: [`@variable`](@ref)
 ```julia
 @variable(model, x, Foo)
 ```
+
 will call
+
 ```julia
 build_variable(_error::Function, info::VariableInfo, ::Type{Foo})
 ```
 
 Passing special-case positional arguments such as `Bin`, `Int`, and `PSD` is
 okay, along with keyword arguments:
+
 ```julia
 @variable(model, x, Int, Foo(), mykwarg = true)
 # or
 @variable(model, x, Foo(), Int, mykwarg = true)
 ```
+
 will call
+
 ```julia
 build_variable(_error::Function, info::VariableInfo, ::Foo; mykwarg)
 ```
+
 and `info.integer` will be true.
 
 Note that the order of the positional arguments does not matter.
@@ -1807,85 +1839,86 @@ positional arguments `args` and the keyword arguments `kw_args`.
 
 `expr` must be one of the forms:
 
- * Omitted, like `@variable(model)`, which creates an anonymous variable
- * A single symbol like `@variable(model, x)`
- * A container expression like `@variable(model, x[i=1:3])`
- * An anoymous container expression like `@variable(model, [i=1:3])`
+  - Omitted, like `@variable(model)`, which creates an anonymous variable
+  - A single symbol like `@variable(model, x)`
+  - A container expression like `@variable(model, x[i=1:3])`
+  - An anoymous container expression like `@variable(model, [i=1:3])`
 
 ## Bounds
 
 In addition, the expression can have bounds, such as:
 
- * `@variable(model, x >= 0)`
- * `@variable(model, x <= 0)`
- * `@variable(model, x == 0)`
- * `@variable(model, 0 <= x <= 1)`
+  - `@variable(model, x >= 0)`
+  - `@variable(model, x <= 0)`
+  - `@variable(model, x == 0)`
+  - `@variable(model, 0 <= x <= 1)`
 
 and bounds can depend on the indices of the container expressions:
 
- * `@variable(model, -i <= x[i=1:3] <= i)`
+  - `@variable(model, -i <= x[i=1:3] <= i)`
 
 ## Sets
 
 You can explicitly specify the set to which the variable belongs:
 
- * `@variable(model, x in MOI.Interval(0.0, 1.0))`
+  - `@variable(model, x in MOI.Interval(0.0, 1.0))`
 
- For more information on this syntax, read
+For more information on this syntax, read
 [Variables constrained on creation](@ref).
 
 ## Positional arguments
 
 The recognized positional arguments in `args` are the following:
 
- * `Bin`: restricts the variable to the [`MOI.ZeroOne`](@ref) set, that is,
-   `{0, 1}`. For example, `@variable(model, x, Bin)`. Note: you cannot use
-   `@variable(model, Bin)`, use the `binary` keyword instead.
- * `Int`: restricts the variable to the set of integers, that is, ..., -2, -1,
+  - `Bin`: restricts the variable to the [`MOI.ZeroOne`](@ref) set, that is,
+    `{0, 1}`. For example, `@variable(model, x, Bin)`. Note: you cannot use
+    `@variable(model, Bin)`, use the `binary` keyword instead.
+  - `Int`: restricts the variable to the set of integers, that is, ..., -2, -1,
     0, 1, 2, ... For example, `@variable(model, x, Int)`. Note: you cannot use
     `@variable(model, Int)`, use the `integer` keyword instead.
- * `Symmetric`: Only available when creating a square matrix of variables, i.e.,
-   when `expr` is of the form `varname[1:n,1:n]` or `varname[i=1:n,j=1:n]`,
-   it creates a symmetric matrix of variables.
- * `PSD`: A restrictive extension to `Symmetric` which constraints a square
-   matrix of variables to `Symmetric` and constrains to be positive
-   semidefinite.
+  - `Symmetric`: Only available when creating a square matrix of variables, i.e.,
+    when `expr` is of the form `varname[1:n,1:n]` or `varname[i=1:n,j=1:n]`,
+    it creates a symmetric matrix of variables.
+  - `PSD`: A restrictive extension to `Symmetric` which constraints a square
+    matrix of variables to `Symmetric` and constrains to be positive
+    semidefinite.
 
 ## Keyword arguments
 
 Four keyword arguments are useful in all cases:
 
- * `base_name`: Sets the name prefix used to generate variable names. It
-   corresponds to the variable name for scalar variable, otherwise, the
-   variable names are set to `base_name[...]` for each index `...` of the axes
-   `axes`.
- * `start::Float64`: specify the value passed to `set_start_value` for each
-   variable
- * `container`: specify the container type. See
-   [Forcing the container type](@ref variable_forcing) for more information.
- * `set_string_name::Bool = true`: control whether to set the
-   [`MOI.VariableName`](@ref) attribute. Passing `set_string_name = false` can
-   improve performance.
+  - `base_name`: Sets the name prefix used to generate variable names. It
+    corresponds to the variable name for scalar variable, otherwise, the
+    variable names are set to `base_name[...]` for each index `...` of the axes
+    `axes`.
+  - `start::Float64`: specify the value passed to `set_start_value` for each
+    variable
+  - `container`: specify the container type. See
+    [Forcing the container type](@ref variable_forcing) for more information.
+  - `set_string_name::Bool = true`: control whether to set the
+    [`MOI.VariableName`](@ref) attribute. Passing `set_string_name = false` can
+    improve performance.
 
 Other keyword arguments are needed to disambiguate sitations with anonymous
 variables:
 
- * `lower_bound::Float64`: an alternative to `x >= lb`, sets the value of the
-   variable lower bound.
- * `upper_bound::Float64`: an alternative to `x <= ub`, sets the value of the
-   variable upper bound.
- * `binary::Bool`: an alternative to passing `Bin`, sets whether the variable
-   is binary or not.
- * `integer::Bool`: an alternative to passing `Int`, sets whether the variable
-   is integer or not.
- * `set::MOI.AbstractSet`: an alternative to using `x in set`
- * `variable_type`: used by JuMP extensions. See
-   [Extend `@variable`](@ref extend_variable_macro) for more information.
+  - `lower_bound::Float64`: an alternative to `x >= lb`, sets the value of the
+    variable lower bound.
+  - `upper_bound::Float64`: an alternative to `x <= ub`, sets the value of the
+    variable upper bound.
+  - `binary::Bool`: an alternative to passing `Bin`, sets whether the variable
+    is binary or not.
+  - `integer::Bool`: an alternative to passing `Int`, sets whether the variable
+    is integer or not.
+  - `set::MOI.AbstractSet`: an alternative to using `x in set`
+  - `variable_type`: used by JuMP extensions. See
+    [Extend `@variable`](@ref extend_variable_macro) for more information.
 
 ## Examples
 
 The following are equivalent ways of creating a variable `x` of name `x` with
 lower bound 0:
+
 ```julia
 model = Model()
 @variable(model, x >= 0)
@@ -1894,11 +1927,12 @@ x = @variable(model, base_name = "x", lower_bound = 0)
 ```
 
 Other examples:
+
 ```julia
 model = Model()
-@variable(model, x[i=1:3] <= i, Int, start = sqrt(i), lower_bound = -i)
-@variable(model, y[i=1:3], container = DenseAxisArray, set = MOI.ZeroOne())
-@variable(model, z[i=1:3], set_string_name = false)
+@variable(model, x[i = 1:3] <= i, Int, start = sqrt(i), lower_bound = -i)
+@variable(model, y[i = 1:3], container = DenseAxisArray, set = MOI.ZeroOne())
+@variable(model, z[i = 1:3], set_string_name = false)
 ```
 """
 macro variable(args...)
@@ -2271,8 +2305,9 @@ nonlinear constraints and the objective. See also [`@expression`]. For example:
 ```
 
 Indexing over sets and anonymous expressions are also supported:
+
 ```julia
-@NLexpression(m, my_expr_1[i=1:3], sin(i * x))
+@NLexpression(m, my_expr_1[i = 1:3], sin(i * x))
 my_expr_2 = @NLexpression(m, log(1 + sum(exp(x[i])) for i in 1:2))
 ```
 """
@@ -2330,12 +2365,14 @@ with initial value set to `value`. Nonlinear parameters may be used only in
 nonlinear expressions.
 
 # Example
+
 ```jldoctest; setup=:(using JuMP)
 model = Model()
 @NLparameter(model, x == 10)
 value(x)
 
 # output
+
 10.0
 ```
 
@@ -2353,6 +2390,7 @@ x = @NLparameter(model, value = 10)
 value(x)
 
 # output
+
 10.0
 ```
 
@@ -2371,6 +2409,7 @@ model = Model()
 value(y[9])
 
 # output
+
 18.0
 ```
 
@@ -2388,6 +2427,7 @@ y = @NLparameter(model, [i = 1:10] == 2 * i)
 value(y[9])
 
 # output
+
 18.0
 ```
 """

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -124,12 +124,14 @@ end
 Return the current value stored in the nonlinear parameter `p`.
 
 # Example
+
 ```jldoctest; setup=:(using JuMP)
 model = Model()
 @NLparameter(model, p == 10)
 value(p)
 
 # output
+
 10.0
 ```
 """
@@ -141,6 +143,7 @@ value(p::NonlinearParameter) = p.model.nlp_data.nlparamvalues[p.index]::Float64
 Store the value `v` in the nonlinear parameter `p`.
 
 # Example
+
 ```jldoctest; setup=:(using JuMP)
 model = Model()
 @NLparameter(model, p == 0)
@@ -148,6 +151,7 @@ set_value(p, 5)
 value(p)
 
 # output
+
 5.0
 ```
 """
@@ -250,13 +254,18 @@ Pass `nothing` to unset a previous start.
 ```jldoctest
 julia> model = Model();
 
+
 julia> @variable(model, x[1:2]);
+
 
 julia> nl1 = @NLconstraint(model, x[1] <= sqrt(x[2]));
 
+
 julia> nl2 = @NLconstraint(model, x[1] >= exp(x[2]));
 
+
 julia> start = Dict(nl1 => -1.0, nl2 => 1.0);
+
 
 julia> start_vector = [start[con] for con in all_nonlinear_constraints(model)]
 2-element Vector{Float64}:
@@ -264,6 +273,7 @@ julia> start_vector = [start[con] for con in all_nonlinear_constraints(model)]
   1.0
 
 julia> set_nonlinear_dual_start_value(model, start_vector)
+
 
 julia> nonlinear_dual_start_value(model)
 2-element Vector{Float64}:
@@ -2016,11 +2026,11 @@ that the inputs are `Float64`.
 
 ## Notes
 
- * For this method, you must explicitly set `autodiff = true`, because no
-   user-provided gradient function `∇f` is given.
- * Second-derivative information is only computed if `dimension == 1`.
- * `s` does not have to be the same symbol as `f`, but it is generally more
-   readable if it is.
+  - For this method, you must explicitly set `autodiff = true`, because no
+    user-provided gradient function `∇f` is given.
+  - Second-derivative information is only computed if `dimension == 1`.
+  - `s` does not have to be the same symbol as `f`, but it is generally more
+    readable if it is.
 
 ## Examples
 
@@ -2091,16 +2101,16 @@ not assume that the inputs are `Float64`.
 
 ## Notes
 
- * If the function `f` is univariate (i.e., `dimension == 1`), `∇f` must return
-   a number which represents the first-order derivative of the function `f`.
- * If the function `f` is multi-variate, `∇f` must have a signature matching
-   `∇f(g::AbstractVector{T}, args::T...) where {T<:Real}`, where the first
-   argument is a vector `g` that is modified in-place with the gradient.
- * If `autodiff = true` and `dimension == 1`, use automatic differentiation to
-   compute the second-order derivative information. If `autodiff = false`, only
-   first-order derivative information will be used.
- * `s` does not have to be the same symbol as `f`, but it is generally more
-   readable if it is.
+  - If the function `f` is univariate (i.e., `dimension == 1`), `∇f` must return
+    a number which represents the first-order derivative of the function `f`.
+  - If the function `f` is multi-variate, `∇f` must have a signature matching
+    `∇f(g::AbstractVector{T}, args::T...) where {T<:Real}`, where the first
+    argument is a vector `g` that is modified in-place with the gradient.
+  - If `autodiff = true` and `dimension == 1`, use automatic differentiation to
+    compute the second-order derivative information. If `autodiff = false`, only
+    first-order derivative information will be used.
+  - `s` does not have to be the same symbol as `f`, but it is generally more
+    readable if it is.
 
 ## Examples
 
@@ -2186,11 +2196,11 @@ derivatives of the function `f` respectively.
 
 ## Notes
 
- * Because automatic differentiation is not used, you can assume the inputs are
-   all `Float64`.
- * This method will throw an error if `dimension > 1`.
- * `s` does not have to be the same symbol as `f`, but it is generally more
-   readable if it is.
+  - Because automatic differentiation is not used, you can assume the inputs are
+    all `Float64`.
+  - This method will throw an error if `dimension > 1`.
+  - `s` does not have to be the same symbol as `f`, but it is generally more
+    readable if it is.
 
 ## Examples
 
@@ -2235,7 +2245,7 @@ programmatically, and you cannot use [`@NLexpression`](@ref).
 
 ## Notes
 
- * You must interpolate the variables directly into the expression `expr`.
+  - You must interpolate the variables directly into the expression `expr`.
 
 ## Examples
 
@@ -2263,13 +2273,14 @@ programmatically, and you cannot use [`@NLobjective`](@ref).
 
 ## Notes
 
- * You must interpolate the variables directly into the expression `expr`.
- * You must use `MIN_SENSE` or `MAX_SENSE` instead of `Min` and `Max`.
+  - You must interpolate the variables directly into the expression `expr`.
+  - You must use `MIN_SENSE` or `MAX_SENSE` instead of `Min` and `Max`.
 
 ## Examples
 
 ```jldoctest; setup=:(using JuMP; model = Model(); @variable(model, x))
 julia> set_nonlinear_objective(model, MIN_SENSE, :(\$(x) + \$(x)^2))
+
 ```
 """
 function set_nonlinear_objective(model::Model, sense::MOI.OptimizationSense, x)
@@ -2286,7 +2297,7 @@ programmatically, and you cannot use [`@NLconstraint`](@ref).
 
 ## Notes
 
- * You must interpolate the variables directly into the expression `expr`.
+  - You must interpolate the variables directly into the expression `expr`.
 
 ## Examples
 

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -134,6 +134,7 @@ The functional equivalent of the [`@objective`](@ref) macro.
 
 Sets the objective sense and objective function simultaneously, and is
 equivalent to:
+
 ```julia
 set_objective_sense(model, sense)
 set_objective_function(model, func)
@@ -197,12 +198,14 @@ julia> objective_function(model, QuadExpr)
 julia> typeof(objective_function(model, QuadExpr))
 GenericQuadExpr{Float64,VariableRef}
 ```
+
 We see with the last two commands that even if the objective function is affine,
 as it is convertible to a quadratic function, it can be queried as a quadratic
 function and the result is quadratic.
 
 However, it is not convertible to a variable.
-```jldoctest objective_function; filter = r"MathOptInterface\\."s
+
+```jldoctest objective_function; filter = r"MathOptInterface."s
 julia> objective_function(model, VariableRef)
 ERROR: InexactError: convert(MathOptInterface.VariableIndex, MathOptInterface.ScalarAffineFunction{Float64}(MathOptInterface.ScalarAffineTerm{Float64}[MathOptInterface.ScalarAffineTerm{Float64}(2.0, MathOptInterface.VariableIndex(1))], 1.0))
 [...]

--- a/src/print.jl
+++ b/src/print.jl
@@ -141,10 +141,11 @@ end
 Print a plain-text summary of `model` to `io`.
 
 For this method to work, an `AbstractModel` subtype should implement:
- * `name(::AbstractModel)`
- * `show_objective_function_summary`
- * `show_constraints_summary`
- * `show_backend_summary`
+
+  - `name(::AbstractModel)`
+  - `show_objective_function_summary`
+  - `show_constraints_summary`
+  - `show_backend_summary`
 """
 function _print_summary(io::IO, model::AbstractModel)
     println(io, name(model))
@@ -227,9 +228,10 @@ end
 Print a plain-text formulation of `model` to `io`.
 
 For this method to work, an `AbstractModel` subtype must implement:
- * `objective_function_string`
- * `constraints_string`
- * `_nl_subexpression_string`
+
+  - `objective_function_string`
+  - `constraints_string`
+  - `_nl_subexpression_string`
 """
 function _print_model(io::IO, model::AbstractModel)
     mode = MIME("text/plain")
@@ -261,9 +263,10 @@ end
 Print a LaTeX formulation of `model` to `io`.
 
 For this method to work, an `AbstractModel` subtype must implement:
- * `objective_function_string`
- * `constraints_string`
- * `_nl_subexpression_string`
+
+  - `objective_function_string`
+  - `constraints_string`
+  - `_nl_subexpression_string`
 """
 function _print_latex(io::IO, model::AbstractModel)
     mode = MIME("text/latex")

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -41,10 +41,10 @@ An expression type representing an quadratic expression of the form:
 
 ## Fields
 
- * `.aff`: an [`GenericAffExpr`](@ref) representing the affine portion of the
-   expression.
- * `.terms`: an `OrderedDict`, with keys of `UnorderedPair{VarType}` and
-   values of `CoefType`, describing the sparse list of terms `q`.
+  - `.aff`: an [`GenericAffExpr`](@ref) representing the affine portion of the
+    expression.
+  - `.terms`: an `OrderedDict`, with keys of `UnorderedPair{VarType}` and
+    values of `CoefType`, describing the sparse list of terms `q`.
 """
 mutable struct GenericQuadExpr{CoefType,VarType} <: AbstractJuMPScalar
     aff::GenericAffExpr{CoefType,VarType}
@@ -503,7 +503,7 @@ end
     QuadExpr
 
 An alias for `GenericQuadExpr{Float64,VariableRef}`, the specific
-    [`GenericQuadExpr`](@ref) used by JuMP.
+[`GenericQuadExpr`](@ref) used by JuMP.
 """
 const QuadExpr = GenericQuadExpr{Float64,VariableRef}
 

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -43,17 +43,25 @@ vectorization is constrained to belong to the
 ## Examples
 
 Consider the following example:
+
 ```jldoctest PSDCone; setup = :(using JuMP)
 julia> model = Model();
+
 
 julia> @variable(model, x)
 x
 
-julia> a = [ x 2x
-            2x  x];
+julia> a = [
+           x 2x
+           2x x
+       ];
 
-julia> b = [1 2
-            2 4];
+
+julia> b = [
+           1 2
+           2 4
+       ];
+
 
 julia> cref = @constraint(model, a >= b, PSDCone())
 [x - 1    2 x - 2;
@@ -69,11 +77,13 @@ julia> jump_function(constraint_object(cref))
 julia> moi_set(constraint_object(cref))
 MathOptInterface.PositiveSemidefiniteConeSquare(2)
 ```
+
 We see in the output of the last command that the matrix the vectorization of the
 matrix is constrained to belong to the `PositiveSemidefiniteConeSquare`.
 
 ```jldoctest PSDCone
 julia> using LinearAlgebra # For Symmetric
+
 
 julia> cref = @constraint(model, Symmetric(a - b) in PSDCone())
 [x - 1    2 x - 2;
@@ -88,6 +98,7 @@ julia> jump_function(constraint_object(cref))
 julia> moi_set(constraint_object(cref))
 MathOptInterface.PositiveSemidefiniteConeTriangle(2)
 ```
+
 As we see in the output of the last command, the vectorization of only the upper
 triangular part of the matrix is constrained to belong to the
 `PositiveSemidefiniteConeSquare`.
@@ -271,6 +282,7 @@ creating variables in `MOI.Reals`, i.e. "free" variables unless they are
 constrained after their creation.
 
 This function is used by the [`@variable`](@ref) macro as follows:
+
 ```julia
 @variable(model, Q[1:2, 1:2], Symmetric)
 ```
@@ -298,6 +310,7 @@ creating variables in `MOI.Reals`, i.e. "free" variables unless they are
 constrained after their creation.
 
 This function is used by the [`@variable`](@ref) macro as follows:
+
 ```julia
 @variable(model, Q[1:2, 1:2] in SkewSymmetricMatrixSpace())
 ```
@@ -324,6 +337,7 @@ Return a `VariablesConstrainedOnCreation` of shape [`SymmetricMatrixShape`](@ref
 constraining the variables to be positive semidefinite.
 
 This function is used by the [`@variable`](@ref) macro as follows:
+
 ```julia
 @variable(model, Q[1:2, 1:2], PSD)
 ```
@@ -361,14 +375,17 @@ Return a `VectorConstraint` of shape [`SymmetricMatrixShape`](@ref) constraining
 the matrix `Q` to be positive semidefinite.
 
 This function is used by the [`@constraint`](@ref) macros as follows:
+
 ```julia
 @constraint(model, Symmetric(Q) in PSDCone())
 ```
+
 The form above is usually used when the entries of `Q` are affine or quadratic
 expressions, but it can also be used when the entries are variables to get the
 reference of the semidefinite constraint, e.g.,
+
 ```julia
-@variable model Q[1:2,1:2] Symmetric
+@variable model Q[1:2, 1:2] Symmetric
 # The type of `Q` is `Symmetric{VariableRef, Matrix{VariableRef}}`
 var_psd = @constraint model Q in PSDCone()
 # The `var_psd` variable contains a reference to the constraint
@@ -399,6 +416,7 @@ Return a `VectorConstraint` of shape [`SquareMatrixShape`](@ref) constraining
 the matrix `Q` to be symmetric and positive semidefinite.
 
 This function is used by the [`@constraint`](@ref) macro as follows:
+
 ```julia
 @constraint(model, Q in PSDCone())
 ```

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -40,10 +40,13 @@ end
     )
 
 A helper method that re-writes
+
 ```julia
 @constraint(model, X >= Y, extra)
 ```
+
 into
+
 ```julia
 @constraint(model, X - Y in extra)
 ```
@@ -67,10 +70,13 @@ end
     )
 
 A helper method that re-writes
+
 ```julia
 @constraint(model, Y <= X, extra)
 ```
+
 into
+
 ```julia
 @constraint(model, X - Y in extra)
 ```
@@ -126,8 +132,10 @@ shortcut for the `MOI.SecondOrderCone`.
 ## Examples
 
 The following constrains ``\\|(x-1, x-2)\\|_2 \\le t`` and ``t \\ge 0``:
+
 ```jldoctest; setup = :(using JuMP)
 julia> model = Model();
+
 
 julia> @variable(model, x)
 x
@@ -135,7 +143,7 @@ x
 julia> @variable(model, t)
 t
 
-julia> @constraint(model, [t, x-1, x-2] in SecondOrderCone())
+julia> @constraint(model, [t, x - 1, x - 2] in SecondOrderCone())
 [t, x - 1, x - 2] ∈ MathOptInterface.SecondOrderCone(3)
 ```
 """
@@ -153,8 +161,10 @@ euclidean norm of a vector `x` to be less than or equal to ``2tu`` where `t` and
 ## Examples
 
 The following constrains ``\\|(x-1, x-2)\\|^2_2 \\le 2tx`` and ``t, x \\ge 0``:
+
 ```jldoctest; setup = :(using JuMP)
 julia> model = Model();
+
 
 julia> @variable(model, x)
 x
@@ -162,7 +172,7 @@ x
 julia> @variable(model, t)
 t
 
-julia> @constraint(model, [t, x, x-1, x-2] in RotatedSecondOrderCone())
+julia> @constraint(model, [t, x, x - 1, x - 2] in RotatedSecondOrderCone())
 [t, x, x - 1, x - 2] ∈ MathOptInterface.RotatedSecondOrderCone(4)
 ```
 """

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -28,6 +28,7 @@ for an example for which this is not the case.
 Consider polynomial constraints for which the dual is moment constraints and
 moment constraints for which the dual is polynomial constraints. Shapes for
 polynomials can be defined as follows:
+
 ```julia
 struct Polynomial
     coefficients::Vector{Float64}
@@ -36,9 +37,13 @@ end
 struct PolynomialShape <: AbstractShape
     monomials::Vector{Monomial}
 end
-JuMP.reshape_vector(x::Vector, shape::PolynomialShape) = Polynomial(x, shape.monomials)
+function JuMP.reshape_vector(x::Vector, shape::PolynomialShape)
+    return Polynomial(x, shape.monomials)
+end
 ```
+
 and a shape for moments can be defined as follows:
+
 ```julia
 struct Moments
     coefficients::Vector{Float64}
@@ -47,10 +52,14 @@ end
 struct MomentsShape <: AbstractShape
     monomials::Vector{Monomial}
 end
-JuMP.reshape_vector(x::Vector, shape::MomentsShape) = Moments(x, shape.monomials)
+function JuMP.reshape_vector(x::Vector, shape::MomentsShape)
+    return Moments(x, shape.monomials)
+end
 ```
+
 Then `dual_shape` allows the definition of the shape of the dual of polynomial
 and moment constraints:
+
 ```julia
 dual_shape(shape::PolynomialShape) = MomentsShape(shape.monomials)
 dual_shape(shape::MomentsShape) = PolynomialShape(shape.monomials)
@@ -70,6 +79,7 @@ Given a [`SymmetricMatrixShape`](@ref) of vectorized form
 `[1, 2, 3] in MOI.PositiveSemidefinieConeTriangle(2)`, the
 following code returns the set of the original constraint
 `Symmetric(Matrix[1 2; 2 3]) in PSDCone()`:
+
 ```jldoctest; setup = :(using JuMP)
 julia> reshape_set(MOI.PositiveSemidefiniteConeTriangle(2), SymmetricMatrixShape(2))
 PSDCone()
@@ -87,6 +97,7 @@ Return an object in its original shape `shape` given its vectorized form
 
 Given a [`SymmetricMatrixShape`](@ref) of vectorized form `[1, 2, 3]`, the
 following code returns the matrix `Symmetric(Matrix[1 2; 2 3])`:
+
 ```jldoctest; setup = :(using JuMP)
 julia> reshape_vector([1, 2, 3], SymmetricMatrixShape(2))
 2×2 LinearAlgebra.Symmetric{Int64,Array{Int64,2}}:

--- a/src/solution_summary.jl
+++ b/src/solution_summary.jl
@@ -41,12 +41,14 @@ dual solution for every constraint, excluding those with empty names.
 ## Examples
 
 When called at the REPL, the summary is automatically printed:
+
 ```julia
 julia> solution_summary(model)
 [...]
 ```
 
 Use `print` to force the printing of the summary from inside a function:
+
 ```julia
 function foo(model)
     print(solution_summary(model))

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -184,7 +184,7 @@ end
 
 Variable returned by [`add_variable`](@ref). Affine (resp. quadratic) operations
 with variables of type `V<:AbstractVariableRef` and coefficients of type `T`
-    create a `GenericAffExpr{T,V}` (resp. `GenericQuadExpr{T,V}`).
+create a `GenericAffExpr{T,V}` (resp. `GenericQuadExpr{T,V}`).
 """
 abstract type AbstractVariableRef <: AbstractJuMPScalar end
 
@@ -212,8 +212,10 @@ end
 Returns the model to which `v` belongs.
 
 # Example
+
 ```jldoctest; setup=:(using JuMP)
 julia> model = Model();
+
 
 julia> x = @variable(model)
 _[1]
@@ -280,6 +282,7 @@ Delete the variable associated with `variable_ref` from the model `model`.
 Note that `delete` does not unregister the name from the model, so adding a new
 variable of the same name will throw an error. Use [`unregister`](@ref) to
 unregister the name after deletion as follows:
+
 ```julia
 @variable(model, x)
 delete(model, x)
@@ -365,6 +368,7 @@ single variable.
 ```jldoctest
 julia> model = Model();
 
+
 julia> @variable(model, x >= 0)
 x
 
@@ -416,13 +420,14 @@ no variable has this name attribute. Throws an error if several variables have
 ```jldoctest objective_function; setup = :(using JuMP), filter = r"Stacktrace:.*"s
 julia> model = Model();
 
+
 julia> @variable(model, x)
 x
 
 julia> variable_by_name(model, "x")
 x
 
-julia> @variable(model, base_name="x")
+julia> @variable(model, base_name = "x")
 x
 
 julia> variable_by_name(model, "x")
@@ -435,7 +440,7 @@ Stacktrace:
  [5] variable_by_name(::Model, ::String) at /home/blegat/.julia/dev/JuMP/src/variables.jl:268
  [6] top-level scope at none:0
 
-julia> var = @variable(model, base_name="y")
+julia> var = @variable(model, base_name = "y")
 y
 
 julia> variable_by_name(model, "y")
@@ -443,7 +448,9 @@ y
 
 julia> set_name(var, "z")
 
+
 julia> variable_by_name(model, "y")
+
 
 julia> variable_by_name(model, "z")
 z
@@ -1121,13 +1128,19 @@ end
 
 Variable `scalar_variables` constrained to belong to `set`.
 Adding this variable can be understood as doing:
+
 ```julia
-function JuMP.add_variable(model::Model, variable::JuMP.VariableConstrainedOnCreation, names)
+function JuMP.add_variable(
+    model::Model,
+    variable::JuMP.VariableConstrainedOnCreation,
+    names,
+)
     var_ref = JuMP.add_variable(model, variable.scalar_variable, name)
     JuMP.add_constraint(model, JuMP.VectorConstraint(var_ref, variable.set))
     return var_ref
 end
 ```
+
 but adds the variables with `MOI.add_constrained_variable(model, variable.set)`
 instead. See [the MOI documentation](https://jump.dev/MathOptInterface.jl/v0.9.3/apireference/#Variables-1)
 for the difference between adding the variables with `MOI.add_constrained_variable`
@@ -1182,14 +1195,24 @@ end
 
 Vector of variables `scalar_variables` constrained to belong to `set`.
 Adding this variable can be thought as doing:
+
 ```julia
-function JuMP.add_variable(model::Model, variable::JuMP.VariablesConstrainedOnCreation, names)
-    var_refs = JuMP.add_variable.(model, variable.scalar_variables,
-                                  JuMP.vectorize(names, variable.shape))
+function JuMP.add_variable(
+    model::Model,
+    variable::JuMP.VariablesConstrainedOnCreation,
+    names,
+)
+    var_refs =
+        JuMP.add_variable.(
+            model,
+            variable.scalar_variables,
+            JuMP.vectorize(names, variable.shape),
+        )
     JuMP.add_constraint(model, JuMP.VectorConstraint(var_refs, variable.set))
     return JuMP.reshape_vector(var_refs, variable.shape)
 end
 ```
+
 but adds the variables with `MOI.add_constrained_variables(model, variable.set)`
 instead. See [the MOI documentation](https://jump.dev/MathOptInterface.jl/v0.9.3/apireference/#Variables-1)
 for the difference between adding the variables with `MOI.add_constrained_variables`
@@ -1288,6 +1311,7 @@ Returns a list of all variables currently in the model. The variables are
 ordered by creation time.
 
 # Example
+
 ```jldoctest; setup=:(using JuMP)
 model = Model()
 @variable(model, x)
@@ -1364,29 +1388,35 @@ end
 Modifies `model` to "relax" all binary and integrality constraints on
 variables. Specifically,
 
-- Binary constraints are deleted, and variable bounds are tightened if
-  necessary to ensure the variable is constrained to the interval ``[0, 1]``.
-- Integrality constraints are deleted without modifying variable bounds.
-- An error is thrown if semi-continuous or semi-integer constraints are
-  present (support may be added for these in the future).
-- All other constraints are ignored (left in place). This includes discrete
-  constraints like SOS and indicator constraints.
+  - Binary constraints are deleted, and variable bounds are tightened if
+    necessary to ensure the variable is constrained to the interval ``[0, 1]``.
+  - Integrality constraints are deleted without modifying variable bounds.
+  - An error is thrown if semi-continuous or semi-integer constraints are
+    present (support may be added for these in the future).
+  - All other constraints are ignored (left in place). This includes discrete
+    constraints like SOS and indicator constraints.
 
 Returns a function that can be called without any arguments to restore the
 original model. The behavior of this function is undefined if additional
 changes are made to the affected variables in the meantime.
 
 # Example
+
 ```jldoctest; setup=:(using JuMP)
 julia> model = Model();
 
+
 julia> @variable(model, x, Bin);
+
 
 julia> @variable(model, 1 <= y <= 10, Int);
 
+
 julia> @objective(model, Min, x + y);
 
+
 julia> undo_relax = relax_integrality(model);
+
 
 julia> print(model)
 Min x + y
@@ -1397,6 +1427,7 @@ Subject to
  y ≤ 10.0
 
 julia> undo_relax()
+
 
 julia> print(model)
 Min x + y

--- a/test/perf/JuMPBenchmarks.jl
+++ b/test/perf/JuMPBenchmarks.jl
@@ -49,10 +49,11 @@ end
 
 Run each micro benchmark function `N` times.
 
- * If `N == 0`, uses the `BenchmarkTools.@benchmark` macro.
- * If `N > 0`, runs the function multiple times with `@time`.
+  - If `N == 0`, uses the `BenchmarkTools.@benchmark` macro.
+  - If `N > 0`, runs the function multiple times with `@time`.
 
 !!! warning
+    
     This is not a rigorous benchmark if `N > 0`. It uses `@time`, so it doesn't
     accurately capture top-level compilation and inference. Use `N = 0` for a
     more rigorous evaluation, or use `JuMPBenchmarks.benchmark` for a comparison


### PR DESCRIPTION
I think this is probably a win in the long term. It found a few cases where we missed a closing ` ``` `, and there were a few places with incorrect spacing after a list of bullets. 

The downside is the change from `*` to `-` and indentation change, which makes the diff a lot noisier than it would otherwise be. But that's just a penalty to pay once.

I think the additional blank lines in doctests if the line returns `nothing` are a bug?
```julia
julia> model = Model();

julia> unregister(model, :x)

julia> 
```
In my REPL there is only a single blank line, not two.


cc @domluna, that 1.0.2 patch worked.