### PR TITLE
Add HermitianPSDCone

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-MathOptInterface = "1.3.0"
+MathOptInterface = "1.7"
 MutableArithmetics = "1"
 OrderedCollections = "1"
 julia = "1.6"

--- a/docs/src/reference/constraints.md
+++ b/docs/src/reference/constraints.md
@@ -72,6 +72,7 @@ SOS2
 SkewSymmetricMatrixSpace
 SkewSymmetricMatrixShape
 SymmetricMatrixSpace
+HermitianMatrixShape
 moi_set
 ```
 

--- a/docs/src/reference/constraints.md
+++ b/docs/src/reference/constraints.md
@@ -67,6 +67,7 @@ dual_start_value
 SecondOrderCone
 RotatedSecondOrderCone
 PSDCone
+HermitianPSDCone
 SOS1
 SOS2
 SkewSymmetricMatrixSpace

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -445,7 +445,7 @@ struct HermitianPSDCone end
 
 Shape object for a hermitian square matrix of `side_dimension` rows and
 columns. The vectorized form corresponds to
-[`MathOptInterface.HermitianPositiveSemidefiniteConeTriangle`](@ref).
+[`MOI.HermitianPositiveSemidefiniteConeTriangle`](@ref).
 """
 struct HermitianMatrixShape <: AbstractShape
     side_dimension::Int

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -552,7 +552,7 @@ function _vectorize_complex_variables(_error::Function, matrix::Matrix)
         for i in 1:j
             if matrix[i, j] != _conj(matrix[j, i])
                 _error(
-                    "Non-conjugate bounds, integrality or starting values for Hermitian variable.",
+                    "Non-conjugate bounds or starting values for Hermitian variable.",
                 )
             end
         end
@@ -561,6 +561,7 @@ function _vectorize_complex_variables(_error::Function, matrix::Matrix)
 end
 
 _is_binary(v::ScalarVariable) = v.info.binary
+_is_integer(v::ScalarVariable) = v.info.integer
 
 function build_variable(
     _error::Function,
@@ -570,10 +571,10 @@ function build_variable(
     n = _square_side(_error, variables)
     set = MOI.HermitianPositiveSemidefiniteConeTriangle(n)
     shape = HermitianMatrixShape(n)
-    if any(_is_binary, variables)
+    if any(_is_binary, variables) || any(_is_integer, variables)
         # We would then need to fix the imaginary value to zero. Let's wait to
         # see if there is need for such complication first.
-        _error("Binary variable in Hermitian matrix is not supported.")
+        _error("Binary or integer variables in a Hermitian matrix is not supported.")
     end
     return VariablesConstrainedOnCreation(
         _vectorize_complex_variables(_error, variables),

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -522,6 +522,7 @@ function _real(s::String)
     end
     return string("real(", s, ")")
 end
+
 function _imag(s::String)
     if isempty(s)
         return s

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -574,7 +574,9 @@ function build_variable(
     if any(_is_binary, variables) || any(_is_integer, variables)
         # We would then need to fix the imaginary value to zero. Let's wait to
         # see if there is need for such complication first.
-        _error("Binary or integer variables in a Hermitian matrix is not supported.")
+        _error(
+            "Binary or integer variables in a Hermitian matrix is not supported.",
+        )
     end
     return VariablesConstrainedOnCreation(
         _vectorize_complex_variables(_error, variables),

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -426,7 +426,7 @@ macro.
 ## Examples
 
 Consider the following example:
-```jldoctest PSDCone; setup = :(using JuMP)
+```jldoctest; setup = :(using JuMP)
 julia> model = Model();
 
 julia> @variable(model, H[1:3, 1:3] in HermitianPSDCone())

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -434,16 +434,29 @@ julia> @variable(model, H[1:3, 1:3] in HermitianPSDCone())
  real(H[1,1])                                real(H[1,2]) + (0.0 + 1.0im) imag(H[1,2])   real(H[1,3]) + (0.0 + 1.0im) imag(H[1,3])
  real(H[1,2]) + (-0.0 - 1.0im) imag(H[1,2])  real(H[2,2])                                real(H[2,3]) + (0.0 + 1.0im) imag(H[2,3])
  real(H[1,3]) + (-0.0 - 1.0im) imag(H[1,3])  real(H[2,3]) + (-0.0 - 1.0im) imag(H[2,3])  real(H[3,3])
+
+ julia> v = all_variables(model)
+ 9-element Vector{VariableRef}:
+  real(H[1,1])
+  real(H[1,2])
+  real(H[2,2])
+  real(H[1,3])
+  real(H[2,3])
+  real(H[3,3])
+  imag(H[1,2])
+  imag(H[1,3])
+  imag(H[2,3])
 ```
