### PR TITLE
Tidy docs/.gitignore

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,7 +1,5 @@
 build/
 latex_build/
-src/examples/*.md
-src/examples/*/*.md
 src/tutorials/*/*.md
 !src/tutorials/*/introduction.md
 src/moi/


### PR DESCRIPTION
There's no examples subdirectory, so these lines don't seem necessary.