### PR TITLE
Replaces length/size by eachindex/axes

### DIFF
--- a/docs/src/tutorials/algorithms/cutting_stock_column_generation.jl
+++ b/docs/src/tutorials/algorithms/cutting_stock_column_generation.jl
@@ -71,7 +71,7 @@ function get_data()
         6.6 49
         5.1 42
     ]
-    return Data([Piece(data[i, 1], data[i, 2]) for i in 1:size(data, 1)], 100.0)
+    return Data([Piece(data[i, 1], data[i, 2]) for i in axes(data, 1)], 100.0)
 end
 
 data = get_data()

--- a/src/print.jl
+++ b/src/print.jl
@@ -612,9 +612,9 @@ function function_string(
     A::AbstractMatrix{<:AbstractJuMPScalar},
 )
     str = "\\begin{bmatrix}\n"
-    for i in 1:size(A, 1)
+    for i in axes(A, 1)
         line = ""
-        for j in 1:size(A, 2)
+        for j in axes(A, 2)
             if j != 1
                 line *= " & "
             end

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -395,7 +395,7 @@ And data, a 0-dimensional $(Array{Int,0}):
 
     @testset "DenseAxisArray_show_nd" begin
         S = zeros(Int, 2, 2, 3, 3, 3)
-        for i in 1:length(S)
+        for i in eachindex(S)
             S[i] = i
         end
         x = DenseAxisArray(S, 1:2, 1:2, 1:3, 1:3, 1:3)

--- a/test/Containers/DenseAxisArray.jl
+++ b/test/Containers/DenseAxisArray.jl
@@ -414,7 +414,7 @@ And data, a 0-dimensional $(Array{Int,0}):
 
     @testset "DenseAxisArray_show_nd_limit" begin
         S = zeros(Int, 2, 2, 3, 3, 20)
-        for i in 1:length(S)
+        for i in eachindex(S)
             S[i] = i
         end
         x = DenseAxisArray(S, 1:2, 1:2, 1:3, 1:3, 1:20)

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -250,7 +250,7 @@ function test_register_check_forwarddiff_multivariate()
     function f(x...)
         # This is a common case, where user's preallocate a Float64 storage.
         y = zeros(length(x))
-        for i in 1:length(x)
+        for i in eachindex(x)
             y[i] = log(x[i])
         end
         return sum(y)
@@ -270,7 +270,7 @@ function test_register_check_forwarddiff_multivariate_gradf()
     function f(x...)
         # This is a common case, where user's preallocate a Float64 storage.
         y = zeros(length(x))
-        for i in 1:length(x)
+        for i in eachindex(x)
             y[i] = log(x[i])
         end
         return sum(y)
@@ -278,7 +278,7 @@ function test_register_check_forwarddiff_multivariate_gradf()
     function ∇f(x...)
         # This is a common case, where user's preallocate a Float64 storage.
         y = zeros(length(x))
-        for i in 1:length(x)
+        for i in eachindex(x)
             y[i] = 1 / x[i]
         end
         return sum(y)


### PR DESCRIPTION
This resolves the following warnings in VSCode:

> Indexing with indices obtained from `length`, `size` is discouraged. Use `eachindex` or `axes` instead.