### PR TITLE
Fix tests for MOI v1.7.0

### DIFF
--- a/src/file_formats.jl
+++ b/src/file_formats.jl
@@ -12,15 +12,6 @@ function _throw_write_to_file_explanatory_message(
     )
 end
 
-function _throw_write_to_file_explanatory_message(
-    ::MOI.UnsupportedAttribute{MOI.ObjectiveFunction{F}},
-) where {F}
-    return error(
-        "Unable to write problem to file because the chosen file format " *
-        "doesn't support objective functions of the type $F",
-    )
-end
-
 _throw_write_to_file_explanatory_message(err) = rethrow(err)
 
 function _copy_to_bridged_model(f::Function, model::Model)

--- a/test/file_formats.jl
+++ b/test/file_formats.jl
@@ -103,7 +103,7 @@ function test_unsupported_objective()
         "Unable to write problem to file because the chosen file format " *
         "doesn't support objective functions of the type $F",
     )
-    @test_throws(err, write(io, model; format = MOI.FileFormats.FORMAT_LP))
+    @test_throws(err, write(io, model; format = MOI.FileFormats.FORMAT_CBF))
     return
 end
 

--- a/test/file_formats.jl
+++ b/test/file_formats.jl
@@ -93,20 +93,6 @@ function test_unsupported_constraint()
     return
 end
 
-function test_unsupported_objective()
-    model = Model()
-    @variable(model, x)
-    @objective(model, Min, x^2)
-    io = IOBuffer()
-    F = MOI.ScalarQuadraticFunction{Float64}
-    err = ErrorException(
-        "Unable to write problem to file because the chosen file format " *
-        "doesn't support objective functions of the type $F",
-    )
-    @test_throws(err, write(io, model; format = MOI.FileFormats.FORMAT_SDPA))
-    return
-end
-
 struct _FileFormatsUnsupportedAttribute <: MOI.AbstractVariableAttribute end
 
 function test_unsupported_attribute()

--- a/test/file_formats.jl
+++ b/test/file_formats.jl
@@ -103,7 +103,7 @@ function test_unsupported_objective()
         "Unable to write problem to file because the chosen file format " *
         "doesn't support objective functions of the type $F",
     )
-    @test_throws(err, write(io, model; format = MOI.FileFormats.FORMAT_CBF))
+    @test_throws(err, write(io, model; format = MOI.FileFormats.FORMAT_SDPA))
     return
 end
 


### PR DESCRIPTION
MOI v1.7.0 adds support for quadratic objectives in LP file format.

x-ref: https://github.com/jump-dev/SolverTests/runs/7829702546?check_suite_focus=true