### PR TITLE
Fix promotion and adjoint for complex expressions

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -1055,9 +1055,10 @@ Base.ndims(::AbstractJuMPScalar) = 0
 
 # These are required to create symmetric containers of AbstractJuMPScalars.
 LinearAlgebra.symmetric_type(::Type{T}) where {T<:AbstractJuMPScalar} = T
+LinearAlgebra.hermitian_type(::Type{T}) where {T<:AbstractJuMPScalar} = T
 LinearAlgebra.symmetric(scalar::AbstractJuMPScalar, ::Symbol) = scalar
-# This is required for linear algebra operations involving transposes.
-LinearAlgebra.adjoint(scalar::AbstractJuMPScalar) = scalar
+LinearAlgebra.hermitian(scalar::AbstractJuMPScalar, ::Symbol) = adjoint(scalar)
+LinearAlgebra.adjoint(scalar::AbstractJuMPScalar) = conj(scalar)
 
 """
     owner_model(s::AbstractJuMPScalar)

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -499,13 +499,14 @@ function _drop_zeros!(terms::OrderedDict)
         elseif coef isa Complex && iszero(imag(coef))
             terms[var] = real(coef)
         end
-     end
+    end
+    return
 end
 
 function SparseArrays.dropzeros(aff::GenericAffExpr)
     result = copy(aff)
     _drop_zeros!(result.terms)
-   if iszero(result.constant)
+    if iszero(result.constant)
         # This is to work around isequal(0.0, -0.0) == false.
         result.constant = zero(typeof(result.constant))
     elseif result.constant isa Complex && iszero(imag(result.constant))

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -382,9 +382,15 @@ function Base.promote_rule(
 end
 function Base.promote_rule(
     ::Type{GenericAffExpr{S,V}},
-    R::Type{<:Real},
+    R::Type{<:Number},
 ) where {S,V}
     return GenericAffExpr{promote_type(S, R),V}
+end
+function Base.promote_rule(
+    ::Type{<:GenericAffExpr{S,V}},
+    ::Type{<:GenericAffExpr{T,V}},
+) where {S,T,V}
+    return GenericAffExpr{promote_type(S, T),V}
 end
 function Base.promote_rule(
     ::Type{<:GenericAffExpr{S,V}},

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -148,11 +148,7 @@ Remove terms in the quadratic expression with `0` coefficients.
 """
 function drop_zeros!(expr::GenericQuadExpr)
     drop_zeros!(expr.aff)
-    for (key, coef) in expr.terms
-        if iszero(coef)
-            delete!(expr.terms, key)
-        end
-    end
+    _drop_zeros!(expr.terms)
     return
 end
 
@@ -497,11 +493,7 @@ Base.hash(quad::GenericQuadExpr, h::UInt) = hash(quad.aff, hash(quad.terms, h))
 
 function SparseArrays.dropzeros(quad::GenericQuadExpr)
     quad_terms = copy(quad.terms)
-    for (key, value) in quad.terms
-        if iszero(value)
-            delete!(quad_terms, key)
-        end
-    end
+    _drop_zeros!(quad_terms)
     return GenericQuadExpr(dropzeros(quad.aff), quad_terms)
 end
 

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -15,6 +15,7 @@ using Test
 
 import LinearAlgebra
 import MutableArithmetics
+import SparseArrays
 
 const MA = MutableArithmetics
 
@@ -223,6 +224,22 @@ function test_hermitian()
     @test isequal_canonical(H[1, 2], LinearAlgebra.adjoint(H[2, 1]))
     for i in 1:2, j in 1:2
         @test isequal_canonical(A[i, j], H[i, j])
+    end
+    return
+end
+
+function test_complex_sparse_arrays_dropzeros()
+    model = Model()
+    @variable(model, x)
+    a = 2.0 + 1.0im
+    for rhs in (0.0 + 0.0im, 0.0 - 0.0im, -0.0 + 0.0im, -0.0 + -0.0im)
+        # We need to explicitly set the .constant field to avoid a conversion to
+        # 0.0 + 0.0im
+        expr = a * x
+        expr.constant = rhs
+        @test isequal(SparseArrays.dropzeros(expr), a * x)
+        expr.constant = 1.0 + rhs
+        @test isequal(SparseArrays.dropzeros(expr), a * x + 1.0)
     end
     return
 end

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -10,10 +10,12 @@
 
 module TestComplexNumberSupport
 
