### PR TITLE
Prep for v1.3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuMP"
 uuid = "4076af6c-e467-56ae-b986-b466b2749572"
 repo = "https://github.com/jump-dev/JuMP.jl.git"
-version = "1.2.1"
+version = "1.2.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuMP"
 uuid = "4076af6c-e467-56ae-b986-b466b2749572"
 repo = "https://github.com/jump-dev/JuMP.jl.git"
-version = "1.2.2"
+version = "1.3.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ embedded in [Julia](https://julialang.org/). You can find out more about us by
 visiting [jump.dev](https://jump.dev).
 
 
-**Latest Release**: [![version](https://juliahub.com/docs/JuMP/DmXqY/1.2.2/version.svg)](https://juliahub.com/ui/Packages/JuMP/DmXqY/1.2.2) (`release-1.0` branch):
+**Latest Release**: [![version](https://juliahub.com/docs/JuMP/DmXqY/1.3.0/version.svg)](https://juliahub.com/ui/Packages/JuMP/DmXqY/1.3.0) (`release-1.0` branch):
   * Installation via the Julia package manager:
     * `import Pkg; Pkg.add("JuMP")`
   * Get help:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ embedded in [Julia](https://julialang.org/). You can find out more about us by
 visiting [jump.dev](https://jump.dev).
 
 
-**Latest Release**: [![version](https://juliahub.com/docs/JuMP/DmXqY/1.2.1/version.svg)](https://juliahub.com/ui/Packages/JuMP/DmXqY/1.2.1) (`release-1.0` branch):
+**Latest Release**: [![version](https://juliahub.com/docs/JuMP/DmXqY/1.2.2/version.svg)](https://juliahub.com/ui/Packages/JuMP/DmXqY/1.2.2) (`release-1.0` branch):
   * Installation via the Julia package manager:
     * `import Pkg; Pkg.add("JuMP")`
   * Get help:

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -1,9 +1,9 @@
 # Release notes
 
-## Version 1.2.2 (September 3, 2022)
+## Version 1.3.0 (September 5, 2022)
 
 For a detailed list of the closed issues and pull requests from this release,
-see the [tag notes](https://github.com/jump-dev/JuMP.jl/releases/tag/v1.2.2).
+see the [tag notes](https://github.com/jump-dev/JuMP.jl/releases/tag/v1.3.0).
 
 - New features:
   - Support slicing in `SparseAxisArray`

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -1,5 +1,20 @@
 # Release notes
 
+## Version 1.2.2 (September 3, 2022)
+
+For a detailed list of the closed issues and pull requests from this release,
+see the [tag notes](https://github.com/jump-dev/JuMP.jl/releases/tag/v1.2.2).
+
+- New features:
+  - Support slicing in `SparseAxisArray`
+- Bug fixes:
+  - Fixed a bug introduced in v1.2.0 that prevented `DenseAxisArray`s with
+    `Vector` keys.
+- Documentation and maintenance:
+  - Released the JuMP logos under the CC BY 4.0 license
+  - Minor tweaks to the PDF documentation
+  - Improved code coverage of a number of files
+
 ## Version 1.2.1 (August 22, 2022)
 
 For a detailed list of the closed issues and pull requests from this release,


### PR DESCRIPTION
There's an open question whether this should be v1.2.2 or v1.3.0 (the new feature is adding slicing to `SparseAxisArray`). It feels like a minor enough addition that we can just keep v1.2.2 since this is mainly bug fixes and maintenance.