### PR TITLE
Allow `_AxisLookup` to fallback to Dict `getindex`

### DIFF
--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -48,17 +48,17 @@ function build_lookup(ax)
     return _AxisLookup(d)
 end
 
-Base.getindex(x::_AxisLookup{Dict{K,Int}}, key::K) where {K} = x.data[key]
+Base.getindex(x::_AxisLookup{Dict{K,Int}}, key) where {K} = x.data[key]
 Base.getindex(::_AxisLookup{Dict{K,Int}}, key::Colon) where {K} = key
 
 function Base.getindex(
     x::_AxisLookup{Dict{K,Int}},
-    keys::AbstractVector{<:K},
+    keys::AbstractVector,
 ) where {K}
     return [x[key] for key in keys]
 end
 
-function Base.get(x::_AxisLookup{Dict{K,Int}}, key::K, default) where {K}
+function Base.get(x::_AxisLookup{Dict{K,Int}}, key, default) where {K}
     return get(x.data, key, default)
 end
 

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -93,6 +93,13 @@ And data, a 2-element $(Vector{Float64}):
         @test 1 .+ A == correct_answer
     end
 
+    @testset "String index set" begin
+        A = @inferred DenseAxisArray([1.0, 2.0], ["a", "b"])
+        @test (@inferred A["a"]) == (@inferred A[GenericString("a")]) == 1.0
+        @test (@inferred A[["a", "b"]]) ==
+            (@inferred A[[GenericString("a"), GenericString("b")]]) == A
+    end
+
     @testset "Mixed range/symbol index sets" begin
         A = @inferred DenseAxisArray([1 2; 3 4], 2:3, [:a, :b])
         @test size(A) == (2, 2)
@@ -248,6 +255,11 @@ And data, a 0-dimensional $(Array{Int,0}):
         @test (@inferred C[2:3, [:a, :b]]) == C
         @test (@inferred C[2, [:a, :b]]) == DenseAxisArray([5.0, 6.0], [:a, :b])
         @test (@inferred C[2:3, :b]) == DenseAxisArray([6.0, 8.0], 2:3)
+
+        D = DenseAxisArray([5.0 6.0; 7.0 8.0], 2:3, ["a", "b"])
+        @test (@inferred D[2, GenericString("b")]) == 6.0
+        @test (@inferred D[2, [GenericString("a"), GenericString("b")]]) ==
+            DenseAxisArray([5.0, 6.0], ["a", "b"])
     end
     @testset "BitArray" begin
         x = DenseAxisArray([0 1; 1 0], [:a, :b], 1:2)

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -97,7 +97,8 @@ And data, a 2-element $(Vector{Float64}):
         A = @inferred DenseAxisArray([1.0, 2.0], ["a", "b"])
         @test (@inferred A["a"]) == (@inferred A[GenericString("a")]) == 1.0
         @test (@inferred A[["a", "b"]]) ==
-              (@inferred A[[GenericString("a"), GenericString("b")]]) == A
+              (@inferred A[[GenericString("a"), GenericString("b")]]) ==
+              A
     end
 
     @testset "Mixed range/symbol index sets" begin

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -43,6 +43,7 @@ using Test
         @test isassigned(A, 2)
         @test !isassigned(A, 1)
         @test length.(axes(A)) == (2,)
+        @test_throws KeyError A["2"]
 
         correct_answer = DenseAxisArray([2.0, 3.0], 2:3)
         @test sprint(show, correct_answer) == """

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -97,7 +97,7 @@ And data, a 2-element $(Vector{Float64}):
         A = @inferred DenseAxisArray([1.0, 2.0], ["a", "b"])
         @test (@inferred A["a"]) == (@inferred A[GenericString("a")]) == 1.0
         @test (@inferred A[["a", "b"]]) ==
-            (@inferred A[[GenericString("a"), GenericString("b")]]) == A
+              (@inferred A[[GenericString("a"), GenericString("b")]]) == A
     end
 
     @testset "Mixed range/symbol index sets" begin
@@ -259,7 +259,7 @@ And data, a 0-dimensional $(Array{Int,0}):
         D = DenseAxisArray([5.0 6.0; 7.0 8.0], 2:3, ["a", "b"])
         @test (@inferred D[2, GenericString("b")]) == 6.0
         @test (@inferred D[2, [GenericString("a"), GenericString("b")]]) ==
-            DenseAxisArray([5.0, 6.0], ["a", "b"])
+              DenseAxisArray([5.0, 6.0], ["a", "b"])
     end
     @testset "BitArray" begin
         x = DenseAxisArray([0 1; 1 0], [:a, :b], 1:2)


### PR DESCRIPTION
- Allows e.g. looking up `String` key with another `AbstractString` 
- The use-case here is when a DenseAxisArray is created with `InlineString` keys but where this is an implementation detail and we want to be able to index with a regular `String`
  
Before:
```julia
julia> using JuMP, InlineStrings

julia> daa = JuMP.Containers.DenseAxisArray(reshape(1:6, 2, :), 1:2, ["a","b","c"])
2-dimensional DenseAxisArray{Int64,2,...} with index sets:
    Dimension 1, 1:2
    Dimension 2, ["a", "b", "c"]
And data, a 2×3 Matrix{Int64}:
 1  3  5
 2  4  6

julia> daa[1, "b"]
3

julia> daa[1, InlineString("b")]
ERROR: KeyError: key "b" not found
Stacktrace:
 [1] getindex(#unused#::JuMP.Containers._AxisLookup{Dict{String, Int64}}, key::String1)
   @ JuMP.Containers ~/.julia/packages/JuMP/Y4piv/src/Containers/DenseAxisArray.jl:18
 [2] _getindex_recurse(data::Tuple{JuMP.Containers._AxisLookup{Dict{String, Int64}}}, keys::Tuple{String1}, condition::JuMP.Containers.var"#10#12")
   @ JuMP.Containers ~/.julia/packages/JuMP/Y4piv/src/Containers/DenseAxisArray.jl:309
 [3] _getindex_recurse(data::Tuple{JuMP.Containers._AxisLookup{Tuple{Int64, Int64}}, JuMP.Containers._AxisLookup{Dict{String, Int64}}}, keys::Tuple{Int64, String1}, condition::JuMP.Containers.var"#10#12")
   @ JuMP.Containers ~/.julia/packages/JuMP/Y4piv/src/Containers/DenseAxisArray.jl:308
 [4] to_index(A::JuMP.Containers.DenseAxisArray{Int64, 2, Tuple{UnitRange{Int64}, Vector{String}}, Tuple{JuMP.Containers._AxisLookup{Tuple{Int64, Int64}}, JuMP.Containers._AxisLookup{Dict{String, Int64}}}}, idx::Tuple{Int64, String1})
   @ JuMP.Containers ~/.julia/packages/JuMP/Y4piv/src/Containers/DenseAxisArray.jl:318
 [5] getindex(::JuMP.Containers.DenseAxisArray{Int64, 2, Tuple{UnitRange{Int64}, Vector{String}}, Tuple{JuMP.Containers._AxisLookup{Tuple{Int64, Int64}}, JuMP.Containers._AxisLookup{Dict{String, Int64}}}}, ::Int64, ::String1)
   @ JuMP.Containers ~/.julia/packages/JuMP/Y4piv/src/Containers/DenseAxisArray.jl:325
 [6] top-level scope
   @ REPL[33]:1
```

After (this PR):
```julia
julia> daa[1, InlineString("b")]
3

julia> daa2 = JuMP.Containers.DenseAxisArray(reshape(1:6, 2, :), 1:2, InlineString.(["a","b","c"]));

julia> daa2[1, "b"]
3
```