### PR TITLE
[docs] reduce some unnecessary outputs

### DIFF
--- a/docs/src/tutorials/linear/facility_location.jl
+++ b/docs/src/tutorials/linear/facility_location.jl
@@ -290,7 +290,6 @@ for i in 1:m, j in 1:n
             color = :black,
             label = nothing,
         )
-        break
     end
 end
 

--- a/docs/src/tutorials/linear/geographic_clustering.jl
+++ b/docs/src/tutorials/linear/geographic_clustering.jl
@@ -33,96 +33,30 @@ import HiGHS
 import LinearAlgebra
 
 # For this example, we'll use the 20 most populous cities in the United States.
-
 cities = DataFrames.DataFrame(;
-    city = [
-        "New York, NY",
-        "Los Angeles, CA",
-        "Chicago, IL",
-        "Houston, TX",
-        "Philadelphia, PA",
-        "Phoenix, AZ",
-        "San Antonio, TX",
-        "San Diego, CA",
-        "Dallas, TX",
-        "San Jose, CA",
-        "Austin, TX",
-        "Indianapolis, IN",
-        "Jacksonville, FL",
-        "San Francisco, CA",
-        "Columbus, OH",
-        "Charlotte, NC",
-        "Fort Worth, TX",
-        "Detroit, MI",
-        "El Paso, TX",
-        "Memphis, TN",
+    Union{String,Float64}[
+        "New York, NY" 8.405 40.7127 -74.0059
+        "Los Angeles, CA" 3.884 34.0522 -118.2436
+        "Chicago, IL" 2.718 41.8781 -87.6297
+        "Houston, TX" 2.195 29.7604 -95.3698
+        "Philadelphia, PA" 1.553 39.9525 -75.1652
+        "Phoenix, AZ" 1.513 33.4483 -112.0740
+        "San Antonio, TX" 1.409 29.4241 -98.4936
+        "San Diego, CA" 1.355 32.7157 -117.1610
+        "Dallas, TX" 1.257 32.7766 -96.7969
+        "San Jose, CA" 0.998 37.3382 -121.8863
+        "Austin, TX" 0.885 30.2671 -97.7430
+        "Indianapolis, IN" 0.843 39.7684 -86.1580
+        "Jacksonville, FL" 0.842 30.3321 -81.6556
+        "San Francisco, CA" 0.837 37.7749 -122.4194
+        "Columbus, OH" 0.822 39.9611 -82.9987
+        "Charlotte, NC" 0.792 35.2270 -80.8431
+        "Fort Worth, TX" 0.792 32.7554 -97.3307
+        "Detroit, MI" 0.688 42.3314 -83.0457
+        "El Paso, TX" 0.674 31.7775 -106.4424
+        "Memphis, TN" 0.653 35.1495 -90.0489
     ],
-    population = [
-        8.405,
-        3.884,
-        2.718,
-        2.195,
-        1.553,
-        1.513,
-        1.409,
-        1.355,
-        1.257,
-        0.998,
-        0.885,
-        0.843,
-        0.842,
-        0.837,
-        0.822,
-        0.792,
-        0.792,
-        0.688,
-        0.674,
-        0.653,
-    ],
-    lat = [
-        40.7127,
-        34.0522,
-        41.8781,
-        29.7604,
-        39.9525,
-        33.4483,
-        29.4241,
-        32.7157,
-        32.7766,
-        37.3382,
-        30.2671,
-        39.7684,
-        30.3321,
-        37.7749,
-        39.9611,
-        35.2270,
-        32.7554,
-        42.3314,
-        31.7775,
-        35.1495,
-    ],
-    lon = [
-        -74.0059,
-        -118.2436,
-        -87.6297,
-        -95.3698,
-        -75.1652,
-        -112.0740,
-        -98.4936,
-        -117.1610,
-        -96.7969,
-        -121.8863,
-        -97.7430,
-        -86.1580,
-        -81.6556,
-        -122.4194,
-        -82.9987,
-        -80.8431,
-        -97.3307,
-        -83.0457,
-        -106.4424,
-        -90.0489,
-    ],
+    ["city", "population", "lat", "lon"],
 )
 
 # ### Model Specifics
@@ -178,12 +112,8 @@ dm = LinearAlgebra.LowerTriangular([
 model = Model(HiGHS.Optimizer)
 set_silent(model)
 #-
-
 @variable(model, x[1:n, 1:k], Bin)
-
-#-
-
-@constraint(model, [i = 1:n], sum(x[i, :]) == 1)
+@constraint(model, [i = 1:n], sum(x[i, :]) == 1);
 
 # To reduce symmetry, we fix the first city to belong to the first group.
 

--- a/docs/src/tutorials/linear/geographic_clustering.jl
+++ b/docs/src/tutorials/linear/geographic_clustering.jl
@@ -33,7 +33,7 @@ import HiGHS
 import LinearAlgebra
 
 # For this example, we'll use the 20 most populous cities in the United States.
-cities = DataFrames.DataFrame(;
+cities = DataFrames.DataFrame(
     Union{String,Float64}[
         "New York, NY" 8.405 40.7127 -74.0059
         "Los Angeles, CA" 3.884 34.0522 -118.2436

--- a/docs/src/tutorials/linear/knapsack.jl
+++ b/docs/src/tutorials/linear/knapsack.jl
@@ -15,11 +15,12 @@ using JuMP
 import HiGHS
 import Test
 
-function example_knapsack(; verbose = true)
+function example_knapsack()
     profit = [5, 3, 2, 7, 4]
     weight = [2, 8, 4, 2, 5]
     capacity = 10
     model = Model(HiGHS.Optimizer)
+    set_silent(model)
     @variable(model, x[1:5], Bin)
     ## Objective: maximize profit
     @objective(model, Max, profit' * x)
@@ -27,13 +28,11 @@ function example_knapsack(; verbose = true)
     @constraint(model, weight' * x <= capacity)
     ## Solve problem using MIP solver
     optimize!(model)
-    if verbose
-        println("Objective is: ", objective_value(model))
-        println("Solution is:")
-        for i in 1:5
-            print("x[$i] = ", value(x[i]))
-            println(", p[$i]/w[$i] = ", profit[i] / weight[i])
-        end
+    println("Objective is: ", objective_value(model))
+    println("Solution is:")
+    for i in 1:5
+        print("x[$i] = ", value(x[i]))
+        println(", p[$i]/w[$i] = ", profit[i] / weight[i])
     end
     Test.@test termination_status(model) == OPTIMAL
     Test.@test primal_status(model) == FEASIBLE_POINT

--- a/docs/src/tutorials/linear/n-queens.jl
+++ b/docs/src/tutorials/linear/n-queens.jl
@@ -40,12 +40,13 @@ import LinearAlgebra
 N = 8
 
 model = Model(HiGHS.Optimizer)
+set_silent(model)
 
 # Next, let's create an N x N chessboard of binary values. 0 will represent an
 # empty space on the board and 1 will represent a space occupied by one of our
 # queens:
 
-@variable(model, x[1:N, 1:N], Bin)
+@variable(model, x[1:N, 1:N], Bin);
 
 # Now we can add our constraints:
 

--- a/docs/src/tutorials/linear/network_flows.jl
+++ b/docs/src/tutorials/linear/network_flows.jl
@@ -72,7 +72,7 @@ G = [
 n = size(G)[1]
 
 shortest_path = Model(HiGHS.Optimizer)
-
+set_silent(shortest_path)
 @variable(shortest_path, x[1:n, 1:n], Bin)
 # Arcs with zero cost are not a part of the path as they do no exist
 @constraint(shortest_path, [i = 1:n, j = 1:n; G[i, j] == 0], x[i, j] == 0)
@@ -127,6 +127,7 @@ G = [
 n = size(G)[1]
 
 assignment = Model(HiGHS.Optimizer)
+set_silent(assignment)
 @variable(assignment, y[1:n, 1:n], Bin)
 # One person can only be assigned to one object
 @constraint(assignment, [i = 1:n], sum(y[:, i]) == 1)

--- a/docs/src/tutorials/linear/prod.jl
+++ b/docs/src/tutorials/linear/prod.jl
@@ -172,6 +172,7 @@ function example_prod(; verbose = true)
     ]
     ## DEFINE MODEL
     prod = Model(HiGHS.Optimizer)
+    set_silent(prod)
     ## VARIABLES
     ## Average number of crews employed in each period
     @variable(prod, Crews[0:lastperiod] >= 0)

--- a/docs/src/tutorials/linear/sudoku.jl
+++ b/docs/src/tutorials/linear/sudoku.jl
@@ -58,7 +58,7 @@ using HiGHS
 sudoku = Model(HiGHS.Optimizer)
 
 # Create our variables
-@variable(sudoku, x[i = 1:9, j = 1:9, k = 1:9], Bin)
+@variable(sudoku, x[i = 1:9, j = 1:9, k = 1:9], Bin);
 
 # Now we can begin to add our constraints. We'll actually start with something
 # obvious to us as humans, but what we need to enforce: that there can be only
@@ -134,7 +134,7 @@ end
 optimize!(sudoku)
 
 # Extract the values of x
-x_val = value.(x)
+x_val = value.(x);
 # Create a matrix to store the solution
 sol = zeros(Int, 9, 9)  # 9x9 matrix of integers
 for i in 1:9
@@ -175,15 +175,15 @@ set_optimizer_attribute(model, "presolve", "off")
 # Instead of the binary variables, we directly define a 9x9 grid of integer
 # values between 1 and 9:
 
-@variable(model, 1 <= x[1:9, 1:9] <= 9, Int)
+@variable(model, 1 <= x[1:9, 1:9] <= 9, Int);
 
 # Then, we enforce that the values in each row must be all-different:
 
-@constraint(model, [i = 1:9], x[i, :] in MOI.AllDifferent(9))
+@constraint(model, [i = 1:9], x[i, :] in MOI.AllDifferent(9));
 
 # That the values in each column must be all-different:
 
-@constraint(model, [j = 1:9], x[:, j] in MOI.AllDifferent(9))
+@constraint(model, [j = 1:9], x[:, j] in MOI.AllDifferent(9));
 
 # And that the values in each 3x3 sub-grid must be all-different:
 

--- a/docs/src/tutorials/linear/urban_plan.jl
+++ b/docs/src/tutorials/linear/urban_plan.jl
@@ -13,6 +13,7 @@ import Test
 
 function example_urban_plan()
     model = Model(HiGHS.Optimizer)
+    set_silent(model)
     ## x is indexed by row and column
     @variable(model, 0 <= x[1:5, 1:5] <= 1, Int)
     ## y is indexed by R or C, the points, and an index in 1:5. Note how JuMP


### PR DESCRIPTION
Some of the LP tutorials contain a lot of unnecessary output (pages of printed variables, or multiple plots in sequence).

They currently finish at page 179, so lets see how many pages we claw back. Update: 164, so we saved 15 pages!

Preview: https://jump.dev/JuMP.jl/previews/PR3061/JuMP.pdf