### PR TITLE
[docs] Remove literate footer in PDF

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -322,7 +322,23 @@ _validate_pages()
 #  Build the LaTeX docs (if needed)
 # ==============================================================================
 
+function _remove_literate_footer(dir)
+    for filename in _file_list(dir, dir, ".md")
+        index = findfirst(
+            "---\n\n!!! tip\n    This tutorial was generated using [Literate",
+            read(filename, String),
+        )
+        if index !== nothing
+            write(filename, file[1:(first(index)-1)])
+        end
+    end
+    return
+end
+
 if _PDF
+    for (root, dir, files) in walkdir(joinpath(@__DIR__, "src", "tutorials"))
+        _remove_literate_footer.(joinpath.(root, dir))
+    end
     # Remove release notes from PDF
     splice!(_PAGES, 7)   # JuMP release notes
     pop!(_PAGES[end][2]) # MOI release notes

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -324,9 +324,10 @@ _validate_pages()
 
 function _remove_literate_footer(dir)
     for filename in _file_list(dir, dir, ".md")
+        file = read(filename, String)
         index = findfirst(
             "---\n\n!!! tip\n    This tutorial was generated using [Literate",
-            read(filename, String),
+            file,
         )
         if index !== nothing
             write(filename, file[1:(first(index)-1)])


### PR DESCRIPTION
We don't need 

<img width="560" alt="image" src="https://user-images.githubusercontent.com/8177701/187339314-6acbb760-0129-4a7e-a09b-3624b7c46b76.png">

after every tutorial in the PDF.