### PR TITLE
[docs] clarify that PSD ensures a symmetric matrix

### DIFF
--- a/docs/src/manual/variables.md
+++ b/docs/src/manual/variables.md
@@ -944,11 +944,9 @@ model[:x]
 
 ## Semidefinite variables
 
-A square symmetric matrix ``X`` is positive semidefinite if all eigenvalues are
-nonnegative.
+Declare a square matrix of JuMP variables to be positive semidefinite by passing
+`PSD` as an optional positional argument:
 
-Declare a matrix of JuMP variables to be positive semidefinite by passing `PSD`
-as an optional positional argument:
 ```jldoctest; setup=:(model=Model())
 julia> @variable(model, x[1:2, 1:2], PSD)
 2×2 LinearAlgebra.Symmetric{VariableRef, Matrix{VariableRef}}:
@@ -956,14 +954,19 @@ julia> @variable(model, x[1:2, 1:2], PSD)
  x[1,2]  x[2,2]
 ```
 
+This will ensure that `x` is symmetric, and that all of its eigenvalues are
+nonnegative.
+
 !!! note
     `x` must be a square 2-dimensional `Array` of JuMP variables; it cannot be a
     DenseAxisArray or a SparseAxisArray.
 
 ## Symmetric variables
 
-Declare a square matrix of JuMP variables to be symmetric by passing
-`Symmetric`  as an optional positional argument:
+Declare a square matrix of JuMP variables to be symmetric (but not necessarily
+positive semidefinite) by passing `Symmetric`  as an optional positional
+argument:
+
 ```jldoctest; setup=:(model=Model())
 julia> @variable(model, x[1:2, 1:2], Symmetric)
 2×2 LinearAlgebra.Symmetric{VariableRef, Matrix{VariableRef}}:


### PR DESCRIPTION
Pointed out on discourse that our docs were slightly confusing: https://discourse.julialang.org/t/how-to-get-non-trivial-solution-with-sdp-in-scs/91896/9?u=odow