### PR TITLE
Report result_count in solution_summary by default

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+ - Added a `result` keyword argument to [`solution_summary`] to allow
+   summarizing models with multiple solutions (#3138)
+
 ### Other
 
  - Added Benders tutorial with in-place resolves (#3145)

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -43,17 +43,17 @@ julia> solution_summary(model)
 * Solver : HiGHS
 
 * Status
-  Result             : 1 of 1
+  Result count       : 1
   Termination status : OPTIMAL
-  Primal status      : FEASIBLE_POINT
-  Dual status        : FEASIBLE_POINT
   Message from the solver:
   "kHighsModelStatusOptimal"
 
-* Candidate solution
-  Objective value      : -2.05143e+02
-  Objective bound      : -0.00000e+00
-  Relative gap         : Inf
+* Candidate solution (result #1)
+  Primal status      : FEASIBLE_POINT
+  Dual status        : FEASIBLE_POINT
+  Objective value    : -2.05143e+02
+  Objective bound    : -0.00000e+00
+  Relative gap       : Inf
   Dual objective value : -2.05143e+02
 
 * Work counters
@@ -66,17 +66,17 @@ julia> solution_summary(model; verbose = true)
 * Solver : HiGHS
 
 * Status
-  Result             : 1 of 1
+  Result count       : 1
   Termination status : OPTIMAL
-  Primal status      : FEASIBLE_POINT
-  Dual status        : FEASIBLE_POINT
   Message from the solver:
   "kHighsModelStatusOptimal"
 
-* Candidate solution
-  Objective value      : -2.05143e+02
-  Objective bound      : -0.00000e+00
-  Relative gap         : Inf
+* Candidate solution (result #1)
+  Primal status      : FEASIBLE_POINT
+  Dual status        : FEASIBLE_POINT
+  Objective value    : -2.05143e+02
+  Objective bound    : -0.00000e+00
+  Relative gap       : Inf
   Dual objective value : -2.05143e+02
   Primal solution :
     x : 1.54286e+01

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -43,8 +43,10 @@ julia> solution_summary(model)
 
 * Status
   Termination status : OPTIMAL
-  Primal status      : FEASIBLE_POINT
-  Dual status        : FEASIBLE_POINT
+  Result count       : 1
+  Solution #1 (default)
+    Primal status    : FEASIBLE_POINT
+    Dual status      : FEASIBLE_POINT
   Message from the solver:
   "kHighsModelStatusOptimal"
 
@@ -65,10 +67,10 @@ julia> solution_summary(model, verbose=true)
 
 * Status
   Termination status : OPTIMAL
-  Primal status      : FEASIBLE_POINT
-  Dual status        : FEASIBLE_POINT
   Result count       : 1
-  Has duals          : true
+  Solution #1 (default)
+    Primal status    : FEASIBLE_POINT
+    Dual status      : FEASIBLE_POINT
   Message from the solver:
   "kHighsModelStatusOptimal"
 

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -35,18 +35,18 @@ Subject to
 
 ## Solutions summary
 
-[`solution_summary`](@ref) can be used for checking the summary of the optimization solutions.
+[`solution_summary`](@ref) can be used for checking the summary of the
+optimization solutions.
 
 ```jldoctest solutions; filter=r"[0-9]+\.[0-9]+e[\+\-][0-9]+"
 julia> solution_summary(model)
 * Solver : HiGHS
 
 * Status
+  Result             : 1 of 1
   Termination status : OPTIMAL
-  Result count       : 1
-  Solution #1 (default)
-    Primal status    : FEASIBLE_POINT
-    Dual status      : FEASIBLE_POINT
+  Primal status      : FEASIBLE_POINT
+  Dual status        : FEASIBLE_POINT
   Message from the solver:
   "kHighsModelStatusOptimal"
 
@@ -62,15 +62,14 @@ julia> solution_summary(model)
   Barrier iterations : 0
   Node count         : -1
 
-julia> solution_summary(model, verbose=true)
+julia> solution_summary(model; verbose = true)
 * Solver : HiGHS
 
 * Status
+  Result             : 1 of 1
   Termination status : OPTIMAL
-  Result count       : 1
-  Solution #1 (default)
-    Primal status    : FEASIBLE_POINT
-    Dual status      : FEASIBLE_POINT
+  Primal status      : FEASIBLE_POINT
+  Dual status        : FEASIBLE_POINT
   Message from the solver:
   "kHighsModelStatusOptimal"
 
@@ -535,9 +534,10 @@ end
 Some solvers support returning multiple solutions. You can check how many
 solutions are available to query using [`result_count`](@ref).
 
-Functions for querying the solutions, for example, [`primal_status`](@ref) and
-[`value`](@ref), all take an additional keyword argument `result` which can be
-used to specify which result to return.
+Functions for querying the solutions, for example, [`primal_status`](@ref),
+[`dual_status`](@ref), [`value`](@ref), [`dual`](@ref), and [`solution_summary`](@ref)
+all take an additional keyword argument `result` which can be used to specify
+which result to return.
 
 !!! warning
     Even if [`termination_status`](@ref) is `OPTIMAL`, some of the returned
@@ -560,6 +560,7 @@ end
 an_optimal_solution = value.(x; result = 1)
 optimal_objective = objective_value(model; result = 1)
 for i in 2:result_count(model)
+    print(solution_summary(model; result = i))
     @assert has_values(model; result = i)
     println("Solution $(i) = ", value.(x; result = i))
     obj = objective_value(model; result = i)

--- a/src/solution_summary.jl
+++ b/src/solution_summary.jl
@@ -165,11 +165,11 @@ function _show_candidate_solution_summary(io::IO, summary::_SolutionSummary)
             )
         end
     end
-    println(io)
     return
 end
 
 function _show_work_counters_summary(io::IO, summary::_SolutionSummary)
+    println(io)
     println(io, "* Work counters")
     _print_if_not_missing(io, "  Solve time (sec)   : ", summary.solve_time)
     _print_if_not_missing(

--- a/src/solution_summary.jl
+++ b/src/solution_summary.jl
@@ -103,16 +103,8 @@ end
 
 function _show_status_summary(io::IO, summary::_SolutionSummary)
     println(io, "* Status")
-    println(
-        io,
-        "  Result             : ",
-        summary.result,
-        " of ",
-        summary.result_count,
-    )
+    println(io, "  Result count       : ", summary.result_count)
     println(io, "  Termination status : ", summary.termination_status)
-    println(io, "  Primal status      : ", summary.primal_status)
-    println(io, "  Dual status        : ", summary.dual_status)
     if summary.result == 1
         println(io, "  Message from the solver:")
         println(io, "  \"", summary.raw_status, "\"")
@@ -122,21 +114,23 @@ function _show_status_summary(io::IO, summary::_SolutionSummary)
 end
 
 function _show_candidate_solution_summary(io::IO, summary::_SolutionSummary)
-    println(io, "* Candidate solution")
+    println(io, "* Candidate solution (result #$(summary.result))")
+    println(io, "  Primal status      : ", summary.primal_status)
+    println(io, "  Dual status        : ", summary.dual_status)
     _print_if_not_missing(
         io,
-        "  Objective value      : ",
+        "  Objective value    : ",
         summary.objective_value,
     )
     if summary.result == 1
         _print_if_not_missing(
             io,
-            "  Objective bound      : ",
+            "  Objective bound    : ",
             summary.objective_bound,
         )
         _print_if_not_missing(
             io,
-            "  Relative gap         : ",
+            "  Relative gap       : ",
             summary.relative_gap,
         )
     end

--- a/src/solution_summary.jl
+++ b/src/solution_summary.jl
@@ -96,12 +96,10 @@ end
 function _show_status_summary(io::IO, summary::_SolutionSummary)
     println(io, "* Status")
     println(io, "  Termination status : ", summary.termination_status)
-    println(io, "  Primal status      : ", summary.primal_status)
-    println(io, "  Dual status        : ", summary.dual_status)
-    if summary.verbose
-        println(io, "  Result count       : ", summary.result_count)
-        println(io, "  Has duals          : ", summary.has_duals)
-    end
+    println(io, "  Result count       : ", summary.result_count)
+    println(io, "  Solution #1 (default)")
+    println(io, "    Primal status    : ", summary.primal_status)
+    println(io, "    Dual status      : ", summary.dual_status)
     println(io, "  Message from the solver:")
     println(io, "  \"", summary.raw_status, "\"")
     println(io)

--- a/src/solution_summary.jl
+++ b/src/solution_summary.jl
@@ -6,6 +6,7 @@
 import Printf
 
 struct _SolutionSummary
+    result::Int
     verbose::Bool
     solver::String
     # Status
@@ -31,9 +32,10 @@ struct _SolutionSummary
 end
 
 """
-    solution_summary(model::Model; verbose::Bool = false)
+    solution_summary(model::Model; result::Int = 1, verbose::Bool = false)
 
-Return a struct that can be used print a summary of the solution.
+Return a struct that can be used print a summary of the solution in result
+`result`.
 
 If `verbose=true`, write out the primal solution for every variable and the
 dual solution for every constraint, excluding those with empty names.
@@ -54,23 +56,27 @@ function foo(model)
 end
 ```
 """
-function solution_summary(model::Model; verbose::Bool = false)
+function solution_summary(model::Model; result::Int = 1, verbose::Bool = false)
+    num_results = result_count(model)
+    has_primal = has_values(model; result = result)
+    has_dual = has_duals(model; result = result)
     return _SolutionSummary(
+        result,
         verbose,
         solver_name(model),
         termination_status(model),
-        primal_status(model),
-        dual_status(model),
+        primal_status(model; result = result),
+        dual_status(model; result = result),
         raw_status(model),
-        result_count(model),
-        has_values(model),
-        has_duals(model),
-        _try_get(objective_value, model),
+        num_results,
+        has_primal,
+        has_dual,
+        _try_get(m -> objective_value(m; result = result), model),
         _try_get(objective_bound, model),
         _try_get(relative_gap, model),
-        _try_get(dual_objective_value, model),
-        verbose ? _get_solution_dict(model) : missing,
-        verbose ? _get_constraint_dict(model) : missing,
+        _try_get(m -> dual_objective_value(m; result = result), model),
+        verbose && has_primal ? _get_solution_dict(model, result) : missing,
+        verbose && has_dual ? _get_constraint_dict(model, result) : missing,
         _try_get(solve_time, model),
         _try_get(barrier_iterations, model),
         _try_get(simplex_iterations, model),
@@ -89,19 +95,28 @@ function Base.show(io::IO, summary::_SolutionSummary)
     println(io)
     _show_status_summary(io, summary)
     _show_candidate_solution_summary(io, summary)
-    _show_work_counters_summary(io, summary)
+    if summary.result == 1
+        _show_work_counters_summary(io, summary)
+    end
     return
 end
 
 function _show_status_summary(io::IO, summary::_SolutionSummary)
     println(io, "* Status")
+    println(
+        io,
+        "  Result             : ",
+        summary.result,
+        " of ",
+        summary.result_count,
+    )
     println(io, "  Termination status : ", summary.termination_status)
-    println(io, "  Result count       : ", summary.result_count)
-    println(io, "  Solution #1 (default)")
-    println(io, "    Primal status    : ", summary.primal_status)
-    println(io, "    Dual status      : ", summary.dual_status)
-    println(io, "  Message from the solver:")
-    println(io, "  \"", summary.raw_status, "\"")
+    println(io, "  Primal status      : ", summary.primal_status)
+    println(io, "  Dual status        : ", summary.dual_status)
+    if summary.result == 1
+        println(io, "  Message from the solver:")
+        println(io, "  \"", summary.raw_status, "\"")
+    end
     println(io)
     return
 end
@@ -113,12 +128,18 @@ function _show_candidate_solution_summary(io::IO, summary::_SolutionSummary)
         "  Objective value      : ",
         summary.objective_value,
     )
-    _print_if_not_missing(
-        io,
-        "  Objective bound      : ",
-        summary.objective_bound,
-    )
-    _print_if_not_missing(io, "  Relative gap         : ", summary.relative_gap)
+    if summary.result == 1
+        _print_if_not_missing(
+            io,
+            "  Objective bound      : ",
+            summary.objective_bound,
+        )
+        _print_if_not_missing(
+            io,
+            "  Relative gap         : ",
+            summary.relative_gap,
+        )
+    end
     _print_if_not_missing(
         io,
         "  Dual objective value : ",
@@ -165,28 +186,24 @@ function _show_work_counters_summary(io::IO, summary::_SolutionSummary)
     return
 end
 
-function _get_solution_dict(model)
+function _get_solution_dict(model, result)
     dict = Dict{String,Float64}()
-    if has_values(model)
-        for x in all_variables(model)
-            variable_name = name(x)
-            if !isempty(variable_name)
-                dict[variable_name] = value(x)
-            end
+    for x in all_variables(model)
+        variable_name = name(x)
+        if !isempty(variable_name)
+            dict[variable_name] = value(x; result = result)
         end
     end
     return dict
 end
 
-function _get_constraint_dict(model)
+function _get_constraint_dict(model, result)
     dict = Dict{String,Float64}()
-    if has_duals(model)
-        for (F, S) in list_of_constraint_types(model)
-            for constraint in all_constraints(model, F, S)
-                constraint_name = name(constraint)
-                if !isempty(constraint_name)
-                    dict[constraint_name] = dual(constraint)
-                end
+    for (F, S) in list_of_constraint_types(model)
+        for constraint in all_constraints(model, F, S)
+            constraint_name = name(constraint)
+            if !isempty(constraint_name)
+                dict[constraint_name] = dual(constraint; result = result)
             end
         end
     end

--- a/test/solution_summary.jl
+++ b/test/solution_summary.jl
@@ -26,8 +26,10 @@ function test_empty_model()
 
 * Status
   Termination status : OPTIMIZE_NOT_CALLED
-  Primal status      : NO_SOLUTION
-  Dual status        : NO_SOLUTION
+  Result count       : 0
+  Solution #1 (default)
+    Primal status    : NO_SOLUTION
+    Dual status      : NO_SOLUTION
   Message from the solver:
   "optimize not called"
 
@@ -85,8 +87,10 @@ function test_solution_summary()
 
 * Status
   Termination status : OPTIMAL
-  Primal status      : FEASIBLE_POINT
-  Dual status        : FEASIBLE_POINT
+  Result count       : 1
+  Solution #1 (default)
+    Primal status    : FEASIBLE_POINT
+    Dual status      : FEASIBLE_POINT
   Message from the solver:
   "solver specific string"
 
@@ -110,10 +114,10 @@ function test_solution_summary()
 
 * Status
   Termination status : OPTIMAL
-  Primal status      : FEASIBLE_POINT
-  Dual status        : FEASIBLE_POINT
   Result count       : 1
-  Has duals          : true
+  Solution #1 (default)
+    Primal status    : FEASIBLE_POINT
+    Dual status      : FEASIBLE_POINT
   Message from the solver:
   "solver specific string"
 

--- a/test/solution_summary.jl
+++ b/test/solution_summary.jl
@@ -151,7 +151,6 @@ function test_solution_summary()
 
 * Candidate solution
   Objective value      : -0.00000e+00
-
 """
 
     summary = solution_summary(model; result = 2, verbose = true)
@@ -169,7 +168,6 @@ function test_solution_summary()
   Primal solution :
     x : 0.00000e+00
     y : 0.00000e+00
-
 """
 
     summary = solution_summary(model; result = 3)
@@ -183,7 +181,6 @@ function test_solution_summary()
   Dual status        : NO_SOLUTION
 
 * Candidate solution
-
 """
     return
 end

--- a/test/solution_summary.jl
+++ b/test/solution_summary.jl
@@ -25,14 +25,14 @@ function test_empty_model()
 * Solver : No optimizer attached.
 
 * Status
-  Result             : 1 of 0
+  Result count       : 0
   Termination status : OPTIMIZE_NOT_CALLED
-  Primal status      : NO_SOLUTION
-  Dual status        : NO_SOLUTION
   Message from the solver:
   "optimize not called"
 
-* Candidate solution
+* Candidate solution (result #1)
+  Primal status      : NO_SOLUTION
+  Dual status        : NO_SOLUTION
 
 * Work counters
 """
@@ -90,17 +90,17 @@ function test_solution_summary()
 * Solver : Mock
 
 * Status
-  Result             : 1 of 2
+  Result count       : 2
   Termination status : OPTIMAL
-  Primal status      : FEASIBLE_POINT
-  Dual status        : FEASIBLE_POINT
   Message from the solver:
   "solver specific string"
 
-* Candidate solution
-  Objective value      : -1.00000e+00
-  Objective bound      : -3.00000e+00
-  Relative gap         : 6.66667e-01
+* Candidate solution (result #1)
+  Primal status      : FEASIBLE_POINT
+  Dual status        : FEASIBLE_POINT
+  Objective value    : -1.00000e+00
+  Objective bound    : -3.00000e+00
+  Relative gap       : 6.66667e-01
   Dual objective value : -1.00000e+00
 
 * Work counters
@@ -115,17 +115,17 @@ function test_solution_summary()
 * Solver : Mock
 
 * Status
-  Result             : 1 of 2
+  Result count       : 2
   Termination status : OPTIMAL
-  Primal status      : FEASIBLE_POINT
-  Dual status        : FEASIBLE_POINT
   Message from the solver:
   "solver specific string"
 
-* Candidate solution
-  Objective value      : -1.00000e+00
-  Objective bound      : -3.00000e+00
-  Relative gap         : 6.66667e-01
+* Candidate solution (result #1)
+  Primal status      : FEASIBLE_POINT
+  Dual status        : FEASIBLE_POINT
+  Objective value    : -1.00000e+00
+  Objective bound    : -3.00000e+00
+  Relative gap       : 6.66667e-01
   Dual objective value : -1.00000e+00
   Primal solution :
     x : 1.00000e+00
@@ -144,13 +144,13 @@ function test_solution_summary()
 * Solver : Mock
 
 * Status
-  Result             : 2 of 2
+  Result count       : 2
   Termination status : OPTIMAL
+
+* Candidate solution (result #2)
   Primal status      : FEASIBLE_POINT
   Dual status        : NO_SOLUTION
-
-* Candidate solution
-  Objective value      : -0.00000e+00
+  Objective value    : -0.00000e+00
 """
 
     summary = solution_summary(model; result = 2, verbose = true)
@@ -158,13 +158,13 @@ function test_solution_summary()
 * Solver : Mock
 
 * Status
-  Result             : 2 of 2
+  Result count       : 2
   Termination status : OPTIMAL
+
+* Candidate solution (result #2)
   Primal status      : FEASIBLE_POINT
   Dual status        : NO_SOLUTION
-
-* Candidate solution
-  Objective value      : -0.00000e+00
+  Objective value    : -0.00000e+00
   Primal solution :
     x : 0.00000e+00
     y : 0.00000e+00
@@ -175,12 +175,12 @@ function test_solution_summary()
 * Solver : Mock
 
 * Status
-  Result             : 3 of 2
+  Result count       : 2
   Termination status : OPTIMAL
+
+* Candidate solution (result #3)
   Primal status      : NO_SOLUTION
   Dual status        : NO_SOLUTION
-
-* Candidate solution
 """
     return
 end


### PR DESCRIPTION
Closes #3136

The backstory to this is that https://discourse.julialang.org/t/mosek-does-not-give-the-optimal-value-derived-by-simplex-methods/90727 would have been a lot more obvious to debug if `result_count` was reported by default in `solution_summary`.

I'm open to other suggestions about how we could communicate this. The `Solution #1 (default)` comes from #3136, but it doesn't really apply when `result_count = 0`. Should we even report primal/dual status then?