### PR TITLE
[Containers] add slicing for SparseAxisArray

### DIFF
--- a/docs/src/manual/containers.md
+++ b/docs/src/manual/containers.md
@@ -207,33 +207,32 @@ JuMP.Containers.SparseAxisArray{Tuple{Int64, Int64}, 2, Tuple{Int64, Int64}} wit
 
 The `[indices; condition]` syntax is used:
 ```jldoctest containers_sparse
-julia> x = Containers.@container([i = 1:3, j = [:A, :B]; i > 1 && j == :B], (i, j))
+julia> x = Containers.@container([i = 1:3, j = [:A, :B]; i > 1], (i, j))
 JuMP.Containers.SparseAxisArray{Tuple{Int64, Symbol}, 2, Tuple{Int64, Symbol}} with 2 entries:
+  [2, A]  =  (2, :A)
   [2, B]  =  (2, :B)
+  [3, A]  =  (3, :A)
   [3, B]  =  (3, :B)
 ```
 Here we have the index sets `i = 1:3, j = [:A, :B]`, followed by `;`, and then a
-condition, which evaluates to `true` or `false`: `i > 1 && j == :B`.
+condition, which evaluates to `true` or `false`: `i > 1`.
 
 ### Slicing
 
-```@meta
-# TODO: This is included so we know to update the documentation when this is fixed.
-```
-
-Slicing is not supported.
+Slicing is supported:
 ```jldoctest containers_sparse
-julia> x[:, :B]
-ERROR: ArgumentError: Indexing with `:` is not supported by Containers.SparseAxisArray
-[...]
+julia> y = x[:, :B]
+SparseAxisArray{Tuple{Int64, Symbol}, 2, Tuple{Int64, Symbol}} with 2 entries:
+  [2, B]  =  (2, :B)
+  [3, B]  =  (3, :B)
 ```
 
 ### Looping
 
 Use `eachindex` to loop over the elements:
 ```jldoctest containers_sparse
-julia> for key in eachindex(x)
-           println(x[key])
+julia> for key in eachindex(y)
+           println(y[key])
        end
 (2, :B)
 (3, :B)
@@ -247,7 +246,7 @@ Broadcasting over a SparseAxisArray returns a SparseAxisArray
 julia> swap(x::Tuple) = (last(x), first(x))
 swap (generic function with 1 method)
 
-julia> swap.(x)
+julia> swap.(y)
 JuMP.Containers.SparseAxisArray{Tuple{Symbol, Int64}, 2, Tuple{Int64, Symbol}} with 2 entries:
   [2, B]  =  (:B, 2)
   [3, B]  =  (:B, 3)

--- a/docs/src/manual/containers.md
+++ b/docs/src/manual/containers.md
@@ -222,9 +222,9 @@ condition, which evaluates to `true` or `false`: `i > 1`.
 Slicing is supported:
 ```jldoctest containers_sparse
 julia> y = x[:, :B]
-JuMP.Containers.SparseAxisArray{Tuple{Int64, Symbol}, 2, Tuple{Int64, Symbol}} with 2 entries:
-  [2, B]  =  (2, :B)
-  [3, B]  =  (3, :B)
+JuMP.Containers.SparseAxisArray{Tuple{Int64, Symbol}, 1, Tuple{Int64}} with 2 entries:
+  [2]  =  (2, :B)
+  [3]  =  (3, :B)
 ```
 
 ### Looping
@@ -247,9 +247,9 @@ julia> swap(x::Tuple) = (last(x), first(x))
 swap (generic function with 1 method)
 
 julia> swap.(y)
-JuMP.Containers.SparseAxisArray{Tuple{Symbol, Int64}, 2, Tuple{Int64, Symbol}} with 2 entries:
-  [2, B]  =  (:B, 2)
-  [3, B]  =  (:B, 3)
+JuMP.Containers.SparseAxisArray{Tuple{Symbol, Int64}, 1, Tuple{Int64}} with 2 entries:
+  [2]  =  (:B, 2)
+  [3]  =  (:B, 3)
 ```
 
 ## Forcing the container type

--- a/docs/src/manual/containers.md
+++ b/docs/src/manual/containers.md
@@ -208,7 +208,7 @@ JuMP.Containers.SparseAxisArray{Tuple{Int64, Int64}, 2, Tuple{Int64, Int64}} wit
 The `[indices; condition]` syntax is used:
 ```jldoctest containers_sparse
 julia> x = Containers.@container([i = 1:3, j = [:A, :B]; i > 1], (i, j))
-JuMP.Containers.SparseAxisArray{Tuple{Int64, Symbol}, 2, Tuple{Int64, Symbol}} with 2 entries:
+JuMP.Containers.SparseAxisArray{Tuple{Int64, Symbol}, 2, Tuple{Int64, Symbol}} with 4 entries:
   [2, A]  =  (2, :A)
   [2, B]  =  (2, :B)
   [3, A]  =  (3, :A)
@@ -222,7 +222,7 @@ condition, which evaluates to `true` or `false`: `i > 1`.
 Slicing is supported:
 ```jldoctest containers_sparse
 julia> y = x[:, :B]
