### PR TITLE
Add fallback for unsupported Name attribute

### DIFF
--- a/src/print.jl
+++ b/src/print.jl
@@ -131,12 +131,11 @@ default if empty.
 name(model::AbstractModel) = "An Abstract JuMP Model"
 
 function name(model::Model)
-    try
+    if MOI.supports(backend(model), MOI.Name())
         ret = MOI.get(model, MOI.Name())
         return isempty(ret) ? "A JuMP Model" : ret
-    catch
-        return "A JuMP Model"
     end
+    return "A JuMP Model"
 end
 
 """

--- a/src/print.jl
+++ b/src/print.jl
@@ -131,8 +131,12 @@ default if empty.
 name(model::AbstractModel) = "An Abstract JuMP Model"
 
 function name(model::Model)
-    ret = MOI.get(model, MOI.Name())
-    return isempty(ret) ? "A JuMP Model" : ret
+    try
+        ret = MOI.get(model, MOI.Name())
+        return isempty(ret) ? "A JuMP Model" : ret
+    catch
+        return "A JuMP Model"
+    end
 end
 
 """

--- a/test/print.jl
+++ b/test/print.jl
@@ -942,6 +942,15 @@ function test_print_IJulia_with_math_operators()
     return
 end
 
+struct _UnsupportedNameOptimizer <: MOI.AbstractOptimizer end
+MOI.is_empty(::_UnsupportedNameOptimizer) = true
+
+function test_Name_direct_mode()
+    model = direct_model(_UnsupportedNameOptimizer())
+    @test name(model) == "A JuMP Model"
+    return
+end
+
 end
 
 TestPrint.runtests()


### PR DESCRIPTION
Related to https://github.com/jump-dev/Ipopt.jl/issues/317. We can fix Ipopt, but there might be other solvers.  The `Name` attribute is optional, in general.