### PR TITLE
Fix optimizer_attribute with AbstractString names

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -804,6 +804,12 @@ function set_optimizer_attribute(model::Model, name::String, value)
     return
 end
 
+# This method is needed for string types like String15 coming from a DataFrame.
+function set_optimizer_attribute(model::Model, name::AbstractString, value)
+    set_optimizer_attribute(model, String(name), value)
+    return
+end
+
 """
     set_optimizer_attribute(
         model::Model,
@@ -876,6 +882,11 @@ See also: [`set_optimizer_attribute`](@ref), [`set_optimizer_attributes`](@ref).
 """
 function get_optimizer_attribute(model::Model, name::String)
     return get_optimizer_attribute(model, MOI.RawOptimizerAttribute(name))
+end
+
+# This method is needed for string types like String15 coming from a DataFrame.
+function get_optimizer_attribute(model::Model, name::AbstractString)
+    return get_optimizer_attribute(model, String(name))
 end
 
 """

--- a/test/model.jl
+++ b/test/model.jl
@@ -462,6 +462,17 @@ function test_get_optimizer_attribute()
     @test JuMP.get_optimizer_attribute(model, "aaa") == "bbb"
 end
 
+function test_optimizer_attribute_abstract_string()
+    mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
+    model = Model(() -> MOIU.MockOptimizer(mock))
+    attribute = "abc"
+    abstract_str = @views attribute[1:end]
+    JuMP.set_optimizer_attribute(model, abstract_str, "x")
+    @test JuMP.get_optimizer_attribute(model, abstract_str) == "x"
+    @test JuMP.get_optimizer_attribute(model, attribute) == "x"
+    return
+end
+
 function test_set_retrieve_time_limit()
     mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
     model = Model(() -> MOIU.MockOptimizer(mock))


### PR DESCRIPTION
x-ref https://discourse.julialang.org/t/set-optimizer-attribute-does-not-work-in-newer-versions-of-jump-julia-etc/89727