### PR TITLE
Improve coverage in src/variable.jl

### DIFF
--- a/test/variable.jl
+++ b/test/variable.jl
@@ -1051,6 +1051,32 @@ function test_start_value_nothing(ModelType, ::Any)
     return
 end
 
+function test_Model_VariableRef(::Any, ::Any)
+    model = Model()
+    x = VariableRef(model)
+    @test x isa VariableRef
+    @test name(x) == ""
+    @test num_variables(model) == 1
+    return
+end
+
+function test_Model_VariableIndex_VariableRef(::Any, ::Any)
+    model = Model()
+    @variable(model, x)
+    @test MOI.VariableIndex(x) === index(x)
+    return
+end
+
+function test_Model_VariableIndex_VariableRef_fix_with_upper_bound(::Any, ::Any)
+    model = Model()
+    @variable(model, x <= 2)
+    fix(x, 1.0; force = true)
+    @test is_fixed(x)
+    @test fix_value(x) == 1.0
+    @test !has_upper_bound(x)
+    return
+end
+
 function runtests()
     for name in names(@__MODULE__; all = true)
         if !startswith("$(name)", "test_")


### PR DESCRIPTION
These three methods weren't tested: https://app.codecov.io/gh/jump-dev/JuMP.jl/blob/master/src/variables.jl

The fix with an upper bound is an oversight and needs testing.

The other two are a bit weird, and could potentially be deprecated. 

There's a one-argument `VariableRef` which adds a new variable:

https://github.com/jump-dev/JuMP.jl/blob/95a29745394271ceb9a7fd470e5f0d77d44289a7/src/variables.jl#L352-L355

There's an overload for `MOI.VariableIndex` instead of `index`:
https://github.com/jump-dev/JuMP.jl/blob/95a29745394271ceb9a7fd470e5f0d77d44289a7/src/variables.jl#L469