-using LinearAlgebra
 using JuMP
 using Test
+
+import LinearAlgebra
 import MutableArithmetics
+
 const MA = MutableArithmetics
 
 function runtests()
@@ -205,26 +207,24 @@ end
 function test_hermitian()
     model = Model()
     @variable(model, x)
-    A = [3  1im
-         -1im 2x]
+    A = [3 1im; -1im 2x]
     @test A isa Matrix{GenericAffExpr{ComplexF64,VariableRef}}
-    A = [3x^2  1im
-         -1im 2x]
+    A = [3x^2 1im; -1im 2x]
     @test A isa Matrix{GenericQuadExpr{ComplexF64,VariableRef}}
-    A = [3x  1im
-         -1im 2x^2]
+    A = [3x 1im; -1im 2x^2]
     @test A isa Matrix{GenericQuadExpr{ComplexF64,VariableRef}}
-    A = [3x  1im
-         -1im 2x]
+    A = [3x 1im; -1im 2x]
     @test A isa Matrix{GenericAffExpr{ComplexF64,VariableRef}}
     @test isequal_canonical(A', A)
-    H = Hermitian(A)
-    @test H isa Hermitian{GenericAffExpr{ComplexF64,VariableRef},Matrix{GenericAffExpr{ComplexF64,VariableRef}}}
-    @test isequal_canonical(A[1, 2], adjoint(A[2, 1]))
-    @test isequal_canonical(H[1, 2], adjoint(H[2, 1]))
+    H = LinearAlgebra.Hermitian(A)
+    T = GenericAffExpr{ComplexF64,VariableRef}
+    @test H isa LinearAlgebra.Hermitian{T,Matrix{T}}
+    @test isequal_canonical(A[1, 2], LinearAlgebra.adjoint(A[2, 1]))
+    @test isequal_canonical(H[1, 2], LinearAlgebra.adjoint(H[2, 1]))
     for i in 1:2, j in 1:2
         @test isequal_canonical(A[i, j], H[i, j])
     end
+    return
 end
 
 end

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -10,6 +10,7 @@
 
 module TestComplexNumberSupport
 
+using LinearAlgebra
 using JuMP
 using Test
 import MutableArithmetics
@@ -199,6 +200,31 @@ function test_complex_abs2()
     @test abs2(x + 2im) == x^2 + 4
     @test abs2(x + 2) == x^2 + 4x + 4
     @test abs2(x * im + 2) == x^2 + 4
+end
+
+function test_hermitian()
+    model = Model()
+    @variable(model, x)
+    A = [3  1im
+         -1im 2x]
+    @test A isa Matrix{GenericAffExpr{ComplexF64,VariableRef}}
+    A = [3x^2  1im
+         -1im 2x]
+    @test A isa Matrix{GenericQuadExpr{ComplexF64,VariableRef}}
+    A = [3x  1im
+         -1im 2x^2]
+    @test A isa Matrix{GenericQuadExpr{ComplexF64,VariableRef}}
+    A = [3x  1im
+         -1im 2x]
+    @test A isa Matrix{GenericAffExpr{ComplexF64,VariableRef}}
+    @test isequal_canonical(A', A)
+    H = Hermitian(A)
+    @test H isa Hermitian{GenericAffExpr{ComplexF64,VariableRef},Matrix{GenericAffExpr{ComplexF64,VariableRef}}}
+    @test isequal_canonical(A[1, 2], adjoint(A[2, 1]))
+    @test isequal_canonical(H[1, 2], adjoint(H[2, 1]))
+    for i in 1:2, j in 1:2
+        @test isequal_canonical(A[i, j], H[i, j])
+    end
 end
 
 end


### PR DESCRIPTION
Some of the matrices constructed in the tests had eltype Any or GenericAffExpr with no type argument. With this PR, the eltype is now promoted properly.
Secondly, adjoint should redirect to conj in case coefficients are complex.