### PR TITLE
Improve performance of `relax_integrality`

### DIFF
--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1419,25 +1419,17 @@ Subject to
 ```
 """
 function relax_integrality(model::Model)
-    semicont_type = _MOICON{MOI.VariableIndex,MOI.Semicontinuous{Float64}}
-    semiint_type = _MOICON{MOI.VariableIndex,MOI.Semiinteger{Float64}}
-    semicont_semiint_constraints = vcat(
-        all_constraints(model, VariableRef, MOI.ZeroOne),
-        all_constraints(model, VariableRef, MOI.Integer),
-    )
-    semicont_semiint_variables = VariableRef.(semicont_semiint_constraints)
-    for v in semicont_semiint_variables
-        if MOI.is_valid(backend(model), semicont_type(index(v).value))
-            error(
-                "Support for relaxing semicontinuous constraints is not " *
-                "yet implemented.",
-            )
-        elseif MOI.is_valid(backend(model), semiint_type(index(v).value))
-            error(
-                "Support for relaxing semi-integer constraints is not " *
-                "yet implemented.",
-            )
-        end
+    if num_constraints(model, VariableRef, MOI.Semicontinuous{Float64}) > 0
+        error(
+            "Support for relaxing semicontinuous constraints is not " *
+            "yet implemented.",
+        )
+    end
+    if num_constraints(model, VariableRef, MOI.Semiinteger{Float64}) > 0
+        error(
+            "Support for relaxing semi-integer constraints is not " *
+            "yet implemented.",
+        )
     end
 
     bin_int_constraints = vcat(

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1421,13 +1421,12 @@ Subject to
 function relax_integrality(model::Model)
     semicont_type = _MOICON{MOI.VariableIndex,MOI.Semicontinuous{Float64}}
     semiint_type = _MOICON{MOI.VariableIndex,MOI.Semiinteger{Float64}}
-    # Get only the binary and integer variables, as the others don't need to be modified.
-    bin_int_constraints = vcat(
+    semicont_semiint_constraints = vcat(
         all_constraints(model, VariableRef, MOI.ZeroOne),
         all_constraints(model, VariableRef, MOI.Integer),
     )
-    bin_int_variables = VariableRef.(bin_int_constraints)
-    for v in bin_int_constraints
+    semicont_semiint_variables = VariableRef.(semicont_semiint_constraints)
+    for v in semicont_semiint_variables
         if MOI.is_valid(backend(model), semicont_type(index(v).value))
             error(
                 "Support for relaxing semicontinuous constraints is not " *
@@ -1441,6 +1440,11 @@ function relax_integrality(model::Model)
         end
     end
 
+    bin_int_constraints = vcat(
+        all_constraints(model, VariableRef, MOI.ZeroOne),
+        all_constraints(model, VariableRef, MOI.Integer),
+    )
+    bin_int_variables = VariableRef.(bin_int_constraints)
     info_pre_relaxation =
         map(v -> (v, _info_from_variable(v)), bin_int_variables)
     # We gather the info first because some solvers perform poorly when you

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1441,7 +1441,8 @@ function relax_integrality(model::Model)
         end
     end
 
-    info_pre_relaxation = map(v -> (v, _info_from_variable(v)), bin_int_variables)
+    info_pre_relaxation =
+        map(v -> (v, _info_from_variable(v)), bin_int_variables)
     # We gather the info first because some solvers perform poorly when you
     # interleave queries and changes. See, e.g.,
     # https://github.com/jump-dev/Gurobi.jl/pull/301.


### PR DESCRIPTION
Attempt to close #3086 

This makes relaxing my problem with the following size:

```julia
julia> model
A JuMP Model
Minimization problem with:
Variables: 1193207
Objective function type: AffExpr
`AffExpr`-in-`MathOptInterface.EqualTo{Float64}`: 399576 constraints
`AffExpr`-in-`MathOptInterface.GreaterThan{Float64}`: 43031 constraints
`AffExpr`-in-`MathOptInterface.LessThan{Float64}`: 904612 constraints
`VariableRef`-in-`MathOptInterface.GreaterThan{Float64}`: 1144294 constraints
`VariableRef`-in-`MathOptInterface.LessThan{Float64}`: 48912 constraints
`VariableRef`-in-`MathOptInterface.Integer`: 1 constraint
`VariableRef`-in-`MathOptInterface.ZeroOne`: 48912 constraints
Model mode: AUTOMATIC
CachingOptimizer state: NO_OPTIMIZER
Solver name: No optimizer attached.
```

go from 

```julia
julia> @time JuMP.relax_integrality(model)
 44.611944 seconds (33.02 M allocations: 1.550 GiB, 1.33% gc time, 0.82% compilation time)
```

to 

```julia
julia> @time JuMP.relax_integrality(model)
  1.818470 seconds (2.73 M allocations: 105.338 MiB, 6.19% compilation time: 66% of which was recompilation)
```