### PR TITLE
Remove JSON test dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,15 +12,13 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-JSON = "0.21"
 MathOptInterface = "1.3.0"
 MutableArithmetics = "1"
 OrderedCollections = "1"
 julia = "1.6"
 
 [extras]
-JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["JSON", "Test"]
+test = ["Test"]

--- a/test/file_formats.jl
+++ b/test/file_formats.jl
@@ -5,7 +5,6 @@
 
 module TestFileFormats
 
-import JSON
 using JuMP
 using Test
 
@@ -53,9 +52,15 @@ function test_mof_nlp()
     io = IOBuffer()
     write(io, model; format = MOI.FileFormats.FORMAT_MOF)
     seekstart(io)
-    file = JSON.parse(io)
-    @test file["name"] == "MathOptFormat Model"
-    @test length(file["constraints"]) == 2
+    file = read(io, String)
+    @test occursin("\"version\"", file)
+    @test occursin("\"variables\"", file)
+    @test occursin("\"objective\"", file)
+    @test occursin("\"constraints\"", file)
+    @test startswith(file, "{")
+    @test endswith(file, r"}\n?")
+    @test length(file) > 100
+    return
 end
 
 function test_nl_nlp()


### PR DESCRIPTION
We still have JSON as a transitive dependency through MOI, but there's no need to explicitly have it in JuMP just for this one trivial test.