### PR TITLE
Change MutableArithmetics.rewrite to move_factors_into_sums=false

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 MathOptInterface = "1.14"
-MutableArithmetics = "1"
+MutableArithmetics = "1.1"
 OrderedCollections = "1"
 SnoopPrecompile = "1"
 julia = "1.6"

--- a/docs/src/manual/expressions.md
+++ b/docs/src/manual/expressions.md
@@ -195,7 +195,7 @@ julia> @variable(model, y)
 y
 
 julia> ex = @expression(model, x^2 + 2 * x * y + y^2 + x + y - 1)
-x² + 2 y*x + y² + x + y - 1
+x² + 2 x*y + y² + x + y - 1
 ```
 
 ### Operator overloading

--- a/src/complement.jl
+++ b/src/complement.jl
@@ -70,6 +70,6 @@ function parse_constraint_call(
     F,
     x,
 )
-    f, parse_code = _MA.rewrite(F)
+    f, parse_code = _MA.rewrite(F; move_factors_into_sums = false)
     return parse_code, :(_build_complements_constraint($errorf, $f, $(esc(x))))
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -500,9 +500,9 @@ function parse_constraint_head(
             "`$ub >= ... >= $lb`.",
         )
     end
-    new_aff, parse_aff = _MA.rewrite(aff)
-    new_lb, parse_lb = _MA.rewrite(lb)
-    new_ub, parse_ub = _MA.rewrite(ub)
+    new_aff, parse_aff = _MA.rewrite(aff; move_factors_into_sums = false)
+    new_lb, parse_lb = _MA.rewrite(lb; move_factors_into_sums = false)
+    new_ub, parse_ub = _MA.rewrite(ub; move_factors_into_sums = false)
     parse_code = quote
         $parse_aff
         $parse_lb
@@ -583,7 +583,7 @@ function parse_constraint_call(
     func,
     set,
 )
-    f, parse_code = _MA.rewrite(func)
+    f, parse_code = _MA.rewrite(func; move_factors_into_sums = false)
     build_call = if vectorized
         :(build_constraint.($_error, _desparsify($f), Ref($(esc(set)))))
     else
@@ -617,7 +617,7 @@ function parse_constraint_call(
     rhs,
 )
     func = vectorized ? :($lhs .- $rhs) : :($lhs - $rhs)
-    f, parse_code = _MA.rewrite(func)
+    f, parse_code = _MA.rewrite(func; move_factors_into_sums = false)
     set = operator_to_set(_error, operator)
     # `_functionize` deals with the pathological case where the `lhs` is a
     # `VariableRef` and the `rhs` is a summation with no terms.
@@ -1496,7 +1496,7 @@ macro objective(model, args...)
     end
     sense, x = args
     sense_expr = _moi_sense(_error, sense)
-    newaff, parsecode = _MA.rewrite(x)
+    newaff, parsecode = _MA.rewrite(x; move_factors_into_sums = false)
     code = quote
         $parsecode
         # Don't leak a `_MA.Zero` if the objective expression is an empty
@@ -1585,7 +1585,7 @@ macro expression(args...)
             "different name for the index.",
         )
     end
-    code = _MA.rewrite_and_return(x)
+    code = _MA.rewrite_and_return(x; move_factors_into_sums = false)
     code = quote
         # Don't leak a `_MA.Zero` if the expression is an empty summation, or
         # other structure that returns `_MA.Zero()`.

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -603,7 +603,7 @@ end
 function test_Error_on_unexpected_comparison()
     m = Model()
     @variable(m, x)
-    @test_macro_throws ErrorException @expression(m, x <= 1)
+    @test_throws ErrorException @expression(m, x <= 1)
     return
 end
 

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -180,7 +180,7 @@ function test_printing_expressions()
         "x_{1}\\times y_{2,2} + x_{2}\\times y_{2,2} + z$ijulia_sq + 3 x_{1} + 3 x_{2} - 1",
     )
 
-    ex = @expression(mod, -z * x[1] - x[1] * z + x[1] * x[2] + 0 * z^2)
+    ex = @expression(mod, -z * x[1] - z * x[1] + x[1] * x[2] + 0 * z^2)
     io_test(MIME("text/plain"), ex, "-2 z*x[1] + x[1]*x[2]")
     io_test(MIME("text/latex"), ex, "-2 z\\times x_{1} + x_{1}\\times x_{2}")
 


### PR DESCRIPTION
Needs https://github.com/jump-dev/MutableArithmetics.jl/pull/170

I've been experimenting with a drop-in replacement for `MA.@rewrite` and `MA.rewrite`. JuMP throws up some interesting challenges, so it took me a while to get this correct. The tests are now passing with a couple of minimal changes.

1. A change from compile-time to run-time error for `@expression(model, x <= 1)`
2. A correction of the error in `@constraint(m, x[i = 1] <= 1)` so that it matches the non-macro error obtained from `x[i = 1]`
3. A printing change from `y * x` to `x * y`. This is just cosmetic, and depends on the order that we encounter the variables, but the new behavior now more closely resembles what the user wrote.

The biggest surprises were some of our design choices:

 * Rewriting `a + b` to `operate!!(add_mul, a, b)` instead of `operate!!(+, a, b)` 
 * Rewriting `a - b` to `operate!!(sub_mul, a, b)` instead of `operate!!(-, a, b)`
 * We rewrite only `+` and `-` to their mutable `add_mul` and `sub_mul` equivalents. We don't rewrite something like `operate!!(/, a, b)`, even if the operation is supported.
 * Supporting the invalid syntax `sum(i+j for i=1:2, j=i:2)`:
   ```julia
   julia> sum(i+j for i=1:2, j=i:2)
   ERROR: UndefVarError: i not defined

   julia> JuMP.MutableArithmetics2.@rewrite(sum(i+j for i=1:2, j=i:2))
   9
   ```
   The last one took me a while to debug...

There are a couple of options for merging this.

 1. <s>keep it in JuMP</s>
 2. Add it to MutableArithmetics as a replacement for the existing code
 3. Add it to MutableArithmetics as a new feature, perhaps renaming to `rewrite_expr`?