### PR TITLE
Remove an unused method in quad_expr.jl

### DIFF
--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -84,13 +84,6 @@ function GenericQuadExpr(
     )
 end
 
-function GenericAffExpr{V,K}(
-    aff::GenericAffExpr{V,K},
-    kv::AbstractArray{<:Pair},
-) where {K,V}
-    return GenericQuadExpr{V,K}(aff, _new_ordered_dict(UnorderedPair{K}, V, kv))
-end
-
 function GenericQuadExpr{V,K}(aff::GenericAffExpr{V,K}, kv::Pair...) where {K,V}
     return GenericQuadExpr{V,K}(
         aff,


### PR DESCRIPTION
This is a very weird method. It is called GenericAffExpr, but it returns GenericQuadExpr, and it isn't tested. 

It was added way back in https://github.com/jump-dev/JuMP.jl/pull/1301, but I don't know why. Potentially just a copy-paste from the `GenericAffExpr` method:
```julia
function GenericAffExpr{V,K}(constant, kv::AbstractArray{<:Pair}) where {K,V}
     return GenericAffExpr{V,K}(convert(V, constant), new_ordered_dict(K, V, kv))
 end
```

I think it's safe to remove.