### PR TITLE
Add support for Hermitian PSD constraint

### DIFF
--- a/docs/src/manual/complex.md
+++ b/docs/src/manual/complex.md
@@ -259,14 +259,19 @@ macro:
 ```jldoctest
 julia> model = Model();
 
-julia> @variable(model, H[1:2, 1:2], Symmetric)
-2×2 LinearAlgebra.Symmetric{VariableRef, Matrix{VariableRef}}:
- H[1,1]  H[1,2]
- H[1,2]  H[2,2]
+julia> @variable(model, x[1:2])
+2-element Vector{VariableRef}:
+ x[1]
+ x[2]
 
 julia> import LinearAlgebra
 
-julia> @constraint(model, LinearAlgebra.Hermitian(H) in HermitianPSDCone())
-[H[1,1]                (1.0 + 1.0im) H[1,2];
- (1.0 - 1.0im) H[1,2]  H[2,2]] ∈ HermitianPSDCone()
+julia> H = LinearAlgebra.Hermitian([x[1] 1im; -1im -x[2]])
+2×2 LinearAlgebra.Hermitian{GenericAffExpr{ComplexF64, VariableRef}, Matrix{GenericAffExpr{ComplexF64, VariableRef}}}:
+ x[1]           (0.0 + 1.0im)
+ (0.0 - 1.0im)  (-1.0 - 0.0im) x[2]
+
+julia> @constraint(model, H in HermitianPSDCone())
+[x[1]           (0.0 + 1.0im);
+ (0.0 - 1.0im)  (-1.0 + 0.0im) x[2]] ∈ HermitianPSDCone()
 ```

--- a/docs/src/manual/complex.md
+++ b/docs/src/manual/complex.md
@@ -260,7 +260,7 @@ macro:
 julia> model = Model();
 
 julia> @variable(model, H[1:2, 1:2], Symmetric)
-2×2 Symmetric{VariableRef, Matrix{VariableRef}}:
+2×2 LinearAlgebra.Symmetric{VariableRef, Matrix{VariableRef}}:
  H[1,1]  H[1,2]
  H[1,2]  H[2,2]
 

--- a/docs/src/manual/complex.md
+++ b/docs/src/manual/complex.md
@@ -251,3 +251,22 @@ GenericAffExpr{ComplexF64, VariableRef}
 julia> typeof(H[2, 1])
 GenericAffExpr{ComplexF64, VariableRef}
 ```
+
+## Hermitian PSD constraints
+
+The [`HermitianPSDCone`](@ref) can also be used in the [`@constraint`](@ref)
+macro:
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, H[1:2, 1:2], Symmetric)
+2×2 Symmetric{VariableRef, Matrix{VariableRef}}:
+ H[1,1]  H[1,2]
+ H[1,2]  H[2,2]
+
+julia> import LinearAlgebra
+
+julia> @constraint(model, LinearAlgebra.Hermitian(H) in HermitianPSDCone())
+[H[1,1]                (1.0 + 1.0im) H[1,2];
+ (1.0 - 1.0im) H[1,2]  H[2,2]] ∈ HermitianPSDCone()
+```

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -203,7 +203,7 @@ Base.broadcastable(a::GenericAffExpr) = Ref(a)
 
 Base.conj(a::GenericAffExpr{<:Real}) = a
 Base.real(a::GenericAffExpr{<:Real}) = a
-Base.imag(a::GenericAffExpr{<:Real}) = a
+Base.imag(a::GenericAffExpr{<:Real}) = zero(a)
 Base.abs2(a::GenericAffExpr{<:Real}) = a^2
 
 Base.conj(a::GenericAffExpr{<:Complex}) = map_coefficients(conj, a)

--- a/src/print.jl
+++ b/src/print.jl
@@ -684,7 +684,10 @@ in_set_string(::MIME"text/latex", ::MOI.ZeroOne) = "\\in \\{0, 1\\}"
 in_set_string(::MIME"text/plain", ::MOI.Integer) = "integer"
 in_set_string(::MIME"text/latex", ::MOI.Integer) = "\\in \\mathbb{Z}"
 
-function in_set_string(mode, set::Union{PSDCone,HermitianPSDCone,MOI.AbstractSet})
+function in_set_string(
+    mode,
+    set::Union{PSDCone,HermitianPSDCone,MOI.AbstractSet},
+)
     # Use an `if` here instead of multiple dispatch to avoid ambiguity errors.
     if mode == MIME("text/plain")
         return _math_symbol(mode, :in) * " $(set)"