-We see in the output of the last command that the matrix the vectorization of the
-matrix is constrained to belong to the `PositiveSemidefiniteConeSquare`.
+We see in the output of the last commands that 9 real variables were created.
+The matrix `H` contrains affine expressions in terms of these 9 variables that
+parametrize a Hermitian matrix.
 """
 struct HermitianPSDCone end
 
 """
     HermitianMatrixShape
 
-Shape object for a hermitian square matrix of `side_dimension` rows and
+Shape object for a Hermitian square matrix of `side_dimension` rows and
 columns. The vectorized form corresponds to
 [`MOI.HermitianPositiveSemidefiniteConeTriangle`](@ref).
 """
@@ -518,13 +531,13 @@ function _vectorize_complex_variables(_error::Function, matrix::Matrix)
     for j in 1:n
         if !_isreal(matrix[j, j])
             _error(
-                "Non-real bounds or starting values for diagonal of hermitian variable.",
+                "Non-real bounds or starting values for diagonal of Hermitian variable.",
             )
         end
         for i in 1:j
             if matrix[i, j] != _conj(matrix[j, i])
                 _error(
-                    "Non-conjugate bounds, integrality or starting values for hermitian variable.",
+                    "Non-conjugate bounds, integrality or starting values for Hermitian variable.",
                 )
             end
         end
@@ -545,7 +558,7 @@ function build_variable(
     if any(_is_binary, variables)
         # We would then need to fix the imaginary value to zero. Let's wait to
         # see if there is need for such complication first.
-        _error("Binary variable in hermitian matrix is not supported.")
+        _error("Binary variable in Hermitian matrix is not supported.")
     end
     return VariablesConstrainedOnCreation(
         _vectorize_complex_variables(_error, variables),

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -441,7 +441,7 @@ matrix is constrained to belong to the `PositiveSemidefiniteConeSquare`.
 struct HermitianPSDCone end
 
 """
-    SymmetricMatrixShape
+    HermitianMatrixShape
 
 Shape object for a hermitian square matrix of `side_dimension` rows and
 columns. The vectorized form corresponds to

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -516,8 +516,18 @@ function _mapinfo(f::Function, v::JuMP.ScalarVariable)
     )
 end
 
-_real(s::String) = string("real(", s, ")")
-_imag(s::String) = string("imag(", s, ")")
+function _real(s::String)
+    if isempty(s)
+        return s
+    end
+    return string("real(", s, ")")
+end
+function _imag(s::String)
+    if isempty(s)
+        return s
+    end
+    return string("imag(", s, ")")
+end
 
 _real(v::ScalarVariable) = _mapinfo(real, v)
 _imag(v::ScalarVariable) = _mapinfo(imag, v)

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -446,6 +446,10 @@ julia> @variable(model, H[1:3, 1:3] in HermitianPSDCone())
   imag(H[1,2])
   imag(H[1,3])
   imag(H[2,3])
