### PR TITLE
Add set_time_limit for setting time limits with Dates.Period

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ repo = "https://github.com/jump-dev/JuMP.jl.git"
 version = "1.4.0"
 
 [deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 MutableArithmetics = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"

--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -232,11 +232,10 @@ julia> unset_silent(model)
 
 Use [`set_time_limit_sec`](@ref), [`unset_time_limit_sec`](@ref), and
 [`time_limit_sec`](@ref) to manage time limits.
-```jldoctest
+```jldoctest time_limit
 julia> model = Model(HiGHS.Optimizer);
 
 julia> set_time_limit_sec(model, 60.0)
-
 
 julia> time_limit_sec(model)
 60.0
@@ -245,6 +244,18 @@ julia> unset_time_limit_sec(model)
 
 julia> time_limit_sec(model)
 Inf
+```
+
+To avoid making unit-conversion mistakes with [`set_time_limit_sec`](@ref), you
+can instead use [`set_time_limit`](@ref) with a `Dates.Period` object:
+
+```jldoctest time_limit
+julia> import Dates
+
+julia> set_time_limit(model, Dates.Hour(1))
+
+julia> time_limit_sec(model)
+3600.0
 ```
 
 !!! info

--- a/docs/src/reference/models.md
+++ b/docs/src/reference/models.md
@@ -45,6 +45,7 @@ set_optimizer_attribute
 set_optimizer_attributes
 set_silent
 unset_silent
+set_time_limit
 set_time_limit_sec
 unset_time_limit_sec
 time_limit_sec

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -17,6 +17,7 @@ For more information, go to https://jump.dev.
 """
 module JuMP
 
+import Dates
 using LinearAlgebra
 using SparseArrays
 
@@ -922,6 +923,21 @@ See also: [`set_silent`](@ref).
 """
 function unset_silent(model::Model)
     return MOI.set(model, MOI.Silent(), false)
+end
+
+"""
+    set_time_limit(model::Model, limit::Dates.Period)
+
+Set the time limit of the solver.
+
+Can be unset using [`unset_time_limit_sec`](@ref).
+
+See also: [`set_time_limit_sec`](@ref), [`unset_time_limit_sec`](@ref), and
+[`time_limit_sec`](@ref).
+"""
+function set_time_limit(model::Model, limit::Dates.Period)
+    limit_sec = 1e-9 * Dates.value(floor(limit, Dates.Nanosecond))
+    return set_time_limit_sec(model, limit_sec)
 end
 
 """

--- a/test/model.jl
+++ b/test/model.jl
@@ -15,6 +15,8 @@ module TestModels
 using JuMP
 using Test
 
+import Dates
+
 # Simple LP model not supporting Interval
 MOIU.@model(
     SimpleLPModel,

--- a/test/model.jl
+++ b/test/model.jl
@@ -478,6 +478,25 @@ function test_set_retrieve_time_limit()
     return
 end
 
+function test_set_time_limit()
+    mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
+    model = Model(() -> MOIU.MockOptimizer(mock))
+    for (limit, value) in [
+        Dates.Hour(1) => 3600.0,
+        Dates.Hour(2) => 7200.0,
+        Dates.Minute(1) => 60.0,
+        Dates.Minute(3) => 180.0,
+        Dates.Second(1) => 1.0,
+        Dates.Second(71) => 71.0,
+        Dates.Millisecond(60) => 0.06,
+        Dates.Millisecond(121) => 0.121,
+    ]
+        JuMP.set_time_limit(model, limit)
+        @test JuMP.time_limit_sec(model) ≈ value
+    end
+    return
+end
+
 struct DummyExtensionData
     model::JuMP.Model
 end


### PR DESCRIPTION
Closes #3115

I'm not convinced that it should be `set_time_limit` instead of `set_time_limit_sec`. I get that semantically it's a little clearer, but it introduces a new function, and stops authors from (easily) writing generic code that allows users to pass either a `Float64` or a `Dates.Period` object.

cc @dourouc05 