--- a/src/print.jl
+++ b/src/print.jl
@@ -684,7 +684,7 @@ in_set_string(::MIME"text/latex", ::MOI.ZeroOne) = "\\in \\{0, 1\\}"
 in_set_string(::MIME"text/plain", ::MOI.Integer) = "integer"
 in_set_string(::MIME"text/latex", ::MOI.Integer) = "\\in \\mathbb{Z}"
 
-function in_set_string(mode, set::Union{PSDCone,MOI.AbstractSet})
+function in_set_string(mode, set::Union{PSDCone,HermitianPSDCone,MOI.AbstractSet})
     # Use an `if` here instead of multiple dispatch to avoid ambiguity errors.
     if mode == MIME("text/plain")
         return _math_symbol(mode, :in) * " $(set)"

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -417,7 +417,7 @@ end
 
 Hermitian positive semidefinite cone object that can be used to create a
 Hermitian positive semidefinite square matrix in the [`@variable`](@ref)
-macro.
+and [`@constraint`](@ref) macros.
 
 ## Examples
 

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -222,6 +222,10 @@ function reshape_set(::MOI.PositiveSemidefiniteConeSquare, ::SquareMatrixShape)
 end
 vectorize(matrix::Matrix, ::SquareMatrixShape) = vec(matrix)
 
+function vectorize(matrix, shape::Union{SymmetricMatrixShape,SquareMatrixShape})
+    return vectorize(Matrix(matrix), shape)
+end
+
 # This is a special method because calling `Matrix(matrix)` accesses an undef
 # reference.
 function vectorize(matrix::UpperTriangular, ::SquareMatrixShape)
@@ -464,10 +468,7 @@ struct HermitianMatrixShape <: AbstractShape
     side_dimension::Int
 end
 
-function vectorize(
-    matrix,
-    shape::Union{SymmetricMatrixShape,SquareMatrixShape,HermitianMatrixShape},
-)
+function vectorize(matrix, shape::HermitianMatrixShape)
     return vectorize(Matrix(matrix), shape)
 end
 

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -464,7 +464,10 @@ struct HermitianMatrixShape <: AbstractShape
     side_dimension::Int
 end
 
-function vectorize(matrix, shape::Union{SymmetricMatrixShape,SquareMatrixShape,HermitianMatrixShape})
+function vectorize(
+    matrix,
+    shape::Union{SymmetricMatrixShape,SquareMatrixShape,HermitianMatrixShape},
+)
     return vectorize(Matrix(matrix), shape)
 end
 
