### PR TITLE
Add has_start_value function

### DIFF
--- a/docs/src/reference/variables.md
+++ b/docs/src/reference/variables.md
@@ -38,6 +38,7 @@ variable_by_name
 ## Start values
 
 ```@docs
+has_start_value
 set_start_value
 start_value
 ```

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1001,6 +1001,17 @@ function start_value(v::VariableRef)::Union{Nothing,Float64}
 end
 
 """
+    has_start_value(variable::VariableRef)
+
+Return `true` if the variable has a start value set otherwise return `false`.
+
+See also [`set_start_value`](@ref).
+"""
+function has_start_value(v::VariableRef)::
+    return MOI.get(owner_model(v), MOI.VariablePrimalStart(), v) !== nothing
+end
+
+"""
     set_start_value(variable::VariableRef, value::Union{Real,Nothing})
 
 Set the start value (MOI attribute `VariablePrimalStart`) of the `variable` to

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1009,7 +1009,6 @@ See also [`set_start_value`](@ref).
 """
 has_start_value(v::VariableRef)::Bool = start_value(v) !== nothing
     return MOI.get(owner_model(v), MOI.VariablePrimalStart(), v) !== nothing
-end
 
 """
     set_start_value(variable::VariableRef, value::Union{Real,Nothing})

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1001,13 +1001,13 @@ function start_value(v::VariableRef)::Union{Nothing,Float64}
 end
 
 """
-    has_start_value(variable::VariableRef)
+    has_start_value(variable::AbstractVariableRef)
 
 Return `true` if the variable has a start value set otherwise return `false`.
 
 See also [`set_start_value`](@ref).
 """
-has_start_value(v::VariableRef)::Bool = start_value(v) !== nothing
+has_start_value(v::AbstractVariableRef)::Bool = start_value(v) !== nothing
 
 """
     set_start_value(variable::VariableRef, value::Union{Real,Nothing})

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1008,7 +1008,6 @@ Return `true` if the variable has a start value set otherwise return `false`.
 See also [`set_start_value`](@ref).
 """
 has_start_value(v::VariableRef)::Bool = start_value(v) !== nothing
-    return MOI.get(owner_model(v), MOI.VariablePrimalStart(), v) !== nothing
 
 """
     set_start_value(variable::VariableRef, value::Union{Real,Nothing})

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1007,7 +1007,7 @@ Return `true` if the variable has a start value set otherwise return `false`.
 
 See also [`set_start_value`](@ref).
 """
-function has_start_value(v::VariableRef)::
+has_start_value(v::VariableRef)::Bool = start_value(v) !== nothing
     return MOI.get(owner_model(v), MOI.VariablePrimalStart(), v) !== nothing
 end
 

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -247,7 +247,8 @@ function JuMP.unfix(vref::MyVariableRef)
     )
 end
 function JuMP.start_value(vref::MyVariableRef)::Union{Nothing,Float64}
-    return variable_info(vref).start
+    info = variable_info(vref)
+    return info.has_start ? info.start : nothing
 end
 function JuMP.set_start_value(vref::MyVariableRef, start)
     info = variable_info(vref)

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -220,8 +220,9 @@ function test_variable_starts_set_get(ModelType, ::Any)
     JuMP.set_start_value.(x, x0)
     @test JuMP.start_value.(x) == x0
     @test JuMP.start_value.([x[1], x[2], x[3]]) == x0
-
+    @test JuMP.has_start_value(x[1]) == true
     @variable(model, y[1:3, 1:2])
+    @test JuMP.has_start_value(y[1,1]) == false
     @test_throws DimensionMismatch JuMP.set_start_value.(y, collect(1:6))
 end
 

--- a/test/variable.jl
+++ b/test/variable.jl
@@ -222,7 +222,7 @@ function test_variable_starts_set_get(ModelType, ::Any)
     @test JuMP.start_value.([x[1], x[2], x[3]]) == x0
     @test JuMP.has_start_value(x[1]) == true
     @variable(model, y[1:3, 1:2])
-    @test JuMP.has_start_value(y[1,1]) == false
+    @test JuMP.has_start_value(y[1, 1]) == false
     @test_throws DimensionMismatch JuMP.set_start_value.(y, collect(1:6))
 end
 


### PR DESCRIPTION
helper to avoid calling having to call `start_value(x) == nothing` when checking for start values. 