### PR TITLE
[Containers] add support for view of DenseAxisArray

### DIFF
--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -631,6 +631,10 @@ end
 function Base.eachindex(A::DenseAxisArrayView)
     # Return a generator so that we lazily evaluate the product instead of
     # collecting into a vector.
+    #
+    # In future, we might want to return the appropriate matrix of
+    # `CartesianIndex` to avoid having to do the lookups with
+    # `DenseAxisArrayKey`.
     return (DenseAxisArrayKey(k) for k in Base.product(A.axes...))
 end
 

--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -348,6 +348,19 @@ function Base.IndexStyle(::Type{DenseAxisArray{T,N,Ax}}) where {T,N,Ax}
     return IndexAnyCartesian()
 end
 
+function Base.setindex!(
+    A::DenseAxisArray{T,N},
+    value::DenseAxisArray{T,N},
+    args...,
+) where {T,N}
+    @show args
+    @show Base.to_index(A, args)
+    for key in Base.product(args...)
+        A[key...] = value[key...]
+    end
+    return A
+end
+
 ########
 # Keys #
 ########
@@ -362,6 +375,10 @@ struct DenseAxisArrayKey{T<:Tuple}
 end
 Base.getindex(k::DenseAxisArrayKey, args...) = getindex(k.I, args...)
 Base.getindex(a::DenseAxisArray, k::DenseAxisArrayKey) = a[k.I...]
+
+function Base.setindex!(A::DenseAxisArray, value, key::DenseAxisArrayKey)
+    return setindex!(A, value, key.I...)
+end
 
 struct DenseAxisArrayKeys{T<:Tuple,S<:DenseAxisArrayKey,N} <: AbstractArray{S,N}
     product_iter::Base.Iterators.ProductIterator{T}
@@ -559,3 +576,57 @@ end
 # but some users may depend on it's functionality so we have a work-around
 # instead of just breaking code.
 Base.repeat(x::DenseAxisArray; kwargs...) = repeat(x.data; kwargs...)
+
+###
+### view
+###
+
+_get_subaxis(::Colon, b) = b
+
+function _get_subaxis(a, b)
+    for ai in a
+        if !(ai in b)
+            throw(KeyError(ai))
+        end
+    end
+    return a
+end
+struct DenseAxisArrayView{T,N,D,A} <: AbstractArray{T,N}
+    data::D
+    axes::A
+    function DenseAxisArrayView(
+        x::Containers.DenseAxisArray{T,N},
+        args...,
+    ) where {T,N}
+        axis = tuple([_get_subaxis(a, b) for (a, b) in zip(args, axes(x))]...)
+        return new{T,N,typeof(x),typeof(axis)}(x, axis)
+    end
+end
+
+function Base.view(A::Containers.DenseAxisArray, args...)
+    return DenseAxisArrayView(A, args...)
+end
+
+Base.size(x::DenseAxisArrayView) = length.(x.axes)
+
+Base.axes(x::DenseAxisArrayView) = x.axes
+
+function Base.getindex(x::DenseAxisArrayView, args...)
+    return getindex(x.data, args...)
+end
+
+function Base.setindex!(x::DenseAxisArrayView, args...)
+    return setindex!(x.data, args...)
+end
+
+function Base.eachindex(A::DenseAxisArrayView)
+    return DenseAxisArrayKey.(Base.product(A.axes...))
+end
+
+Base.show(io::IO, x::DenseAxisArrayView) = print(io, x.data)
+
+Base.print_array(io::IO, x::DenseAxisArrayView) = show(io, x)
+
+function Base.summary(io::IO, x::DenseAxisArrayView)
+    return print(io, "view(::DenseAxisArray, ", join(x.axes, ", "), "), over")
+end

--- a/test/Containers/test_DenseAxisArray.jl
+++ b/test/Containers/test_DenseAxisArray.jl
@@ -525,8 +525,7 @@ function test_containers_denseaxisarray_view()
     @test size(B) == (3, 2)
     @test B[1, :a] == A[1, :a]
     @test B[3, :a] == A[3, :a]
-    # Views are weird, because we can still access the underlying array?
-    @test B[3, :c] == A[3, :c]
+    @test_throws KeyError B[3, :c]
     @test sprint(show, B) == sprint(show, B.data)
     @test sprint(Base.print_array, B) == sprint(show, B.data)
     @test sprint(Base.summary, B) ==
@@ -566,6 +565,13 @@ function test_containers_denseaxisarray_view_addition()
     c = Containers.@container([i = 1:4, j = 2:3], i + 2 * j)
     d = view(c, 2:3, :)
     @test_throws MethodError d + d
+    return
+end
+
+function test_containers_denseaxisarray_view_colon()
+    c = Containers.@container([i = 1:4, j = 2:3], i + 2 * j)
+    d = view(c, 2:3, :)
+    @test d[:, 2] == Containers.@container([i = 2:3], i + 2 * 2)
     return
 end
 


### PR DESCRIPTION
Closes #3151
Part of #2998 (still to do SparseAxisArray?)

I'm not overly convinced of this approach. I felt I was just poking methods until things were working. For something like `D[I] .= 1.0`, Base uses a weird dispatch down `dotview` and `maybeview`.

I should add more tests before merging, and consider also SparseAxisArray.

There's also a question: should you be able to access a value that isn't in the view, but is in the underlying array?