@@ -547,12 +550,14 @@ function build_variable(
 end
 
 """
-    build_constraint(_error::Function, Q::Hermitian{V, M},
-                     ::HermitianPSDCone) where {V <: AbstractJuMPScalar,
-                                                M <: AbstractMatrix{V}}
+    build_constraint(
+        _error::Function,
+        Q::Hermitian{V,M},
+        ::HermitianPSDCone,
+    ) where {V<:AbstractJuMPScalar,M<:AbstractMatrix{V}}
 
 Return a `VectorConstraint` of shape [`HermitianMatrixShape`](@ref) constraining
-the matrix `Q` to be hermitian positive semidefinite.
+the matrix `Q` to be Hermitian positive semidefinite.
 
 This function is used by the [`@constraint`](@ref) macros as follows:
 ```julia

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1352,8 +1352,10 @@ function _imag(s::String)
 end
 
 _real(v::ScalarVariable) = _mapinfo(real, v)
+_real(scalar::AbstractJuMPScalar) = real(scalar)
 
 _imag(v::ScalarVariable) = _mapinfo(imag, v)
+_imag(scalar::AbstractJuMPScalar) = imag(scalar)
 
 _conj(v::ScalarVariable) = _mapinfo(conj, v)
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -191,7 +191,7 @@ abstract type AbstractVariableRef <: AbstractJuMPScalar end
 variable_ref_type(v::AbstractVariableRef) = typeof(v)
 Base.conj(v::AbstractVariableRef) = v
 Base.real(v::AbstractVariableRef) = v
-Base.imag(v::AbstractVariableRef) = v
+Base.imag(v::AbstractVariableRef) = zero(v)
 Base.abs2(v::AbstractVariableRef) = v^2
 
 """

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -177,11 +177,11 @@ function test_complex_conj()
     @variable(model, x)
     @test conj(x) === x
     @test real(x) === x
-    @test imag(x) === x
+    @test imag(x) == 0
     real_aff = 2 * x + 3
     @test conj(real_aff) === real_aff
     @test real(real_aff) === real_aff
-    @test imag(real_aff) === real_aff
+    @test imag(real_aff) == 0
     complex_aff = (2 + im) * x + 3 - im
     @test conj(complex_aff) == (2 - im) * x + 3 + im
     @test real(complex_aff) == 2x + 3
@@ -241,6 +241,19 @@ function test_complex_sparse_arrays_dropzeros()
         expr.constant = 1.0 + rhs
         @test isequal(SparseArrays.dropzeros(expr), a * x + 1.0)
     end
+    return
+end
+
+function test_complex_hermitian_constraint()
+    model = Model()
+    @variable(model, x[1:2, 1:2])
+    H = LinearAlgebra.Hermitian(x)
+    @test vectorize(H, HermitianMatrixShape(2)) ==
+          [x[1, 1], x[1, 2], x[2, 2], 0.0]
+    @constraint(model, c, H in HermitianPSDCone())
+    @test constraint_object(c).func == [x[1, 1], x[1, 2], x[2, 2], 0.0]
+    @test function_string(MIME("text/plain"), constraint_object(c)) ==
+          "[x[1,1]  x[1,2];\n x[1,2]  x[2,2]]"
     return
 end
 

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -1316,15 +1316,12 @@ function test_HermitianPSDCone_errors(ModelType, VariableRefType)
     model = ModelType()
     @variable(model, x)
     @variable(model, y)
-    var_str = " VariableRef"
-    if VariableRefType != VariableRef
-        var_str = " Main.TestConstraint.JuMPExtension.MyVariableRef"
-    end
+    aff_str = "$(GenericAffExpr{ComplexF64,VariableRefType})"
     err = ErrorException(
         "In `@constraint(model, Hermitian([x 1im; -1im -y]) in HermitianPSDCone(), unknown_kw = 1)`:" *
         " Unrecognized constraint building format. Tried to invoke " *
-        "`build_constraint(error, GenericAffExpr{ComplexF64,$var_str}[" *
-        "x (0.0 + 1.0im); (0.0 - 1.0im) (-1.0 - 0.0im) y], HermitianPSDCone(); unknown_kw = 1)`, but no " *
+        "`build_constraint(error, $aff_str[" *
+        "x (0.0 + 1.0im); (0.0 - 1.0im) (-1.0 - 0.0im) y], $(HermitianPSDCone()); unknown_kw = 1)`, but no " *
         "such method exists. This is due to specifying an unrecognized " *
         "function, constraint set, and/or extra positional/keyword " *
         "arguments.\n\nIf you're trying to create a JuMP extension, you " *

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -1289,6 +1289,61 @@ function test_Model_relax_with_penalty!_specific_with_default(::Any, ::Any)
     return
 end
 
+function test_Hermitian_PSD_constraint(ModelType, VariableRefType)
+    m = ModelType()
+    @variable(m, x)
+    @variable(m, y)
+    @variable(m, w)
+
+    @constraint(m, href, Hermitian([x 1im; -1im -y] - [1 x + w * im; x - w * im -2]) in HermitianPSDCone())
+    _test_constraint_name_util(
+        href,
+        "href",
+        Vector{AffExpr},
+        MOI.HermitianPositiveSemidefiniteConeTriangle,
+    )
+    c = JuMP.constraint_object(href)
+    @test JuMP.isequal_canonical(c.func[1], x - 1)
+    @test JuMP.isequal_canonical(c.func[2], -x)
+    @test JuMP.isequal_canonical(c.func[3], 2 - y)
+    @test JuMP.isequal_canonical(c.func[4], 1 - w)
+    @test c.set == MOI.HermitianPositiveSemidefiniteConeTriangle(2)
+    @test c.shape isa JuMP.HermitianMatrixShape
+
+   return
+end
+
+function test_SDP_errors(ModelType, VariableRefType)
+    model = ModelType()
+    @variable(model, x)
+    @variable(model, y)
+    # Test fallback and account for different Julia version behavior
+    if VariableRefType == VariableRef
+        var_str = " VariableRef"
+    else
+        var_str = " Main.TestConstraint.JuMPExtension.MyVariableRef"
+    end
+    err = ErrorException(
+        "In `@constraint(model, Hermitian([x 1im; -1im -y]) in HermitianPSDCone(), unknown_kw = 1)`:" *
+        " Unrecognized constraint building format. Tried to invoke " *
+        "`build_constraint(error, GenericAffExpr{ComplexF64,$var_str}[" *
+        "x (0.0 + 1.0im); (0.0 + 1.0im) (-1.0 + 0.0im) y], HermitianPSDCone(); unknown_kw = 1)`, but no " *
+        "such method exists. This is due to specifying an unrecognized " *
+        "function, constraint set, and/or extra positional/keyword " *
+        "arguments.\n\nIf you're trying to create a JuMP extension, you " *
+        "need to implement `build_constraint` to accomodate these arguments.",
+    )
+    @test_throws_strip(
+        err,
+        @constraint(
+            model,
+            Hermitian([x 1im; -1im -y]) in HermitianPSDCone(),
+            unknown_kw = 1,
+        ),
+    )
+    return
+end
+
 function runtests()
     for name in names(@__MODULE__; all = true)
         if !startswith("$(name)", "test_")

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -1290,12 +1290,12 @@ function test_Model_relax_with_penalty!_specific_with_default(::Any, ::Any)
 end
 
 function test_Hermitian_PSD_constraint(ModelType, VariableRefType)
-    m = ModelType()
-    @variable(m, x)
-    @variable(m, y)
-    @variable(m, w)
-
-    @constraint(m, href, Hermitian([x 1im; -1im -y] - [1 x + w * im; x - w * im -2]) in HermitianPSDCone())
+    model = ModelType()
+    @variable(model, x)
+    @variable(model, y)
+    @variable(model, w)
+    A = [x 1im; -1im -y] - [1 x + w * im; x - w * im -2]
+    @constraint(model, href, Hermitian(A) in HermitianPSDCone())
     _test_constraint_name_util(
         href,
         "href",
@@ -1309,8 +1309,7 @@ function test_Hermitian_PSD_constraint(ModelType, VariableRefType)
     @test JuMP.isequal_canonical(c.func[4], 1 - w)
     @test c.set == MOI.HermitianPositiveSemidefiniteConeTriangle(2)
     @test c.shape isa JuMP.HermitianMatrixShape
-
-   return
+    return
 end
 
 function test_SDP_errors(ModelType, VariableRefType)

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -1294,7 +1294,7 @@ function test_Hermitian_PSD_constraint(ModelType, VariableRefType)
     @variable(model, x)
     @variable(model, y)
     @variable(model, w)
-    A = [x 1im; -1im -y] - [1 x + w * im; x - w * im -2]
+    A = [x 1im; -1im -y] - [1 (x+w*im); (x-w*im) -2]
     @constraint(model, href, Hermitian(A) in HermitianPSDCone())
     _test_constraint_name_util(
         href,

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -1312,21 +1312,19 @@ function test_Hermitian_PSD_constraint(ModelType, VariableRefType)
     return
 end
 
-function test_SDP_errors(ModelType, VariableRefType)
+function test_HermitianPSDCone_errors(ModelType, VariableRefType)
     model = ModelType()
     @variable(model, x)
     @variable(model, y)
-    # Test fallback and account for different Julia version behavior
-    if VariableRefType == VariableRef
-        var_str = " VariableRef"
-    else
+    var_str = " VariableRef"
+    if VariableRefType != VariableRef
         var_str = " Main.TestConstraint.JuMPExtension.MyVariableRef"
     end
     err = ErrorException(
         "In `@constraint(model, Hermitian([x 1im; -1im -y]) in HermitianPSDCone(), unknown_kw = 1)`:" *
         " Unrecognized constraint building format. Tried to invoke " *
         "`build_constraint(error, GenericAffExpr{ComplexF64,$var_str}[" *
-        "x (0.0 + 1.0im); (0.0 + 1.0im) (-1.0 + 0.0im) y], HermitianPSDCone(); unknown_kw = 1)`, but no " *
+        "x (0.0 + 1.0im); (0.0 - 1.0im) (-1.0 - 0.0im) y], HermitianPSDCone(); unknown_kw = 1)`, but no " *
         "such method exists. This is due to specifying an unrecognized " *
         "function, constraint set, and/or extra positional/keyword " *
         "arguments.\n\nIf you're trying to create a JuMP extension, you " *

--- a/test/print.jl
+++ b/test/print.jl
@@ -977,7 +977,8 @@ function test_print_hermitian_psd_cone()
     model = Model()
     @variable(model, x[1:2])
     in_sym = JuMP._math_symbol(MIME("text/plain"), :in)
-    c = @constraint(model, Hermitian([x[1] 1im; -1im x[2]]) in HermitianPSDCone())
+    H = Hermitian([x[1] 1im; -1im x[2]])
+    c = @constraint(model, H in HermitianPSDCone())
     @test sprint(io -> show(io, MIME("text/plain"), c)) ==
           "[x[1]           (0.0 + 1.0im);\n (0.0 - 1.0im)  x[2]] $in_sym $(HermitianPSDCone())"
     @test sprint(io -> show(io, MIME("text/latex"), c)) ==

--- a/test/print.jl
+++ b/test/print.jl
@@ -973,6 +973,17 @@ function test_minus_one_complex_aff_expr()
     return
 end
 
+function test_print_hermitian_psd_cone()
+    model = Model()
+    @variable(model, x[1:2, 1:2])
+    c = @constraint(model, Hermitian(x) in HermitianPSDCone())
+    @test sprint(io -> show(io, MIME("text/plain"), c)) ==
+          "[x[1,1]                (1.0 + 1.0im) x[1,2];\n (1.0 - 1.0im) x[1,2]  x[2,2]] ∈ HermitianPSDCone()"
+    @test sprint(io -> show(io, MIME("text/latex"), c)) ==
+          "\$\$ \\begin{bmatrix}\nx_{1,1} & (1.0 + 1.0im) x_{1,2}\\\\\n(1.0 - 1.0im) x_{1,2} & x_{2,2}\\\\\n\\end{bmatrix} \\in \\text{HermitianPSDCone()} \$\$"
+    return
+end
+
 end
 
 TestPrint.runtests()

--- a/test/print.jl
+++ b/test/print.jl
@@ -975,13 +975,13 @@ end
 
 function test_print_hermitian_psd_cone()
     model = Model()
-    @variable(model, x[1:2, 1:2])
+    @variable(model, x[1:2])
     in_sym = JuMP._math_symbol(MIME("text/plain"), :in)
-    c = @constraint(model, Hermitian(x) in HermitianPSDCone())
+    c = @constraint(model, Hermitian([x[1] 1im; -1im x[2]]) in HermitianPSDCone())
     @test sprint(io -> show(io, MIME("text/plain"), c)) ==
-          "[x[1,1]                (1.0 + 1.0im) x[1,2];\n (1.0 - 1.0im) x[1,2]  x[2,2]] $in_sym HermitianPSDCone()"
+          "[x[1]           (0.0 + 1.0im);\n (0.0 - 1.0im)  x[2]] $in_sym $(HermitianPSDCone())"
     @test sprint(io -> show(io, MIME("text/latex"), c)) ==
-          "\$\$ \\begin{bmatrix}\nx_{1,1} & (1.0 + 1.0im) x_{1,2}\\\\\n(1.0 - 1.0im) x_{1,2} & x_{2,2}\\\\\n\\end{bmatrix} \\in \\text{HermitianPSDCone()} \$\$"
+          "\$\$ \\begin{bmatrix}\nx_{1} & (0.0 + 1.0im)\\\\\n(0.0 - 1.0im) & x_{2}\\\\\n\\end{bmatrix} \\in \\text{$(HermitianPSDCone())} \$\$"
     return
 end
 

--- a/test/print.jl
+++ b/test/print.jl
@@ -976,9 +976,10 @@ end
 function test_print_hermitian_psd_cone()
     model = Model()
     @variable(model, x[1:2, 1:2])
+    in_sym = JuMP._math_symbol(MIME("text/plain"), :in)
     c = @constraint(model, Hermitian(x) in HermitianPSDCone())
     @test sprint(io -> show(io, MIME("text/plain"), c)) ==
-          "[x[1,1]                (1.0 + 1.0im) x[1,2];\n (1.0 - 1.0im) x[1,2]  x[2,2]] ∈ HermitianPSDCone()"
+          "[x[1,1]                (1.0 + 1.0im) x[1,2];\n (1.0 - 1.0im) x[1,2]  x[2,2]] $in_sym HermitianPSDCone()"
     @test sprint(io -> show(io, MIME("text/latex"), c)) ==
           "\$\$ \\begin{bmatrix}\nx_{1,1} & (1.0 + 1.0im) x_{1,2}\\\\\n(1.0 - 1.0im) x_{1,2} & x_{2,2}\\\\\n\\end{bmatrix} \\in \\text{HermitianPSDCone()} \$\$"
     return


### PR DESCRIPTION
Add support for the following
```julia
@constraint(model, Hermitian(...) in HermitianPSDCone())
```

- [x] Add tests with printing
- [x] Add it in the docstring of `HermitianPSDCone`

Closes https://github.com/jump-dev/JuMP.jl/issues/3153