### PR TITLE
Pass names (index_vars) to container extensions.

### DIFF
--- a/src/Containers/container.jl
+++ b/src/Containers/container.jl
@@ -15,7 +15,7 @@ a `VectorizedProductIterator` and the function returns
 function default_container end
 
 """
-    container(f::Function, names, indices, c::Type{C})
+    container(f::Function, indices, c::Type{C}, names)
 
 Create a container of type `C` with index names `names`, indices `indices` and
 values at given indices given by `f`. If this method is not specialized on
@@ -67,7 +67,7 @@ SparseAxisArray{Int64,2,Tuple{Int64,Int64}} with 5 entries:
   [1, 3]  =  4
 ```
 """
-function container(f::Function, names, indices, D)
+function container(f::Function, indices, D, names)
     return container(f, indices, D)
 end
 

--- a/src/Containers/container.jl
+++ b/src/Containers/container.jl
@@ -17,15 +17,15 @@ function default_container end
 """
     container(f::Function, names, indices, c::Type{C})
 
-Create a container of type `C` with index names `names`, indices `indices` and values at given
-indices given by `f`. If this method is not specialized on `Type{C}`, it falls back to calling 
-`container(f, indices, c)` for backwards compatibility with containers not supporting index names.
+Create a container of type `C` with index names `names`, indices `indices` and
+values at given indices given by `f`. If this method is not specialized on
+`Type{C}`, it falls back to calling  `container(f, indices, c)` for backwards
+compatibility with containers not supporting index names.
 
     container(f::Function, indices, ::Type{C})
 
 Create a container of type `C` with indices `indices` and values at given
 indices given by `f`.
-
 
     container(f::Function, indices)
 
@@ -67,8 +67,6 @@ SparseAxisArray{Int64,2,Tuple{Int64,Int64}} with 5 entries:
   [1, 3]  =  4
 ```
 """
-function container end
-
 function container(f::Function, names, indices, D)
     return container(f, indices, D)
 end

--- a/src/Containers/container.jl
+++ b/src/Containers/container.jl
@@ -15,10 +15,17 @@ a `VectorizedProductIterator` and the function returns
 function default_container end
 
 """
+    container(f::Function, names, indices, c::Type{C})
+
+Create a container of type `C` with index names `names`, indices `indices` and values at given
+indices given by `f`. If this method is not specialized on `Type{C}`, it falls back to calling 
+`container(f, indices, c)` for backwards compatibility with containers not supporting index names.
+
     container(f::Function, indices, ::Type{C})
 
 Create a container of type `C` with indices `indices` and values at given
 indices given by `f`.
+
 
     container(f::Function, indices)
 
@@ -61,6 +68,10 @@ SparseAxisArray{Int64,2,Tuple{Int64,Int64}} with 5 entries:
 ```
 """
 function container end
+
+function container(f::Function, names, indices, D)
+    return container(f, indices, D)
+end
 
 function container(f::Function, indices)
     return container(f, indices, default_container(indices))
@@ -177,9 +188,4 @@ function container(::Function, ::Any, D::Type)
         "Unable to build a container with the provided type $(D). Implement " *
         "`Containers.container(::Function, indices, ::Type{$(D)})`.",
     )
-end
-
-# Default to dropping names (as before)
-function container(f::Function, names, indices, D)
-    return container(f, indices, D)
 end

--- a/src/Containers/container.jl
+++ b/src/Containers/container.jl
@@ -178,3 +178,8 @@ function container(::Function, ::Any, D::Type)
         "`Containers.container(::Function, indices, ::Type{$(D)})`.",
     )
 end
+
+# Default to dropping names (as before)
+function container(f::Function, names, indices, D)
+    container(f, indices, D)
+end

--- a/src/Containers/container.jl
+++ b/src/Containers/container.jl
@@ -181,5 +181,5 @@ end
 
 # Default to dropping names (as before)
 function container(f::Function, names, indices, D)
-    container(f, indices, D)
+    return container(f, indices, D)
 end

