### PR TITLE
Fix parsing of double-sided nl constraints

### DIFF
--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -1474,6 +1474,17 @@ function test_user_defined_hessian()
     return
 end
 
+function test_nlp_comparison()
+    model = Model()
+    @variable(model, x)
+    c1 = @NLconstraint(model, 1 - 2 <= sin(x) <= -1 + 2)
+    @test c1 isa NonlinearConstraintRef
+    a, b = 1.0, 2.0
+    c2 = @NLconstraint(model, a / b <= sin(x) <= a * b)
+    @test c2 isa NonlinearConstraintRefs
+    @NLconstraint(model, c3[i=1:2], -i <= sin(x) <= i^2)
+    @test c3 isa Vector{<:NonlinearConstraintRef}
+    return
 end
 
 TestNLP.runtests()

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -1481,10 +1481,12 @@ function test_nlp_comparison()
     @test c1 isa NonlinearConstraintRef
     a, b = 1.0, 2.0
     c2 = @NLconstraint(model, a / b <= sin(x) <= a * b)
-    @test c2 isa NonlinearConstraintRefs
-    @NLconstraint(model, c3[i=1:2], -i <= sin(x) <= i^2)
+    @test c2 isa NonlinearConstraintRef
+    @NLconstraint(model, c3[i = 1:2], -i <= sin(x) <= i^2)
     @test c3 isa Vector{<:NonlinearConstraintRef}
     return
+end
+
 end
 
 TestNLP.runtests()


### PR DESCRIPTION
Found by https://github.com/JuliaSmoothOptimizers/NLPModelsJuMP.jl/pull/118. JuMP v1.1 evaluates the LHS and RHS terms in scope to check if they are numbers, so for now, we should reproduce the same behavior, even if it leads to weird errors like this one in JuMP v1.1.0:

```Julia
julia> @NLconstraint(model, sin(x) <= sin(x) <= -1 + 2)
ERROR: sin is not defined for type AbstractVariableRef. Are you trying to build a nonlinear problem? Make sure you use @NLconstraint/@NLobjective.
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] sin(#unused#::VariableRef)
   @ JuMP ~/.julia/packages/JuMP/Y4piv/src/operators.jl:409
 [3] macro expansion
   @ ~/.julia/packages/JuMP/Y4piv/src/macros.jl:2214 [inlined]
 [4] top-level scope
   @ REPL[12]:1
```