### PR TITLE
redundant back slash for `\in`

### DIFF
--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -1110,7 +1110,7 @@ x in MathOptInterface.Semicontinuous{Float64}(1.5, 3.5)
 ```
 
 Semi-integer variables  are constrained to the set
-``x \\in \{0\} \cup \{l, l+1, \dots, u\}``.
+``x \in \{0\} \cup \{l, l+1, \dots, u\}``.
 
 Create a semi-integer variable using the `MOI.Semiinteger` set:
 ```jldoctest; setup = :(model = Model(); @variable(model, x))


### PR DESCRIPTION
it results in problematic math formula rendering,
![image](https://user-images.githubusercontent.com/13688320/193377193-8d486047-e54b-401a-bc1f-a66bbacf4d51.png)
