### PR TITLE
[docs] remove incorrect statement about conflicting objectives

### DIFF
--- a/docs/src/manual/nlp.md
+++ b/docs/src/manual/nlp.md
@@ -31,10 +31,6 @@ julia> @NLobjective(model, Min, exp(x[1]) - sqrt(x[2]))
 ```
 To modify a nonlinear objective, call [`@NLobjective`](@ref) again.
 
-If you set an objective with both [`@objective`](@ref) and
-[`@NLobjective`](@ref), the nonlinear objective takes precedence, and the
-[`@objective`](@ref) will be ignored.
-
 ## Add a nonlinear constraint
 
 Use [`@NLconstraint`](@ref) to add a nonlinear constraint.


### PR DESCRIPTION
This statement is incorrect. Any calls to `@objective` or `@NLobjective` overwrite existing objective functions.