### PR TITLE
[Containers] fix DenseAxisArray with Vector key

### DIFF
--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -58,6 +58,13 @@ function Base.getindex(
     return [x[key] for key in keys]
 end
 
+function Base.getindex(
+    x::_AxisLookup{Dict{K,Int}},
+    key::K,
+) where {K<:AbstractVector}
+    return x.data[key]
+end
+
 function Base.get(x::_AxisLookup{Dict{K,Int}}, key, default) where {K}
     return get(x.data, key, default)
 end

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -443,11 +443,7 @@ And data, a 0-dimensional $(Array{Int,0}):
         @test isempty(str)
     end
     @testset "DenseAxisArray_vector_keys" begin
-        paths = [
-            [1, 2, 15, 3, 20],
-            [1, 9, 16, 20],
-            [1, 2, 20]
-        ]
+        paths = [[1, 2, 15, 3, 20], [1, 9, 16, 20], [1, 2, 20]]
         x = DenseAxisArray(1:3, paths)
         for i in 1:3
             @test x[paths[i]] == i

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -442,4 +442,17 @@ And data, a 0-dimensional $(Array{Int,0}):
         str = sprint((io, x) -> Base.show_nd(io, x, Base.print_matrix, true), x)
         @test isempty(str)
     end
+    @testset "DenseAxisArray_vector_keys" begin
+        paths = [
+            [1, 2, 15, 3, 20],
+            [1, 9, 16, 20],
+            [1, 2, 20]
+        ]
+        x = DenseAxisArray(1:3, paths)
+        for i in 1:3
+            @test x[paths[i]] == i
+            @test isassigned(x, paths[i]) == true
+        end
+        @test isassigned(x, Int[]) == false
+    end
 end


### PR DESCRIPTION
Reported by https://discourse.julialang.org/t/indexing-variables-by-vectors-not-working-in-jumpv1-2-x/86652

Broken by https://github.com/jump-dev/JuMP.jl/pull/3028