### PR TITLE
[docs] add style guide on abstract types

### DIFF
--- a/docs/src/developers/style.md
+++ b/docs/src/developers/style.md
@@ -216,7 +216,12 @@ validate all assumptions that the code makes. In particular:
 
 For example:
 ```jldoctest my_sum
-function _validate_my_sum_defensive_assumptions(x::AbstractArray{T}) where {T}
+"""
+    test_my_sum_defensive_assumptions(x::AbstractArray{T}) where {T}
+
+Test the assumptions made by `my_sum_defensive`.
+"""
+function test_my_sum_defensive_assumptions(x::AbstractArray{T}) where {T}
     try
         # Some types may not define zero.
         @assert zero(T) isa T
@@ -247,7 +252,7 @@ This function makes the following assumptions:
  * That  `+(::T, ::T)` is defined
 """
 function my_sum_defensive(x::AbstractArray{T}) where {T}
-    _validate_my_sum_defensive_assumptions(x)
+    test_my_sum_defensive_assumptions(x)
     y = zero(T)
     for xi in x
         y += xi
@@ -276,6 +281,10 @@ julia> my_sum_defensive(['a', 'b', 'c'])
 ERROR: Unable to call my_sum_defensive(::Vector{Char}) because it failed an internal assumption
 [...]
 ```
+
+As an alternative, you may choose not to call `test_my_sum_defensive_assumptions`
+within `my_sum_defensive`, and instead ask users of `my_sum_defensive` to call
+it in their tests.
 
 ### Juxtaposed multiplication
 

--- a/docs/src/developers/style.md
+++ b/docs/src/developers/style.md
@@ -84,8 +84,8 @@ This function contains a number of implicit assumptions about the type of `x`:
 
 !!! info
     As a motivating example for the second point, [`VariableRef`](@ref) plus
-    `Float64` produces an [`AffExpr`](@ref). Do not assume that `+(::T, ::T)`
-    produces the type `T`.
+    `Float64` produces an [`AffExpr`](@ref). Do not assume that `+(::A, ::B)`
+    produces the type `A` or `B`.
 
 `my_sum` works as expected if the user passes in `Vector{Float64}`:
 ```jldoctest my_sum

--- a/docs/src/developers/style.md
+++ b/docs/src/developers/style.md
@@ -54,9 +54,9 @@ automatically by JuliaFormatter.
 ### Abstract types and composition
 
 Specifying types for method arguments and struct fields is mostly optional in
-Julia. The benefit of this is that it enables functions and types from one
-package to be used with functions and types from another package via multiple
-dispatch.
+Julia. The benefit of abstract method arguments is that it enables functions
+and types from one package to be used with functions and types from another
+package via multiple dispatch.
 
 However, abstractly typed methods have two main drawbacks:
 

--- a/docs/src/developers/style.md
+++ b/docs/src/developers/style.md
@@ -53,10 +53,10 @@ automatically by JuliaFormatter.
 
 ### Abstract types and composition
 
-Specifying types for method arguments and struct fields is mostly optional in
-Julia. The benefit of abstract method arguments is that it enables functions
-and types from one package to be used with functions and types from another
-package via multiple dispatch.
+Specifying types for method arguments is mostly optional in Julia. The benefit
+of abstract method arguments is that it enables functions and types from one
+package to be used with functions and types from another package via multiple
+dispatch.
 
 However, abstractly typed methods have two main drawbacks:
 
@@ -85,7 +85,7 @@ This function contains a number of implicit assumptions about the type of `x`:
 !!! info
     As a motivating example for the second point, [`VariableRef`](@ref) plus
     `Float64` produces an [`AffExpr`](@ref). Do not assume that `+(::A, ::B)`
-    produces the type `A` or `B`.
+    produces an instance of the type `A` or `B`.
 
 `my_sum` works as expected if the user passes in `Vector{Float64}`:
 ```jldoctest my_sum
@@ -110,7 +110,13 @@ passed by the user.
 
 #### Dealing with `MethodError`s
 
-All code must follow the `MethodError` principle:
+This section diverges from the [Julia style guide](https://docs.julialang.org/en/v1.6/manual/style-guide/#Avoid-writing-overly-specific-types),
+as well as other common guides like [SciML](https://github.com/SciML/SciMLStyle#generic-code-is-preferred-unless-code-is-known-to-be-specific).
+The following suggestions are intended to provide a friendlier experience for
+novice Julia programmers, at the cost of limiting the power and flexibility of
+advanced Julia programmers.
+
+Code should follow the `MethodError` principle:
 
 !!! info "The MethodError principle"
     A user should see a `MethodError` only for methods that they called
@@ -140,7 +146,7 @@ _internal_function(x::Integer) = x + 1
 function _internal_function(x)
     error(
         "Internal error. This probably means that you called " *
-        "public_function() with the wrong type.",
+        "`public_function()`s with the wrong type.",
     )
 end
 public_function(x) = _internal_function(x)

--- a/docs/src/developers/style.md
+++ b/docs/src/developers/style.md
@@ -235,7 +235,7 @@ end
 
 # output
 
-my_sum_defensive (generic function with 1 method)
+my_sum_defensive
 ```
 
 This function works on `Vector{Float64}`:
@@ -249,7 +249,7 @@ julia> my_sum_defensive([(1//2) + (4//3)im; (6//5) + (7//11)im])
 17//10 + 65//33*im
 ```
 and it throws an error when the assumptions aren't met:
-```jldoctest
+```jldoctest my_sum
 julia> my_sum_defensive(['a', 'b', 'c'])
 ERROR: Unable to call my_sum_defensive(::Vector{Char}) because it failed an internal assumption
 [...]


### PR DESCRIPTION
## What is this PR?

This PR adds some recommendations to the JuMP style guide that we think you should follow when working with abstract types and method arguments in Julia.

## Why

The  [not-julia](https://yuri.is/not-julia/) article made some very good points.

There was a long discussion on Discourse:
 * https://discourse.julialang.org/t/discussion-on-why-i-no-longer-recommend-julia-by-yuri-vishnevsky/81151
and also one on HackerNews. Here's the relevant JuMP issue: https://github.com/jump-dev/JuMP.jl/issues/2988

## Feedback

We're in no rush to merge this, so please chime in with feedback. This will likely take a few rounds of edits to get right.

Closes #2988