--- a/src/Containers/macro.jl
+++ b/src/Containers/macro.jl
@@ -307,16 +307,16 @@ function container_code(
     if requested_container == :Auto
         return :(Containers.container($f, $indices))
     elseif requested_container == :DenseAxisArray
-        return :(Containers.container($f, $indices, Containers.DenseAxisArray))
+        return :(Containers.container($f, $index_vars, $indices, Containers.DenseAxisArray))
     elseif requested_container == :SparseAxisArray
-        return :(Containers.container($f, $indices, Containers.SparseAxisArray))
+        return :(Containers.container($f, $index_vars, $indices, Containers.SparseAxisArray))
     elseif requested_container == :Array
-        return :(Containers.container($f, $indices, Array))
+        return :(Containers.container($f, $index_vars, $indices, Array))
     else
         # This is a symbol or expression from outside JuMP, so we need to escape
         # it.
         requested_container = esc(requested_container)
-        return :(Containers.container($f, $indices, $requested_container))
+        return :(Containers.container($f, $index_vars, $indices, $requested_container))
     end
 end
 

--- a/src/Containers/macro.jl
+++ b/src/Containers/macro.jl
@@ -309,28 +309,28 @@ function container_code(
     elseif requested_container == :DenseAxisArray
         return :(Containers.container(
             $f,
-            $index_vars,
             $indices,
             Containers.DenseAxisArray,
+            $index_vars,
         ))
     elseif requested_container == :SparseAxisArray
         return :(Containers.container(
             $f,
-            $index_vars,
             $indices,
             Containers.SparseAxisArray,
+            $index_vars,
         ))
     elseif requested_container == :Array
-        return :(Containers.container($f, $index_vars, $indices, Array))
+        return :(Containers.container($f, $indices, Array, $index_vars))
     else
         # This is a symbol or expression from outside JuMP, so we need to escape
         # it.
         requested_container = esc(requested_container)
         return :(Containers.container(
             $f,
-            $index_vars,
             $indices,
             $requested_container,
+            $index_vars,
         ))
     end
 end

--- a/src/Containers/macro.jl
+++ b/src/Containers/macro.jl
@@ -307,16 +307,31 @@ function container_code(
     if requested_container == :Auto
         return :(Containers.container($f, $indices))
     elseif requested_container == :DenseAxisArray
-        return :(Containers.container($f, $index_vars, $indices, Containers.DenseAxisArray))
+        return :(Containers.container(
+            $f,
+            $index_vars,
+            $indices,
+            Containers.DenseAxisArray,
+        ))
     elseif requested_container == :SparseAxisArray
-        return :(Containers.container($f, $index_vars, $indices, Containers.SparseAxisArray))
+        return :(Containers.container(
+            $f,
+            $index_vars,
+            $indices,
+            Containers.SparseAxisArray,
+        ))
     elseif requested_container == :Array
         return :(Containers.container($f, $index_vars, $indices, Array))
     else
         # This is a symbol or expression from outside JuMP, so we need to escape
         # it.
         requested_container = esc(requested_container)
-        return :(Containers.container($f, $index_vars, $indices, $requested_container))
+        return :(Containers.container(
+            $f,
+            $index_vars,
+            $indices,
+            $requested_container,
+        ))
     end
 end
 

--- a/test/Containers/macro.jl
+++ b/test/Containers/macro.jl
@@ -223,9 +223,9 @@ end
 
 function Containers.container(
     f::Function,
-    names,
     indices,
     ::Type{_MyContainer2},
+    names,
 )
     key(i::Tuple) = i
     key(i::Tuple{T}) where {T} = i[1]

--- a/test/Containers/macro.jl
+++ b/test/Containers/macro.jl
@@ -216,22 +216,24 @@ end
 end
 
 # Test containers that use subindex names
-struct _MyContainer2 
-    names
-    d
+struct _MyContainer2
+    names::Any
+    d::Any
 end
 
-function Containers.container(f::Function, names, indices, ::Type{_MyContainer2})
+function Containers.container(
+    f::Function,
+    names,
+    indices,
+    ::Type{_MyContainer2},
+)
     key(i::Tuple) = i
     key(i::Tuple{T}) where {T} = i[1]
-    return _MyContainer2(
-        names,    
-        Dict(key(i) => f(i...) for i in indices)
-        )
+    return _MyContainer2(names, Dict(key(i) => f(i...) for i in indices))
 end
 
 @testset "_MyContainer2" begin
     Containers.@container(v[i = 1:3], sin(i), container = _MyContainer2)
     @test v.d isa Dict{Int,Float64}
-    @test v.names == [:i,]
+    @test v.names == [:i]
 end

--- a/test/Containers/macro.jl
+++ b/test/Containers/macro.jl
@@ -214,3 +214,24 @@ end
     @test length(z) == 4
     @test z[1, 2] == 3
 end
+
+# Test containers that use subindex names
+struct _MyContainer2 
+    names
+    d
+end
+
+function Containers.container(f::Function, names, indices, ::Type{_MyContainer2})
+    key(i::Tuple) = i
+    key(i::Tuple{T}) where {T} = i[1]
+    return _MyContainer2(
+        names,    
+        Dict(key(i) => f(i...) for i in indices)
+        )
+end
+
+@testset "_MyContainer2" begin
+    Containers.@container(v[i = 1:3], sin(i), container = _MyContainer2)
+    @test v.d isa Dict{Int,Float64}
+    @test v.names == [:i,]
+end


### PR DESCRIPTION
Our container in `SparseVariables` supports storing the names of the subindices (`index_vars`), but these are not currently passed to containers.

See https://github.com/hellemo/SparseVariables.jl/issues/19