-SparseAxisArray{Tuple{Int64, Symbol}, 2, Tuple{Int64, Symbol}} with 2 entries:
+JuMP.Containers.SparseAxisArray{Tuple{Int64, Symbol}, 2, Tuple{Int64, Symbol}} with 2 entries:
   [2, B]  =  (2, :B)
   [3, B]  =  (3, :B)
 ```

--- a/src/Containers/SparseAxisArray.jl
+++ b/src/Containers/SparseAxisArray.jl
@@ -127,10 +127,9 @@ function Base.getindex(d::SparseAxisArray{T,N,K}, idx...) where {T,N,K}
         throw(BoundsError(d, idx))
     end
     if _is_slice(first(keys(d.data)), idx)
-        new_data = Dict(
-            _new_key(k, idx) => v for (k, v) in d.data if _filter(k, idx)
-        )
-        if length(new_data) > 0
+        new_data =
+            Dict(_new_key(k, idx) => v for (k, v) in d.data if _filter(k, idx))
+        if !isempty(new_data)
             return SparseAxisArray(new_data)
         end
     end

--- a/src/Containers/SparseAxisArray.jl
+++ b/src/Containers/SparseAxisArray.jl
@@ -85,20 +85,6 @@ function Base.haskey(sa::SparseAxisArray{T,1,Tuple{I}}, idx::I) where {T,I}
     return haskey(sa.data, (idx,))
 end
 
-# Error for sa[..., :, ...]
-_colon_error() = nothing
-
-_colon_error(::Any, args...) = _colon_error(args...)
-
-function _colon_error(::Colon, args...)
-    return throw(
-        ArgumentError(
-            "Indexing with `:` is not supported by" *
-            " Containers.SparseAxisArray",
-        ),
-    )
-end
-
 function Base.setindex!(
     d::SparseAxisArray{T,N,K},
     value,
@@ -107,11 +93,16 @@ function Base.setindex!(
     return setindex!(d, value, idx...)
 end
 
-function Base.setindex!(d::SparseAxisArray{T,N}, value, idx...) where {T,N}
+function Base.setindex!(d::SparseAxisArray{T,N,K}, value, idx...) where {T,N,K}
     if length(idx) < N
         throw(BoundsError(d, idx))
+    elseif _sliced_key_type(K, idx...) !== nothing
+        throw(
+            ArgumentError(
+                "Slicing is not when calling setindex! on a SparseAxisArray",
+            ),
+        )
     end
-    _colon_error(idx...)
     return setindex!(d.data, value, idx)
 end
 

--- a/test/Containers/SparseAxisArray.jl
+++ b/test/Containers/SparseAxisArray.jl
@@ -4,14 +4,6 @@ using Test
 @testset "SparseAxisArray" begin
     function sparse_test(d, sum_d, d2, d3, dsqr, d_bads)
         sqr(x) = x^2
-        @testset "Colon indexing" begin
-            err = ArgumentError(
-                "Indexing with `:` is not supported by" *
-                " Containers.SparseAxisArray",
-            )
-            @test_throws err d[:, ntuple(one, ndims(d) - 1)...]
-            @test_throws err d[ntuple(i -> :a, ndims(d) - 1)..., :]
-        end
         @testset "Map" begin
             @test d == @inferred map(identity, d)
             @test dsqr == @inferred map(sqr, d)
@@ -184,5 +176,15 @@ $(SparseAxisArray{Float64,2,Tuple{Symbol,Char}}) with 2 entries"""
         y = f.(x)
         @test y isa SparseAxisArray{Any,2,Tuple{Any,Int}}
         @test isempty(y)
+    end
+    @testset "Slicing" begin
+        Containers.@container(x[i=1:4, j=1:2; isodd(i + j)], i + j)
+        @test x[:, :] == x
+        Containers.@container(y[i=1:1, j=1:2; isodd(i + j)], i + j)
+        @test x[1, :] == y
+        Containers.@container(z[i=1:4, j=1:1; isodd(i + j)], i + j)
+        @test x[:, 1] == z
+        Containers.@container(a1[i=1:4; isodd(i)], i)
+        @test a1[:] == a1
     end
 end

--- a/test/Containers/SparseAxisArray.jl
+++ b/test/Containers/SparseAxisArray.jl
@@ -182,8 +182,15 @@ $(SparseAxisArray{Float64,2,Tuple{Symbol,Char}}) with 2 entries"""
         @test x[:, :] == x
         @test x[1, :] == Containers.@container(y[j = 1:2; isodd(1 + j)], 1 + j)
         @test x[:, 1] == Containers.@container(z[i = 1:4; isodd(i + 1)], i + 1)
+        @test isempty(x[[1, 3], [1, 3]])
+        @test typeof(x[[1, 3], [1, 3]]) == typeof(x)
+        @test typeof(x[[1, 3], 1]) ==
+              Containers.SparseAxisArray{Int,1,Tuple{Int}}
+        @test isempty(x[[1, 3], 1])
         Containers.@container(y[i = 1:4; isodd(i)], i)
         @test y[:] == y
+        Containers.@container(y[i = 1:4; isodd(i)], i)
+        @test y[[1, 3]] == y
         z = Containers.@container([i = 1:3, j = [:A, :B]; i > 1], (i, j))
         @test z[2, :] == Containers.@container([j = [:A, :B]; true], (2, j))
         @test z[:, :A] == Containers.@container([i = 2:3; true], (i, :A))

--- a/test/Containers/SparseAxisArray.jl
+++ b/test/Containers/SparseAxisArray.jl
@@ -178,13 +178,13 @@ $(SparseAxisArray{Float64,2,Tuple{Symbol,Char}}) with 2 entries"""
         @test isempty(y)
     end
     @testset "Slicing" begin
-        Containers.@container(x[i=1:4, j=1:2; isodd(i + j)], i + j)
+        Containers.@container(x[i = 1:4, j = 1:2; isodd(i + j)], i + j)
         @test x[:, :] == x
-        Containers.@container(y[i=1:1, j=1:2; isodd(i + j)], i + j)
+        Containers.@container(y[i = 1:1, j = 1:2; isodd(i + j)], i + j)
         @test x[1, :] == y
-        Containers.@container(z[i=1:4, j=1:1; isodd(i + j)], i + j)
+        Containers.@container(z[i = 1:4, j = 1:1; isodd(i + j)], i + j)
         @test x[:, 1] == z
-        Containers.@container(a1[i=1:4; isodd(i)], i)
+        Containers.@container(a1[i = 1:4; isodd(i)], i)
         @test a1[:] == a1
     end
 end

--- a/test/Containers/SparseAxisArray.jl
+++ b/test/Containers/SparseAxisArray.jl
@@ -201,4 +201,13 @@ $(SparseAxisArray{Float64,2,Tuple{Symbol,Char}}) with 2 entries"""
         @test z[1:2, [:A, :B]] ==
               Containers.@container([i = 2:2, j = [:A, :B]; true], (i, j))
     end
+    @testset "Slicing on set" begin
+        Containers.@container(x[i = 1:4, j = 1:2; isodd(i + j)], i + j)
+        err = ArgumentError(
+            "Slicing is not when calling setindex! on a SparseAxisArray",
+        )
+        @test_throws(err, x[:, :] = 1)
+        @test_throws(err, x[1, :] = 1)
+        @test_throws(err, x[1, 1:2] = 1)
+    end
 end

--- a/test/Containers/SparseAxisArray.jl
+++ b/test/Containers/SparseAxisArray.jl
@@ -180,11 +180,18 @@ $(SparseAxisArray{Float64,2,Tuple{Symbol,Char}}) with 2 entries"""
     @testset "Slicing" begin
         Containers.@container(x[i = 1:4, j = 1:2; isodd(i + j)], i + j)
         @test x[:, :] == x
-        Containers.@container(y[i = 1:1, j = 1:2; isodd(i + j)], i + j)
-        @test x[1, :] == y
-        Containers.@container(z[i = 1:4, j = 1:1; isodd(i + j)], i + j)
-        @test x[:, 1] == z
-        Containers.@container(a1[i = 1:4; isodd(i)], i)
-        @test a1[:] == a1
+        @test x[1, :] == Containers.@container(y[j = 1:2; isodd(1 + j)], 1 + j)
+        @test x[:, 1] == Containers.@container(z[i = 1:4; isodd(i + 1)], i + 1)
+        Containers.@container(y[i = 1:4; isodd(i)], i)
+        @test y[:] == y
+        z = Containers.@container([i = 1:3, j = [:A, :B]; i > 1], (i, j))
+        @test z[2, :] == Containers.@container([j = [:A, :B]; true], (2, j))
+        @test z[:, :A] == Containers.@container([i = 2:3; true], (i, :A))
+        @test z[:, :] == z
+        @test z[1:2, :A] == Containers.@container([i = 2:2; true], (i, :A))
+        @test z[2, [:A, :B]] ==
+              Containers.@container([j = [:A, :B]; true], (2, j))
+        @test z[1:2, [:A, :B]] ==
+              Containers.@container([i = 2:2, j = [:A, :B]; true], (i, j))
     end
 end


### PR DESCRIPTION
Closes #3029

This creates a copy, so it doesn't address the performance issues in @hellemo's talk, but it does address part of the usability.

This PR doesn't support slicing on `setindex!`. We'd have to play with the broadcasting issues.