### PR TITLE
Use MathJax to render formula in doc

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -291,6 +291,7 @@ _validate_pages()
         # See https://github.com/JuliaDocs/Documenter.jl/issues/868
         prettyurls = get(ENV, "CI", nothing) == "true",
         analytics = "UA-44252521-1",
+        mathengine = Documenter.MathJax2(),
         collapselevel = 1,
         assets = ["assets/extra_styles.css"],
         sidebar_sitename = false,


### PR DESCRIPTION
MOI uses MathJax to render formula correctly.
https://github.com/jump-dev/MathOptInterface.jl/blob/fd3d4aa5c8fe0fb2ad412ffcf1825e2ec914a99b/docs/make.jl#L99