+
+julia> all_constraints(model, Vector{VariableRef}, MOI.HermitianPositiveSemidefiniteConeTriangle)
+1-element Vector{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.VectorOfVariables, MathOptInterface.HermitianPositiveSemidefiniteConeTriangle}}}:
+ [real(H[1,1]), real(H[1,2]), real(H[2,2]), real(H[1,3]), real(H[2,3]), real(H[3,3]), imag(H[1,2]), imag(H[1,3]), imag(H[2,3])] in MathOptInterface.HermitianPositiveSemidefiniteConeTriangle(3)
 ```
 We see in the output of the last commands that 9 real variables were created.
 The matrix `H` contrains affine expressions in terms of these 9 variables that

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -420,7 +420,7 @@ end
     HermitianPSDCone
 
 Hermitian positive semidefinite cone object that can be used to create a
-hermitian positive semidefinite square matrix in the [`@variable`](@ref)
+Hermitian positive semidefinite square matrix in the [`@variable`](@ref)
 macro.
 
 ## Examples

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -1117,7 +1117,7 @@ function test_Hermitian_PSD_errors(ModelType, ::Any)
     @test_throws ErrorException @variable(
         model,
         H[i = 1:2, j = 1:2] in HermitianPSDCone(),
-        Bool
+        Bin
     )
 end
 

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -1151,6 +1151,7 @@ function test_Hermitian_PSD_keyword(::Any, ::Any)
     for i in 1:2, j in 1:2
         @test value(start_value, T[i, j]) == (i + j) + (j - i) * im
     end
+    return
 end
 
 function runtests()

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -1090,6 +1090,7 @@ function test_Hermitian_PSD(::Any, ::Any)
     _test_variable_name_util(v[3], "real(Q[2,2])")
     @test Q[2, 2] == 1v[3]
     @test Q[2, 1] == conj(Q[1, 2])
+    return
 end
 
 function test_Hermitian_PSD_errors(ModelType, ::Any)

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -1154,6 +1154,16 @@ function test_Hermitian_PSD_keyword(::Any, ::Any)
     return
 end
 
+function test_Hermitian_PSD_anon(::Any, ::Any)
+    model = Model()
+    x = @variable(model, [1:2, 1:2] in HermitianPSDCone())
+    @test sprint(show, x[1, 1]) ==  "_[1]"
+    @test sprint(show, x[1, 2]) ==  "_[2] + (0.0 + 1.0im) _[4]"
+    @test sprint(show, x[2, 1]) ==  "_[2] + (-0.0 - 1.0im) _[4]"
+    @test sprint(show, x[2, 2]) ==  "_[3]"
+    return
+end
+
 function runtests()
     for name in names(@__MODULE__; all = true)
         if !startswith("$(name)", "test_")

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -1157,10 +1157,10 @@ end
 function test_Hermitian_PSD_anon(::Any, ::Any)
     model = Model()
     x = @variable(model, [1:2, 1:2] in HermitianPSDCone())
-    @test sprint(show, x[1, 1]) ==  "_[1]"
-    @test sprint(show, x[1, 2]) ==  "_[2] + (0.0 + 1.0im) _[4]"
-    @test sprint(show, x[2, 1]) ==  "_[2] + (-0.0 - 1.0im) _[4]"
-    @test sprint(show, x[2, 2]) ==  "_[3]"
+    @test sprint(show, x[1, 1]) == "_[1]"
+    @test sprint(show, x[1, 2]) == "_[2] + (0.0 + 1.0im) _[4]"
+    @test sprint(show, x[2, 1]) == "_[2] + (-0.0 - 1.0im) _[4]"
+    @test sprint(show, x[2, 2]) == "_[3]"
     return
 end
 

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -1120,23 +1120,33 @@ function test_Hermitian_PSD_errors(ModelType, ::Any)
         H[i = 1:2, j = 1:2] in HermitianPSDCone(),
         Bin
     )
+    @test_throws ErrorException @variable(
+        model,
+        H[i = 1:2, j = 1:2] in HermitianPSDCone(),
+        Int,
+    )
+    @test_throws ErrorException @variable(
+        model,
+        H[i = 1:2, j = 1:2] in HermitianPSDCone(),
+        integer = i != j,
+    )
     return
 end
 
 function test_Hermitian_PSD_keyword(::Any, ::Any)
     model = Model()
-    @variable(
+    @test_throws ErrorException @variable(
         model,
         H[i = 1:2, j = 1:2] in HermitianPSDCone(),
         integer = i != j,
+    )
+    @variable(
+        model,
+        H[i = 1:2, j = 1:2] in HermitianPSDCone(),
         lower_bound = (i + j) + (i - j) * im,
         upper_bound = i * j + (j - i) * im
     )
     v = all_variables(model)
-    @test !is_integer(v[1])
-    @test is_integer(v[2])
-    @test !is_integer(v[3])
-    @test is_integer(v[4])
     for i in 1:2, j in 1:2
         @test value(lower_bound, H[i, j]) == (i + j) + (i - j) * im
     end

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -1120,6 +1120,7 @@ function test_Hermitian_PSD_errors(ModelType, ::Any)
         H[i = 1:2, j = 1:2] in HermitianPSDCone(),
         Bin
     )
+    return
 end
 
 function test_Hermitian_PSD_keyword(::Any, ::Any)


### PR DESCRIPTION
This PR makes it possible to create Hermitian PSD matrix of variable.

The point of argument is going to be how to handle the keyword arguments of `@variable`. This PR does the following:
* If `binary` is true for any entry, throw an error.
* `fixed_value`, `start`, `lower_bound` and `upper_bound` should correspond to entries of hermitian matrices. We interpret the real (resp. imaginary) part as the corresponding value for the real (resp. imaginary) variable created. IIRC @mlubin was worried that it would be confusing, e.g., that `lower_bound = 1 + 2im` would be interpreted as a lower bound of `1` for the real part and a lower bound of `2` for the imaginary part. As a related note, @ccoffrin was asking for `@constraint(model, x + y * im .<= 1 + 2im)` to be interpreted as `@constraint(model, x <= 1)` and `@constraint(model, y <= 2)`.
* `integer` means that both the real and imaginary parts are `integer`. Maybe we should just error here ?