### PR TITLE
Refactor tests which use JuMPExtension.jl

### DIFF
--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -1419,20 +1419,20 @@ function test_extension_Hermitian_PSD_constraint(
     @variable(model, y)
     @variable(model, w)
     A = [x 1im; -1im -y] - [1 (x+w*im); (x-w*im) -2]
-    @constraint(model, href, Hermitian(A) in HermitianPSDCone())
+    @constraint(model, href, LinearAlgebra.Hermitian(A) in HermitianPSDCone())
     _test_constraint_name_util(
         href,
         "href",
         Vector{GenericAffExpr{ComplexF64,VariableRefType}},
         MOI.HermitianPositiveSemidefiniteConeTriangle,
     )
-    c = JuMP.constraint_object(href)
-    @test JuMP.isequal_canonical(c.func[1], x - 1)
-    @test JuMP.isequal_canonical(c.func[2], -x)
-    @test JuMP.isequal_canonical(c.func[3], 2 - y)
-    @test JuMP.isequal_canonical(c.func[4], 1 - w)
+    c = constraint_object(href)
+    @test isequal_canonical(c.func[1], x - 1)
+    @test isequal_canonical(c.func[2], -x)
+    @test isequal_canonical(c.func[3], 2 - y)
+    @test isequal_canonical(c.func[4], 1 - w)
     @test c.set == MOI.HermitianPositiveSemidefiniteConeTriangle(2)
-    @test c.shape isa JuMP.HermitianMatrixShape
+    @test c.shape isa HermitianMatrixShape
     return
 end
 

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -11,96 +11,125 @@
 module TestConstraint
 
 using JuMP
-using LinearAlgebra
 using Test
+
+import LinearAlgebra
 
 include(joinpath(@__DIR__, "utilities.jl"))
 include(joinpath(@__DIR__, "JuMPExtension.jl"))
 
-function _test_constraint_name_util(constraint, name, F::Type, S::Type)
-    @test name == @inferred JuMP.name(constraint)
-    model = constraint.model
-    @test constraint.index == JuMP.constraint_by_name(model, name).index
-    if !(model isa JuMPExtension.MyModel)
-        @test constraint.index ==
-              JuMP.constraint_by_name(model, name, F, S).index
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if startswith("$(name)", "test_")
+            @testset "$(name)" begin
+                getfield(@__MODULE__, name)()
+            end
+        end
+        if startswith("$(name)", "test_extension_")
+            @testset "$(name)-JuMPExtension" begin
+                getfield(@__MODULE__, name)(
+                    JuMPExtension.MyModel,
+                    JuMPExtension.MyVariableRef,
+                )
+            end
+        end
     end
+    return
 end
 
-function test_VariableIndex_constraints(ModelType, ::Any)
+function _test_constraint_name_util(constraint, s_name, F::Type, S::Type)
+    @test s_name == @inferred name(constraint)
+    model = constraint.model
+    @test constraint.index == constraint_by_name(model, s_name).index
+    if !(model isa JuMPExtension.MyModel)
+        @test constraint.index == constraint_by_name(model, s_name, F, S).index
+    end
+    return
+end
+
+function test_extension_VariableIndex_constraints(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     m = ModelType()
     @variable(m, x)
-
     # x <= 10.0 doesn't translate to a SingleVariable constraint because
     # the LHS is first subtracted to form x - 10.0 <= 0.
     @constraint(m, cref, x in MOI.LessThan(10.0))
-    c = JuMP.constraint_object(cref)
+    c = constraint_object(cref)
     @test c.func == x
     @test c.set == MOI.LessThan(10.0)
-
     @variable(m, y[1:2])
     @constraint(m, cref2[i = 1:2], y[i] in MOI.LessThan(float(i)))
-    c = JuMP.constraint_object(cref2[1])
+    c = constraint_object(cref2[1])
     @test c.func == y[1]
     @test c.set == MOI.LessThan(1.0)
+    return
 end
 
-function test_Container_constraints(ModelType, ::Any)
+function test_extension_Container_constraints(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     m = ModelType()
     S = ["a", "b"]
     @variable(m, x[S], Bin)
     cref = @constraint(m, x in SOS2())
-    c = JuMP.constraint_object(cref)
+    c = constraint_object(cref)
     @test c.func == [x["a"], x["b"]]
+    return
 end
 
-function test_VectorOfVariables_constraints(ModelType, ::Any)
+function test_extension_VectorOfVariables_constraints(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     m = ModelType()
     @variable(m, x[1:2])
-
     cref = @constraint(m, x in MOI.Zeros(2))
-    c = JuMP.constraint_object(cref)
+    c = constraint_object(cref)
     @test c.func == x
     @test c.set == MOI.Zeros(2)
-
     cref = @constraint(m, [x[2], x[1]] in MOI.Zeros(2))
-    c = JuMP.constraint_object(cref)
+    c = constraint_object(cref)
     @test c.func == [x[2], x[1]]
     @test c.set == MOI.Zeros(2)
-
     @test_throws DimensionMismatch @constraint(m, [x[2], x[1]] in MOI.Zeros(3))
+    return
 end
 
-function test_AffExpr_scalar_constraints(ModelType, ::Any)
+function test_extension_AffExpr_scalar_constraints(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     model = ModelType()
     @variable(model, x)
-
     cref = @constraint(model, 2x <= 10)
-    @test "" == @inferred JuMP.name(cref)
-    JuMP.set_name(cref, "c")
-    _test_constraint_name_util(cref, "c", JuMP.AffExpr, MOI.LessThan{Float64})
-
-    c = JuMP.constraint_object(cref)
-    @test JuMP.isequal_canonical(c.func, 2x)
+    @test "" == @inferred name(cref)
+    set_name(cref, "c")
+    _test_constraint_name_util(cref, "c", AffExpr, MOI.LessThan{Float64})
+    c = constraint_object(cref)
+    @test isequal_canonical(c.func, 2x)
     @test c.set == MOI.LessThan(10.0)
-
     cref = @constraint(model, 3x + 1 ≥ 10)
-    c = JuMP.constraint_object(cref)
-    @test JuMP.isequal_canonical(c.func, 3x)
+    c = constraint_object(cref)
+    @test isequal_canonical(c.func, 3x)
     @test c.set == MOI.GreaterThan(9.0)
-
     cref = @constraint(model, 1 == -x)
-    c = JuMP.constraint_object(cref)
-    @test JuMP.isequal_canonical(c.func, 1.0x)
+    c = constraint_object(cref)
+    @test isequal_canonical(c.func, 1.0x)
     @test c.set == MOI.EqualTo(-1.0)
-
     cref = @constraint(model, 2 == 1)
-    c = JuMP.constraint_object(cref)
-    @test JuMP.isequal_canonical(c.func, zero(JuMP.AffExpr))
+    c = constraint_object(cref)
+    @test isequal_canonical(c.func, zero(AffExpr))
     @test c.set == MOI.EqualTo(-1.0)
+    return
 end
 
-function test_AffExpr_vectorized_constraints(ModelType, ::Any)
+function test_extension_AffExpr_vectorized_constraints(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     model = ModelType()
     @variable(model, x)
     err = ErrorException(
@@ -111,14 +140,18 @@ function test_AffExpr_vectorized_constraints(ModelType, ::Any)
         @constraint(model, [x == 1 - x, 2x == 3])
     end
     cref = @constraint(model, [x, 2x] .== [1 - x, 3])
-    c = JuMP.constraint_object.(cref)
-    @test JuMP.isequal_canonical(c[1].func, 2.0x)
+    c = constraint_object.(cref)
+    @test isequal_canonical(c[1].func, 2.0x)
     @test c[1].set == MOI.EqualTo(1.0)
-    @test JuMP.isequal_canonical(c[2].func, 2.0x)
+    @test isequal_canonical(c[2].func, 2.0x)
     @test c[2].set == MOI.EqualTo(3.0)
+    return
 end
 
-function test_AffExpr_vectorized_interval_constraints(ModelType, ::Any)
+function test_extension_AffExpr_vectorized_interval_constraints(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     model = ModelType()
     @variable(model, x[1:2])
     err = ErrorException(
@@ -129,134 +162,149 @@ function test_AffExpr_vectorized_interval_constraints(ModelType, ::Any)
     b = [5.0, 6.0]
     @test_throws_strip err @constraint(model, b <= x <= b)
     cref = @constraint(model, b .<= x .<= b)
-    c = JuMP.constraint_object.(cref)
+    c = constraint_object.(cref)
     for i in 1:2
-        @test JuMP.isequal_canonical(c[i].func, 1.0 * x[i])
+        @test isequal_canonical(c[i].func, 1.0 * x[i])
         @test c[i].set == MOI.Interval(b[i], b[i])
     end
     return
 end
 
-function test_AffExpr_vector_constraints(ModelType, ::Any)
+function test_extension_AffExpr_vector_constraints(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     model = ModelType()
     cref = @constraint(model, [1, 2] in MOI.Zeros(2))
-    c = JuMP.constraint_object(cref)
-    @test JuMP.isequal_canonical(c.func[1], zero(JuMP.AffExpr) + 1)
-    @test JuMP.isequal_canonical(c.func[2], zero(JuMP.AffExpr) + 2)
+    c = constraint_object(cref)
+    @test isequal_canonical(c.func[1], zero(AffExpr) + 1)
+    @test isequal_canonical(c.func[2], zero(AffExpr) + 2)
     @test c.set == MOI.Zeros(2)
-    @test c.shape isa JuMP.VectorShape
+    @test c.shape isa VectorShape
     @test_throws DimensionMismatch @constraint(model, [1, 2] in MOI.Zeros(3))
+    return
 end
 
-function test_delete_constraints(ModelType, ::Any)
+function test_extension_delete_constraints(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     model = ModelType()
     @variable(model, x)
     constraint_ref = @constraint(model, 2x <= 1)
-    @test JuMP.is_valid(model, constraint_ref)
-    JuMP.delete(model, constraint_ref)
-    @test !JuMP.is_valid(model, constraint_ref)
+    @test is_valid(model, constraint_ref)
+    delete(model, constraint_ref)
+    @test !is_valid(model, constraint_ref)
     second_model = ModelType()
-    @test_throws Exception JuMP.delete(second_model, constraint_ref)
+    @test_throws Exception delete(second_model, constraint_ref)
+    return
 end
 
-function test_batch_delete_constraints(ModelType, ::Any)
+function test_extension_batch_delete_constraints(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     model = ModelType()
     @variable(model, x[1:9])
     cons = [@constraint(model, sum(x[1:2:9]) <= 3)]
     push!(cons, @constraint(model, sum(x[2:2:8]) <= 2))
     push!(cons, @constraint(model, sum(x[1:3:9]) <= 1))
-    @test all(JuMP.is_valid.(model, cons))
-    JuMP.delete(model, cons[[1, 3]])
-    @test all((!JuMP.is_valid).(model, cons[[1, 3]]))
-    @test JuMP.is_valid(model, cons[2])
+    @test all(is_valid.(model, cons))
+    delete(model, cons[[1, 3]])
+    @test all((!is_valid).(model, cons[[1, 3]]))
+    @test is_valid(model, cons[2])
     second_model = ModelType()
-    @test_throws Exception JuMP.delete(second_model, cons[[1, 3]])
-    @test_throws Exception JuMP.delete(second_model, [cons[2]])
+    @test_throws Exception delete(second_model, cons[[1, 3]])
+    @test_throws Exception delete(second_model, [cons[2]])
+    return
 end
 
-function test_two_sided_constraints(ModelType, ::Any)
+function test_extension_two_sided_constraints(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     m = ModelType()
     @variable(m, x)
     @variable(m, y)
-
     @constraint(m, cref, 1.0 <= x + y + 1.0 <= 2.0)
-    _test_constraint_name_util(
-        cref,
-        "cref",
-        JuMP.AffExpr,
-        MOI.Interval{Float64},
-    )
-
-    c = JuMP.constraint_object(cref)
-    @test JuMP.isequal_canonical(c.func, x + y)
+    _test_constraint_name_util(cref, "cref", AffExpr, MOI.Interval{Float64})
+    c = constraint_object(cref)
+    @test isequal_canonical(c.func, x + y)
     @test c.set == MOI.Interval(0.0, 1.0)
-
     cref = @constraint(m, 2x - y + 2.0 ∈ MOI.Interval(-1.0, 1.0))
-    @test "" == @inferred JuMP.name(cref)
-
-    c = JuMP.constraint_object(cref)
-    @test JuMP.isequal_canonical(c.func, 2x - y)
+    @test "" == @inferred name(cref)
+    c = constraint_object(cref)
+    @test isequal_canonical(c.func, 2x - y)
     @test c.set == MOI.Interval(-3.0, -1.0)
+    return
 end
 
-function test_broadcasted_constraint_eq(ModelType, ::Any)
+function test_extension_broadcasted_constraint_eq(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     m = ModelType()
     @variable(m, x[1:2])
-
     A = [1.0 2.0; 3.0 4.0]
     b = [4.0, 5.0]
-
     cref = @constraint(m, A * x .== b)
     @test (2,) == @inferred size(cref)
-
-    c1 = JuMP.constraint_object(cref[1])
-    @test JuMP.isequal_canonical(c1.func, x[1] + 2x[2])
+    c1 = constraint_object(cref[1])
+    @test isequal_canonical(c1.func, x[1] + 2x[2])
     @test c1.set == MOI.EqualTo(4.0)
-    c2 = JuMP.constraint_object(cref[2])
-    @test JuMP.isequal_canonical(c2.func, 3x[1] + 4x[2])
+    c2 = constraint_object(cref[2])
+    @test isequal_canonical(c2.func, 3x[1] + 4x[2])
     @test c2.set == MOI.EqualTo(5.0)
+    return
 end
 
-function test_broadcasted_constraint_leq(ModelType, ::Any)
+function test_extension_broadcasted_constraint_leq(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     m = ModelType()
     @variable(m, x[1:2, 1:2])
-
     UB = [1.0 2.0; 3.0 4.0]
-
     cref = @constraint(m, x .+ 1 .<= UB)
     @test (2, 2) == @inferred size(cref)
     for i in 1:2
         for j in 1:2
-            c = JuMP.constraint_object(cref[i, j])
-            @test JuMP.isequal_canonical(c.func, x[i, j] + 0)
+            c = constraint_object(cref[i, j])
+            @test isequal_canonical(c.func, x[i, j] + 0)
             @test c.set == MOI.LessThan(UB[i, j] - 1)
         end
     end
+    return
 end
 
-function test_broadcasted_two_sided_constraint(ModelType, ::Any)
+function test_extension_broadcasted_two_sided_constraint(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     m = ModelType()
     @variable(m, x[1:2])
     @variable(m, y[1:2])
     l = [1.0, 2.0]
     u = [3.0, 4.0]
-
     cref = @constraint(m, l .<= x + y .+ 1 .<= u)
     @test (2,) == @inferred size(cref)
-
     for i in 1:2
-        c = JuMP.constraint_object(cref[i])
-        @test JuMP.isequal_canonical(c.func, x[i] + y[i])
+        c = constraint_object(cref[i])
+        @test isequal_canonical(c.func, x[i] + y[i])
         @test c.set == MOI.Interval(l[i] - 1, u[i] - 1)
     end
+    return
 end
 
-function test_broadcasted_constraint_with_indices(ModelType, ::Any)
+function test_extension_broadcasted_constraint_with_indices(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     m = ModelType()
     @variable m x[1:2]
     @constraint m cref1[i = 2:4] x .== [i, i + 1]
     ConstraintRefType = eltype(cref1[2])
-    @test cref1 isa JuMP.Containers.DenseAxisArray{Vector{ConstraintRefType}}
+    @test cref1 isa Containers.DenseAxisArray{Vector{ConstraintRefType}}
     @constraint m cref2[i = 1:3, j = 1:4] x .≤ [i + j, i - j]
     ConstraintRefType = eltype(cref2[1])
     @test cref2 isa Matrix{Vector{ConstraintRefType}}
@@ -264,34 +312,42 @@ function test_broadcasted_constraint_with_indices(ModelType, ::Any)
     @constraint m cref3[i = 1:2] y[i, :] .== 1
     ConstraintRefType = eltype(cref3[1])
     @test cref3 isa Vector{Vector{ConstraintRefType}}
+    return
 end
 
-function test_quadexpr_constraints(ModelType, ::Any)
+function test_extension_quadexpr_constraints(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     model = ModelType()
     @variable(model, x)
     @variable(model, y)
 
     cref = @constraint(model, x^2 + x <= 1)
-    c = JuMP.constraint_object(cref)
-    @test JuMP.isequal_canonical(c.func, x^2 + x)
+    c = constraint_object(cref)
+    @test isequal_canonical(c.func, x^2 + x)
     @test c.set == MOI.LessThan(1.0)
 
     cref = @constraint(model, y * x - 1.0 == 0.0)
-    c = JuMP.constraint_object(cref)
-    @test JuMP.isequal_canonical(c.func, x * y)
+    c = constraint_object(cref)
+    @test isequal_canonical(c.func, x * y)
     @test c.set == MOI.EqualTo(1.0)
 
     cref = @constraint(
         model,
         [2x - 4x * y + 3x^2 - 1, -3y + 2x * y - 2x^2 + 1] in SecondOrderCone()
     )
-    c = JuMP.constraint_object(cref)
-    @test JuMP.isequal_canonical(c.func[1], -1 + 3x^2 - 4x * y + 2x)
-    @test JuMP.isequal_canonical(c.func[2], 1 - 2x^2 + 2x * y - 3y)
+    c = constraint_object(cref)
+    @test isequal_canonical(c.func[1], -1 + 3x^2 - 4x * y + 2x)
+    @test isequal_canonical(c.func[2], 1 - 2x^2 + 2x * y - 3y)
     @test c.set == MOI.SecondOrderCone(2)
+    return
 end
 
-function test_syntax_error_constraint(ModelType, ::Any)
+function test_extension_syntax_error_constraint(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     model = ModelType()
     @variable(model, x[1:2])
     err = ErrorException(
@@ -300,9 +356,13 @@ function test_syntax_error_constraint(ModelType, ::Any)
         "valid JuMP function.",
     )
     @test_throws_strip err @constraint(model, [3, x] in SecondOrderCone())
+    return
 end
 
-function test_indicator_constraint(ModelType, ::Any)
+function test_extension_indicator_constraint(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     model = ModelType()
     @variable(model, a, Bin)
     @variable(model, b, Bin)
@@ -312,7 +372,7 @@ function test_indicator_constraint(ModelType, ::Any)
         @constraint(model, a => {x + 2y <= 1}),
         @constraint(model, a ⇒ {x + 2y ≤ 1})
     ]
-        c = JuMP.constraint_object(cref)
+        c = constraint_object(cref)
         @test c.func == [a, x + 2y]
         @test c.set == MOI.Indicator{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(1.0))
     end
@@ -322,7 +382,7 @@ function test_indicator_constraint(ModelType, ::Any)
         # This returns a vector of constraints that is concatenated.
         @constraint(model, ![b, b] .=> {[2x + y, 2x + y] .≤ 1})
     ]
-        c = JuMP.constraint_object(cref)
+        c = constraint_object(cref)
         @test c.func == [b, 2x + y]
         @test c.set == MOI.Indicator{MOI.ACTIVATE_ON_ZERO}(MOI.LessThan(1.0))
     end
@@ -346,9 +406,13 @@ function test_indicator_constraint(ModelType, ::Any)
         "In `@constraint(model, [a, b] .=> {x + y <= 1})`: Inconsistent use of `.` in symbols to indicate vectorization.",
     )
     @test_macro_throws err @constraint(model, [a, b] .=> {x + y <= 1})
+    return
 end
 
-function test_SDP_constraint(ModelType, VariableRefType)
+function test_extension_SDP_constraint(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     m = ModelType()
     @variable(m, x)
     @variable(m, y)
@@ -356,24 +420,28 @@ function test_SDP_constraint(ModelType, VariableRefType)
     @variable(m, w)
 
     cref = @constraint(m, [x y; z w] in PSDCone())
-    c = JuMP.constraint_object(cref)
+    c = constraint_object(cref)
     @test c.func == [x, z, y, w]
     @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
-    @test c.shape isa JuMP.SquareMatrixShape
+    @test c.shape isa SquareMatrixShape
 
-    @constraint(m, sym_ref, Symmetric([x 1; 1 -y] - [1 x; x -2]) in PSDCone())
+    @constraint(
+        m,
+        sym_ref,
+        LinearAlgebra.Symmetric([x 1; 1 -y] - [1 x; x -2]) in PSDCone()
+    )
     _test_constraint_name_util(
         sym_ref,
         "sym_ref",
         Vector{AffExpr},
         MOI.PositiveSemidefiniteConeTriangle,
     )
-    c = JuMP.constraint_object(sym_ref)
-    @test JuMP.isequal_canonical(c.func[1], x - 1)
-    @test JuMP.isequal_canonical(c.func[2], 1 - x)
-    @test JuMP.isequal_canonical(c.func[3], 2 - y)
+    c = constraint_object(sym_ref)
+    @test isequal_canonical(c.func[1], x - 1)
+    @test isequal_canonical(c.func[2], 1 - x)
+    @test isequal_canonical(c.func[3], 2 - y)
     @test c.set == MOI.PositiveSemidefiniteConeTriangle(2)
-    @test c.shape isa JuMP.SymmetricMatrixShape
+    @test c.shape isa SymmetricMatrixShape
 
     @constraint(m, cref, [x 1; 1 -y] >= [1 x; x -2], PSDCone())
     _test_constraint_name_util(
@@ -382,13 +450,13 @@ function test_SDP_constraint(ModelType, VariableRefType)
         Vector{AffExpr},
         MOI.PositiveSemidefiniteConeSquare,
     )
-    c = JuMP.constraint_object(cref)
-    @test JuMP.isequal_canonical(c.func[1], x - 1)
-    @test JuMP.isequal_canonical(c.func[2], 1 - x)
-    @test JuMP.isequal_canonical(c.func[3], 1 - x)
-    @test JuMP.isequal_canonical(c.func[4], 2 - y)
+    c = constraint_object(cref)
+    @test isequal_canonical(c.func[1], x - 1)
+    @test isequal_canonical(c.func[2], 1 - x)
+    @test isequal_canonical(c.func[3], 1 - x)
+    @test isequal_canonical(c.func[4], 2 - y)
     @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
-    @test c.shape isa JuMP.SquareMatrixShape
+    @test c.shape isa SquareMatrixShape
 
     @constraint(m, iref[i = 1:2], 0 <= [x+i x+y; x+y -y], PSDCone())
     for i in 1:2
@@ -398,75 +466,99 @@ function test_SDP_constraint(ModelType, VariableRefType)
             Vector{AffExpr},
             MOI.PositiveSemidefiniteConeSquare,
         )
-        c = JuMP.constraint_object(iref[i])
-        @test JuMP.isequal_canonical(c.func[1], x + i)
-        @test JuMP.isequal_canonical(c.func[2], x + y)
-        @test JuMP.isequal_canonical(c.func[3], x + y)
-        @test JuMP.isequal_canonical(c.func[4], -y)
+        c = constraint_object(iref[i])
+        @test isequal_canonical(c.func[1], x + i)
+        @test isequal_canonical(c.func[2], x + y)
+        @test isequal_canonical(c.func[3], x + y)
+        @test isequal_canonical(c.func[4], -y)
         @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
-        @test c.shape isa JuMP.SquareMatrixShape
+        @test c.shape isa SquareMatrixShape
     end
 
-    @constraint(m, con_d, 0 <= Diagonal([x, y]), PSDCone())
-    c = JuMP.constraint_object(con_d)
+    @constraint(m, con_d, 0 <= LinearAlgebra.Diagonal([x, y]), PSDCone())
+    c = constraint_object(con_d)
     @test c.func isa Vector{GenericAffExpr{Float64,VariableRefType}}
-    @test JuMP.isequal_canonical(c.func[1], 1x)
+    @test isequal_canonical(c.func[1], 1x)
     @test iszero(c.func[2])
     @test iszero(c.func[3])
-    @test JuMP.isequal_canonical(c.func[4], 1y)
+    @test isequal_canonical(c.func[4], 1y)
     @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
 
-    @constraint(m, con_d_sym, 0 <= Symmetric(Diagonal([x, y])), PSDCone())
-    c = JuMP.constraint_object(con_d_sym)
+    @constraint(
+        m,
+        con_d_sym,
+        0 <= LinearAlgebra.Symmetric(LinearAlgebra.Diagonal([x, y])),
+        PSDCone()
+    )
+    c = constraint_object(con_d_sym)
     @test c.func isa Vector{GenericAffExpr{Float64,VariableRefType}}
-    @test JuMP.isequal_canonical(c.func[1], 1x)
+    @test isequal_canonical(c.func[1], 1x)
     @test iszero(c.func[2])
-    @test JuMP.isequal_canonical(c.func[3], 1y)
+    @test isequal_canonical(c.func[3], 1y)
     @test c.set == MOI.PositiveSemidefiniteConeTriangle(2)
 
-    @constraint(m, con_td, Tridiagonal([z], [x, y], [w]) >= 0, PSDCone())
-    c = JuMP.constraint_object(con_td)
+    @constraint(
+        m,
+        con_td,
+        LinearAlgebra.Tridiagonal([z], [x, y], [w]) >= 0,
+        PSDCone()
+    )
+    c = constraint_object(con_td)
     @test c.func isa Vector{GenericAffExpr{Float64,VariableRefType}}
-    @test JuMP.isequal_canonical(c.func[1], 1x)
-    @test JuMP.isequal_canonical(c.func[2], 1z)
-    @test JuMP.isequal_canonical(c.func[3], 1w)
-    @test JuMP.isequal_canonical(c.func[4], 1y)
+    @test isequal_canonical(c.func[1], 1x)
+    @test isequal_canonical(c.func[2], 1z)
+    @test isequal_canonical(c.func[3], 1w)
+    @test isequal_canonical(c.func[4], 1y)
     @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
 
     @constraint(
         m,
         con_td_sym,
-        Symmetric(Tridiagonal([z], [x, y], [w])) >= 0,
+        LinearAlgebra.Symmetric(LinearAlgebra.Tridiagonal([z], [x, y], [w])) >=
+        0,
         PSDCone(),
     )
-    c = JuMP.constraint_object(con_td_sym)
+    c = constraint_object(con_td_sym)
     @test c.func isa Vector{GenericAffExpr{Float64,VariableRefType}}
-    @test JuMP.isequal_canonical(c.func[1], 1x)
-    @test JuMP.isequal_canonical(c.func[2], 1w)
-    @test JuMP.isequal_canonical(c.func[3], 1y)
+    @test isequal_canonical(c.func[1], 1x)
+    @test isequal_canonical(c.func[2], 1w)
+    @test isequal_canonical(c.func[3], 1y)
     @test c.set == MOI.PositiveSemidefiniteConeTriangle(2)
 
-    @constraint(m, con_ut, UpperTriangular([x y; z w]) >= 0, PSDCone())
-    c = JuMP.constraint_object(con_ut)
+    @constraint(
+        m,
+        con_ut,
+        LinearAlgebra.UpperTriangular([x y; z w]) >= 0,
+        PSDCone()
+    )
+    c = constraint_object(con_ut)
     @test c.func isa Vector{GenericAffExpr{Float64,VariableRefType}}
-    @test JuMP.isequal_canonical(c.func[1], 1x)
+    @test isequal_canonical(c.func[1], 1x)
     @test iszero(c.func[2])
-    @test JuMP.isequal_canonical(c.func[3], 1y)
-    @test JuMP.isequal_canonical(c.func[4], 1w)
+    @test isequal_canonical(c.func[3], 1y)
+    @test isequal_canonical(c.func[4], 1w)
     @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
 
-    @constraint(m, con_lt, 0 <= LowerTriangular([x y; z w]), PSDCone())
-    c = JuMP.constraint_object(con_lt)
+    @constraint(
+        m,
+        con_lt,
+        0 <= LinearAlgebra.LowerTriangular([x y; z w]),
+        PSDCone()
+    )
+    c = constraint_object(con_lt)
     @test c.func isa Vector{GenericAffExpr{Float64,VariableRefType}}
-    @test JuMP.isequal_canonical(c.func[1], 1x)
-    @test JuMP.isequal_canonical(c.func[2], 1z)
+    @test isequal_canonical(c.func[1], 1x)
+    @test isequal_canonical(c.func[2], 1z)
     @test iszero(c.func[3])
-    @test JuMP.isequal_canonical(c.func[4], 1w)
+    @test isequal_canonical(c.func[4], 1w)
     @test c.set == MOI.PositiveSemidefiniteConeSquare(2)
     return
 end
 
-function test_SDP_errors(ModelType, VariableRefType)
+function test_extension_SDP_errors(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     model = ModelType()
     @variable(model, x)
     @variable(model, y)
@@ -510,8 +602,8 @@ function _test_constraint_name_util(ModelType, VariableRefType)
         GenericQuadExpr{Float64,VariableRefType},
         MOI.EqualTo{Float64},
     )
-    JuMP.set_name(con, "kon")
-    @test JuMP.constraint_by_name(model, "con") isa Nothing
+    set_name(con, "kon")
+    @test constraint_by_name(model, "con") isa Nothing
     _test_constraint_name_util(
         con,
         "kon",
@@ -520,8 +612,8 @@ function _test_constraint_name_util(ModelType, VariableRefType)
     )
     y = @constraint(model, kon, [x^2, x] in SecondOrderCone())
     err(name) = ErrorException("Multiple constraints have the name $name.")
-    @test_throws err("kon") JuMP.constraint_by_name(model, "kon")
-    JuMP.set_name(kon, "con")
+    @test_throws err("kon") constraint_by_name(model, "kon")
+    set_name(kon, "con")
     _test_constraint_name_util(
         con,
         "kon",
@@ -534,25 +626,29 @@ function _test_constraint_name_util(ModelType, VariableRefType)
         Vector{GenericQuadExpr{Float64,VariableRefType}},
         MOI.SecondOrderCone,
     )
-    JuMP.set_name(con, "con")
-    @test_throws err("con") JuMP.constraint_by_name(model, "con")
-    @test JuMP.constraint_by_name(model, "kon") isa Nothing
-    JuMP.set_name(kon, "kon")
+    set_name(con, "con")
+    @test_throws err("con") constraint_by_name(model, "con")
+    @test constraint_by_name(model, "kon") isa Nothing
+    set_name(kon, "kon")
     _test_constraint_name_util(
         con,
         "con",
         GenericQuadExpr{Float64,VariableRefType},
         MOI.EqualTo{Float64},
     )
-    return _test_constraint_name_util(
+    _test_constraint_name_util(
         kon,
         "kon",
         Vector{GenericQuadExpr{Float64,VariableRefType}},
         MOI.SecondOrderCone,
     )
+    return
 end
 
-function test_PSD_constraint_errors(ModelType, ::Any)
+function test_extension_PSD_constraint_errors(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     model = ModelType()
     @variable(model, X[1:2, 1:2])
     err = ErrorException(
@@ -573,9 +669,13 @@ function test_PSD_constraint_errors(ModelType, ::Any)
         err,
         @constraint(model, X in MOI.PositiveSemidefiniteConeTriangle(2))
     )
+    return
 end
 
-function test_matrix_constraint_errors(ModelType, VariableRefType)
+function test_extension_matrix_constraint_errors(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     model = ModelType()
     @variable(model, X[1:2, 1:2])
     err = ErrorException(
@@ -586,9 +686,13 @@ function test_matrix_constraint_errors(ModelType, VariableRefType)
     # Note: this should apply to any MOI.AbstractVectorSet. We just pick
     # SecondOrderCone for convenience.
     @test_throws_strip(err, @constraint(model, X in MOI.SecondOrderCone(4)))
+    return
 end
 
-function test_nonsensical_SDP_constraint(ModelType, ::Any)
+function test_extension_nonsensical_SDP_constraint(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     m = ModelType()
     @test_throws_strip(
         ErrorException(
@@ -600,7 +704,6 @@ function test_nonsensical_SDP_constraint(ModelType, ::Any)
     @test_throws MethodError @variable(m, notone[1:5, 2:6], PSD)
     @test_throws MethodError @variable(m, oneD[1:5], PSD)
     @test_throws MethodError @variable(m, threeD[1:5, 1:5, 1:5], PSD)
-
     Y = [1.0 2.0; 2.1 3.0]
     function _ErrorException(m)
         return ErrorException(
@@ -629,15 +732,17 @@ function test_nonsensical_SDP_constraint(ModelType, ::Any)
     return
 end
 
-function test_sum_constraint(ModelType, ::Any)
+function test_extension_sum_constraint(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     model = ModelType()
     @variable(model, x[1:3, 1:3])
     @variable(model, y)
     C = [1 2 3; 4 5 6; 7 8 9]
-
     @test_expression sum(C[i, j] * x[i, j] for i in 1:2, j in 2:3)
     @test_expression sum(C[i, j] * x[i, j] for i in 1:3, j in 1:3 if i != j) - y
-    @test JuMP.isequal_canonical(
+    @test isequal_canonical(
         @expression(model, sum(C[i, j] * x[i, j] for i in 1:3, j in 1:i)),
         sum(C[i, j] * x[i, j] for i in 1:3 for j in 1:i),
     )
@@ -649,9 +754,10 @@ function test_sum_constraint(ModelType, ::Any)
     @test_expression sum(0 * x[i, 1] for i in 1:3)
     @test_expression sum(0 * x[i, 1] + y for i in 1:3)
     @test_expression sum(0 * x[i, 1] + y for i in 1:3 for j in 1:3)
+    return
 end
 
-function test_Model_all_constraints_scalar(::Any, ::Any)
+function test_all_constraints_scalar()
     model = Model()
     @variable(model, x >= 0)
     @test 1 == @inferred num_constraints(
@@ -673,21 +779,22 @@ function test_Model_all_constraints_scalar(::Any, ::Any)
     @test_throws err num_constraints(model, AffExpr, MOI.GreaterThan)
     @test_throws err all_constraints(model, AffExpr, MOI.GreaterThan)
     err = ErrorException(
-        "`GenericAffExpr` is not a concrete type. Did you miss a type parameter?",
+        "`JuMP.GenericAffExpr` is not a concrete type. Did you miss a type parameter?",
     )
     @test_throws err try
-        num_constraints(model, JuMP.GenericAffExpr, MOI.ZeroOne)
+        num_constraints(model, GenericAffExpr, MOI.ZeroOne)
     catch e
-        error(replace(e.msg, "JuMP." => ""))
+        error(replace(e.msg, "" => ""))
     end
     @test_throws err try
-        all_constraints(model, JuMP.GenericAffExpr, MOI.ZeroOne)
+        all_constraints(model, GenericAffExpr, MOI.ZeroOne)
     catch e
-        error(replace(e.msg, "JuMP." => ""))
+        error(replace(e.msg, "" => ""))
     end
+    return
 end
 
-function test_Model_all_constraints_vector(::Any, ::Any)
+function test_all_constraints_vector()
     model = Model()
     @variable(model, x[1:2, 1:2], Symmetric)
     csdp = @constraint(model, x in PSDCone())
@@ -735,7 +842,7 @@ function test_Model_all_constraints_vector(::Any, ::Any)
         replace(
             "`$(GenericAffExpr{Float64})` is not a concrete type. Did you " *
             "miss a type parameter?",
-            "JuMP." => "",
+            "" => "",
         ),
     )
     @test_throws err try
@@ -745,7 +852,7 @@ function test_Model_all_constraints_vector(::Any, ::Any)
             MOI.PositiveSemidefiniteConeTriangle,
         )
     catch e
-        error(replace(e.msg, "JuMP." => ""))
+        error(replace(e.msg, "" => ""))
     end
     @test_throws err try
         all_constraints(
@@ -754,7 +861,7 @@ function test_Model_all_constraints_vector(::Any, ::Any)
             MOI.SecondOrderCone,
         )
     catch e
-        error(replace(e.msg, "JuMP." => ""))
+        error(replace(e.msg, "" => ""))
     end
     err = ErrorException(
         "`MathOptInterface.SOS1` is not a " *
@@ -765,9 +872,10 @@ function test_Model_all_constraints_vector(::Any, ::Any)
         Vector{GenericQuadExpr{Float64,VariableRef}},
         MOI.SOS1,
     )
+    return
 end
 
-function test_Model_list_of_constraint_types(::Any, ::Any)
+function test_list_of_constraint_types()
     model = Model()
     @variable(model, x >= 0, Bin)
     @constraint(model, 2x <= 1)
@@ -783,9 +891,10 @@ function test_Model_list_of_constraint_types(::Any, ::Any)
         (Vector{AffExpr}, MOI.PositiveSemidefiniteConeSquare),
         (Vector{QuadExpr}, MOI.RotatedSecondOrderCone),
     ])
+    return
 end
 
-function test_Model_dual_start(::Any, ::Any)
+function test_dual_start()
     model = Model()
     @variable(model, x)
     con = @constraint(model, 2x <= 1)
@@ -794,9 +903,10 @@ function test_Model_dual_start(::Any, ::Any)
     @test dual_start_value(con) == 2.0
     set_dual_start_value(con, nothing)
     @test dual_start_value(con) === nothing
+    return
 end
 
-function test_Model_dual_start_vector(::Any, ::Any)
+function test_dual_start_vector()
     model = Model()
     @variable(model, x)
     con_vec = @constraint(model, [x, x] in SecondOrderCone())
@@ -805,9 +915,10 @@ function test_Model_dual_start_vector(::Any, ::Any)
     @test dual_start_value(con_vec) == [1.0, 3.0]
     set_dual_start_value(con_vec, nothing)
     @test dual_start_value(con_vec) === nothing
+    return
 end
 
-function test_Model_primal_start(::Any, ::Any)
+function test_primal_start()
     model = Model()
     @variable(model, x)
     con = @constraint(model, 2x <= 1)
@@ -819,7 +930,7 @@ function test_Model_primal_start(::Any, ::Any)
     return
 end
 
-function test_Model_primal_start_vector(::Any, ::Any)
+function test_primal_start_vector()
     model = Model()
     @variable(model, x)
     con_vec = @constraint(model, [x, x] in SecondOrderCone())
@@ -831,91 +942,94 @@ function test_Model_primal_start_vector(::Any, ::Any)
     return
 end
 
-function test_Model_change_coefficient(::Any, ::Any)
-    model = JuMP.Model()
+function test_change_coefficient()
+    model = Model()
     x = @variable(model)
     con_ref = @constraint(model, 2 * x == -1)
-    @test JuMP.normalized_coefficient(con_ref, x) == 2.0
-    JuMP.set_normalized_coefficient(con_ref, x, 1.0)
-    @test JuMP.normalized_coefficient(con_ref, x) == 1.0
-    JuMP.set_normalized_coefficient(con_ref, x, 3)  # Check type promotion.
-    @test JuMP.normalized_coefficient(con_ref, x) == 3.0
+    @test normalized_coefficient(con_ref, x) == 2.0
+    set_normalized_coefficient(con_ref, x, 1.0)
+    @test normalized_coefficient(con_ref, x) == 1.0
+    set_normalized_coefficient(con_ref, x, 3)  # Check type promotion.
+    @test normalized_coefficient(con_ref, x) == 3.0
     quad_con = @constraint(model, x^2 == 0)
-    @test JuMP.normalized_coefficient(quad_con, x) == 0.0
-    JuMP.set_normalized_coefficient(quad_con, x, 2)
-    @test JuMP.normalized_coefficient(quad_con, x) == 2.0
-    @test JuMP.isequal_canonical(
-        JuMP.constraint_object(quad_con).func,
-        x^2 + 2x,
-    )
-end
-
-function test_Model_change_coefficients(::Any, ::Any)
-    model = Model()
-    @variable(model, x)
-    @constraint(model, con, [2x + 3x, 4x] in MOI.Nonnegatives(2))
-    @test JuMP.isequal_canonical(JuMP.constraint_object(con).func, [5.0x, 4.0x])
-    set_normalized_coefficients(con, x, [(Int64(1), 3.0)])
-    @test JuMP.isequal_canonical(JuMP.constraint_object(con).func, [3.0x, 4.0x])
-    set_normalized_coefficients(con, x, [(Int64(1), 2.0), (Int64(2), 5.0)])
-    @test JuMP.isequal_canonical(JuMP.constraint_object(con).func, [2.0x, 5.0x])
+    @test normalized_coefficient(quad_con, x) == 0.0
+    set_normalized_coefficient(quad_con, x, 2)
+    @test normalized_coefficient(quad_con, x) == 2.0
+    @test isequal_canonical(constraint_object(quad_con).func, x^2 + 2x)
     return
 end
 
-function test_Model_change_rhs(::Any, ::Any)
-    model = JuMP.Model()
-    x = @variable(model)
-    con_ref = @constraint(model, 2 * x <= 1)
-    @test JuMP.normalized_rhs(con_ref) == 1.0
-    JuMP.set_normalized_rhs(con_ref, 2.0)
-    @test JuMP.normalized_rhs(con_ref) == 2.0
-    con_ref = @constraint(model, 2 * x - 1 == 1)
-    @test JuMP.normalized_rhs(con_ref) == 2.0
-    JuMP.set_normalized_rhs(con_ref, 3)
-    @test JuMP.normalized_rhs(con_ref) == 3.0
-    con_ref = @constraint(model, 0 <= 2 * x <= 1)
-    @test_throws MethodError JuMP.set_normalized_rhs(con_ref, 3)
+function test_change_coefficients()
+    model = Model()
+    @variable(model, x)
+    @constraint(model, con, [2x + 3x, 4x] in MOI.Nonnegatives(2))
+    @test isequal_canonical(constraint_object(con).func, [5.0x, 4.0x])
+    set_normalized_coefficients(con, x, [(Int64(1), 3.0)])
+    @test isequal_canonical(constraint_object(con).func, [3.0x, 4.0x])
+    set_normalized_coefficients(con, x, [(Int64(1), 2.0), (Int64(2), 5.0)])
+    @test isequal_canonical(constraint_object(con).func, [2.0x, 5.0x])
+    return
 end
 
-function test_Model_add_to_function_constant_scalar(::Any, ::Any)
-    model = JuMP.Model()
+function test_change_rhs()
+    model = Model()
+    x = @variable(model)
+    con_ref = @constraint(model, 2 * x <= 1)
+    @test normalized_rhs(con_ref) == 1.0
+    set_normalized_rhs(con_ref, 2.0)
+    @test normalized_rhs(con_ref) == 2.0
+    con_ref = @constraint(model, 2 * x - 1 == 1)
+    @test normalized_rhs(con_ref) == 2.0
+    set_normalized_rhs(con_ref, 3)
+    @test normalized_rhs(con_ref) == 3.0
+    con_ref = @constraint(model, 0 <= 2 * x <= 1)
+    @test_throws MethodError set_normalized_rhs(con_ref, 3)
+    return
+end
+
+function test_add_to_function_constant_scalar()
+    model = Model()
     x = @variable(model)
     con_ref = @constraint(model, 2 <= 2 * x <= 3)
     con = constraint_object(con_ref)
-    @test JuMP.isequal_canonical(JuMP.jump_function(con), 2x)
-    @test JuMP.moi_set(con) == MOI.Interval(2.0, 3.0)
-    JuMP.add_to_function_constant(con_ref, 1.0)
+    @test isequal_canonical(jump_function(con), 2x)
+    @test moi_set(con) == MOI.Interval(2.0, 3.0)
+    add_to_function_constant(con_ref, 1.0)
     con = constraint_object(con_ref)
-    @test JuMP.isequal_canonical(JuMP.jump_function(con), 2x)
-    @test JuMP.moi_set(con) == MOI.Interval(1.0, 2.0)
+    @test isequal_canonical(jump_function(con), 2x)
+    @test moi_set(con) == MOI.Interval(1.0, 2.0)
+    return
 end
 
-function test_Model_add_to_function_constant_vector(::Any, ::Any)
-    model = JuMP.Model()
+function test_add_to_function_constant_vector()
+    model = Model()
     x = @variable(model)
     con_ref = @constraint(model, [x + 1, x - 1] in MOI.Nonnegatives(2))
     con = constraint_object(con_ref)
-    @test JuMP.isequal_canonical(JuMP.jump_function(con), [x + 1, x - 1])
-    @test JuMP.moi_set(con) == MOI.Nonnegatives(2)
-    JuMP.add_to_function_constant(con_ref, [2, 3])
+    @test isequal_canonical(jump_function(con), [x + 1, x - 1])
+    @test moi_set(con) == MOI.Nonnegatives(2)
+    add_to_function_constant(con_ref, [2, 3])
     con = constraint_object(con_ref)
-    @test JuMP.isequal_canonical(JuMP.jump_function(con), [x + 3, x + 2])
-    @test JuMP.moi_set(con) == MOI.Nonnegatives(2)
+    @test isequal_canonical(jump_function(con), [x + 3, x + 2])
+    @test moi_set(con) == MOI.Nonnegatives(2)
+    return
 end
 
-function test_Model_value_constraint_var(ModelType, ::Any)
+function test_value_constraint_var(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     model = ModelType()
     @variable(model, x[1:2])
     @constraint(model, c1, x[1] + x[2] <= 3.0)
     @constraint(model, c2, x[1]^2 + x[2]^2 <= 3.0)
     @constraint(model, c3, [1.0, x[1], x[2]] in SecondOrderCone())
-
     vals = Dict(x[1] => 1.0, x[2] => 2.0)
     f = vidx -> vals[vidx]
-
     @test value(f, c1) === 3.0 # Affine expression
     @test value(f, c2) === 5.0 # Quadratic expression
     @test value(f, c3) == [1.0, 1.0, 2.0] # Vector expression
+    return
 end
 
 function _test_shadow_price_util(
@@ -933,11 +1047,11 @@ function _test_shadow_price_util(
             eval_variable_constraint_dual = false,
         ),
     )
-    JuMP.optimize!(model)
-    mock_optimizer = JuMP.unsafe_backend(model)
+    optimize!(model)
+    mock_optimizer = unsafe_backend(model)
     MOI.set(mock_optimizer, MOI.TerminationStatus(), MOI.OPTIMAL)
     MOI.set(mock_optimizer, MOI.DualStatus(), MOI.FEASIBLE_POINT)
-    JuMP.optimize!(model)
+    optimize!(model)
     for (key, val) in constraint_dual
         ci = if key isa String
             MOI.get(backend(model), MOI.ConstraintIndex, key)
@@ -945,19 +1059,20 @@ function _test_shadow_price_util(
             x = MOI.get(backend(model), MOI.VariableIndex, key[1])
             MOI.ConstraintIndex{MOI.VariableIndex,key[2]}(x.value)
         end
-        constraint_ref = JuMP.ConstraintRef(model, ci, JuMP.ScalarShape())
+        constraint_ref = ConstraintRef(model, ci, ScalarShape())
         MOI.set(
             mock_optimizer,
             MOI.ConstraintDual(),
-            JuMP.optimizer_index(constraint_ref),
+            optimizer_index(constraint_ref),
             val,
         )
         @test dual(constraint_ref) == val
         @test shadow_price(constraint_ref) == constraint_shadow[key]
     end
+    return
 end
 
-function test_Model_shadow_price(::Any, ::Any)
+function test_shadow_price()
     _test_shadow_price_util(
         """
         variables: x, y
@@ -977,7 +1092,6 @@ function test_Model_shadow_price(::Any, ::Any)
             "c" => -1.0,
         ),
     )
-
     _test_shadow_price_util(
         """
         variables: x, y
@@ -997,7 +1111,6 @@ function test_Model_shadow_price(::Any, ::Any)
             "c" => 1.0,
         ),
     )
-
     _test_shadow_price_util(
         """
         variables: x, y
@@ -1014,7 +1127,6 @@ function test_Model_shadow_price(::Any, ::Any)
             ("y", MOI.GreaterThan{Float64}) => 0.0,
         ),
     )
-
     _test_shadow_price_util(
         """
         variables: x
@@ -1024,7 +1136,6 @@ function test_Model_shadow_price(::Any, ::Any)
         Dict(("x", MOI.EqualTo{Float64}) => -1.0),
         Dict(("x", MOI.EqualTo{Float64}) => 1.0),
     )
-
     _test_shadow_price_util(
         """
         variables: x
@@ -1037,16 +1148,23 @@ function test_Model_shadow_price(::Any, ::Any)
     return
 end
 
-function test_abstractarray_vector_constraint(ModelType, ::Any)
+function test_extension_abstractarray_vector_constraint(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     model = ModelType()
     @variable(model, x[1:2, 1:2])
     c = @constraint(model, view(x, 1:4) in SOS1())
     obj = constraint_object(c)
     @test obj.func == x[1:4]
     @test obj.set == MOI.SOS1([1.0, 2.0, 3.0, 4.0])
+    return
 end
 
-function test_constraint_inference(ModelType, ::Any)
+function test_extension_constraint_inference(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     model = ModelType()
     @variable(model, x)
     foo(model, x) = @constraint(model, 2x <= 1)
@@ -1054,10 +1172,13 @@ function test_constraint_inference(ModelType, ::Any)
     obj = constraint_object(c)
     @test obj.func == 2x
     @test obj.set == MOI.LessThan(1.0)
+    return
 end
 
 struct _UnsupportedConstraintName <: MOI.AbstractOptimizer end
+
 MOI.add_variable(::_UnsupportedConstraintName) = MOI.VariableIndex(1)
+
 function MOI.supports_constraint(
     ::_UnsupportedConstraintName,
     ::Type{MOI.VectorOfVariables},
@@ -1065,6 +1186,7 @@ function MOI.supports_constraint(
 )
     return true
 end
+
 function MOI.add_constraint(
     ::_UnsupportedConstraintName,
     ::MOI.VectorOfVariables,
@@ -1072,9 +1194,10 @@ function MOI.add_constraint(
 )
     return MOI.ConstraintIndex{MOI.VectorOfVariables,MOI.SOS1{Float64}}(1)
 end
+
 MOI.is_empty(::_UnsupportedConstraintName) = true
 
-function test_Model_unsupported_ConstraintName(::Any, ::Any)
+function test_unsupported_ConstraintName()
     model = direct_model(_UnsupportedConstraintName())
     @variable(model, x)
     @constraint(model, c, [x, x] in SOS1())
@@ -1083,7 +1206,7 @@ function test_Model_unsupported_ConstraintName(::Any, ::Any)
     return
 end
 
-function test_PSDCone_constraints(::Any, ::Any)
+function test_PSDCone_constraints()
     model = Model()
     @variable(model, X[1:2, 1:2])
     Y = [1 1; 1 1]
@@ -1102,24 +1225,22 @@ function test_PSDCone_constraints(::Any, ::Any)
     return
 end
 
-function test_PSDCone_Symmetric_constraints(::Any, ::Any)
+function test_PSDCone_Symmetric_constraints()
     model = Model()
     @variable(model, X[1:2, 1:2], Symmetric)
-    Y = Symmetric([1 1; 1 1])
+    Y = LinearAlgebra.Symmetric([1 1; 1 1])
     f = reshape(X - Y, 4)
-    if VERSION >= v"1.6"
-        # Julia 1.0 doesn't maintain symmetry for X - Y, so only test this on
-        # Julia 1.6 and higher.
-        c1 = @constraint(model, X >= Y, PSDCone())
-        obj = constraint_object(c1)
-        @test obj.func == f[[1, 3, 4]]
-        @test obj.set == MOI.PositiveSemidefiniteConeTriangle(2)
-        c2 = @constraint(model, Y <= X, PSDCone())
-        @test constraint_object(c2).func == f[[1, 3, 4]]
-    end
-    c3 = @constraint(model, Symmetric(X - Y) >= 0, PSDCone())
+    # Julia 1.0 doesn't maintain symmetry for X - Y, so only test this on
+    # Julia 1.6 and higher.
+    c1 = @constraint(model, X >= Y, PSDCone())
+    obj = constraint_object(c1)
+    @test obj.func == f[[1, 3, 4]]
+    @test obj.set == MOI.PositiveSemidefiniteConeTriangle(2)
+    c2 = @constraint(model, Y <= X, PSDCone())
+    @test constraint_object(c2).func == f[[1, 3, 4]]
+    c3 = @constraint(model, LinearAlgebra.Symmetric(X - Y) >= 0, PSDCone())
     @test constraint_object(c3).func == f[[1, 3, 4]]
-    c4 = @constraint(model, Symmetric(Y - X) <= 0, PSDCone())
+    c4 = @constraint(model, LinearAlgebra.Symmetric(Y - X) <= 0, PSDCone())
     @test constraint_object(c4).func == f[[1, 3, 4]]
     c5 = @constraint(model, X >= 0, PSDCone())
     @test constraint_object(c5).func == 1.0 .* X[[1, 3, 4]]
@@ -1127,12 +1248,12 @@ function test_PSDCone_Symmetric_constraints(::Any, ::Any)
 end
 
 """
-    test_set_inequalities(::Any, ::Any)
+    test_set_inequalities()
 
 Test the syntax `@constraint(model, X >= Y, Set())` is the same as
 `@constraint(model, X - Y in Set())`.
 """
-function test_set_inequalities(::Any, ::Any)
+function test_set_inequalities()
     model = Model()
     @variable(model, X[1:2])
     Y = [3.0, 4.0]
@@ -1162,7 +1283,7 @@ function test_set_inequalities(::Any, ::Any)
     return
 end
 
-function test_num_constraints(::Any, ::Any)
+function test_num_constraints()
     model = Model()
     @variable(model, x >= 0, Int)
     @constraint(model, 2x <= 1)
@@ -1171,7 +1292,7 @@ function test_num_constraints(::Any, ::Any)
     return
 end
 
-function test_num_constraints_UndefKeywordError(::Any, ::Any)
+function test_num_constraints_UndefKeywordError()
     model = Model()
     @variable(model, x >= 0, Int)
     @constraint(model, 2x <= 1)
@@ -1179,7 +1300,7 @@ function test_num_constraints_UndefKeywordError(::Any, ::Any)
     return
 end
 
-function test_num_constraints_nonlinear(::Any, ::Any)
+function test_num_constraints_nonlinear()
     model = Model()
     @variable(model, x >= 0, Int)
     @constraint(model, 2x <= 1)
@@ -1189,7 +1310,7 @@ function test_num_constraints_nonlinear(::Any, ::Any)
     return
 end
 
-function test_Model_all_constraints(::Any, ::Any)
+function test_all_constraints()
     model = Model()
     @variable(model, x >= 0, Int)
     c = @constraint(model, 2x <= 1)
@@ -1207,7 +1328,7 @@ function test_Model_all_constraints(::Any, ::Any)
     return
 end
 
-function test_Model_relax_with_penalty!_default(::Any, ::Any)
+function test_relax_with_penalty!_default()
     model = Model()
     @variable(model, x >= 0)
     map = relax_with_penalty!(model)
@@ -1224,7 +1345,7 @@ function test_Model_relax_with_penalty!_default(::Any, ::Any)
     return
 end
 
-function test_Model_relax_with_penalty!_max(::Any, ::Any)
+function test_relax_with_penalty!_max()
     model = Model()
     @variable(model, x >= 0)
     @constraint(model, c1, x <= 1)
@@ -1240,7 +1361,7 @@ function test_Model_relax_with_penalty!_max(::Any, ::Any)
     return
 end
 
-function test_Model_relax_with_penalty!_constant(::Any, ::Any)
+function test_relax_with_penalty!_constant()
     model = Model()
     @variable(model, x >= 0)
     map = relax_with_penalty!(model)
@@ -1257,7 +1378,7 @@ function test_Model_relax_with_penalty!_constant(::Any, ::Any)
     return
 end
 
-function test_Model_relax_with_penalty!_specific(::Any, ::Any)
+function test_relax_with_penalty!_specific()
     model = Model()
     @variable(model, x >= 0)
     map = relax_with_penalty!(model)
@@ -1273,7 +1394,7 @@ function test_Model_relax_with_penalty!_specific(::Any, ::Any)
     return
 end
 
-function test_Model_relax_with_penalty!_specific_with_default(::Any, ::Any)
+function test_relax_with_penalty!_specific_with_default()
     model = Model()
     @variable(model, x >= 0)
     map = relax_with_penalty!(model)
@@ -1289,7 +1410,10 @@ function test_Model_relax_with_penalty!_specific_with_default(::Any, ::Any)
     return
 end
 
-function test_Hermitian_PSD_constraint(ModelType, VariableRefType)
+function test_extension_Hermitian_PSD_constraint(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     model = ModelType()
     @variable(model, x)
     @variable(model, y)
@@ -1299,7 +1423,7 @@ function test_Hermitian_PSD_constraint(ModelType, VariableRefType)
     _test_constraint_name_util(
         href,
         "href",
-        Vector{AffExpr},
+        Vector{GenericAffExpr{ComplexF64,VariableRefType}},
         MOI.HermitianPositiveSemidefiniteConeTriangle,
     )
     c = JuMP.constraint_object(href)
@@ -1312,13 +1436,16 @@ function test_Hermitian_PSD_constraint(ModelType, VariableRefType)
     return
 end
 
-function test_HermitianPSDCone_errors(ModelType, VariableRefType)
+function test_extension_HermitianPSDCone_errors(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
     model = ModelType()
     @variable(model, x)
     @variable(model, y)
     aff_str = "$(GenericAffExpr{ComplexF64,VariableRefType})"
     err = ErrorException(
-        "In `@constraint(model, Hermitian([x 1im; -1im -y]) in HermitianPSDCone(), unknown_kw = 1)`:" *
+        "In `@constraint(model, H in HermitianPSDCone(), unknown_kw = 1)`:" *
         " Unrecognized constraint building format. Tried to invoke " *
         "`build_constraint(error, $aff_str[" *
         "x (0.0 + 1.0im); (0.0 - 1.0im) (-1.0 - 0.0im) y], $(HermitianPSDCone()); unknown_kw = 1)`, but no " *
@@ -1327,32 +1454,12 @@ function test_HermitianPSDCone_errors(ModelType, VariableRefType)
         "arguments.\n\nIf you're trying to create a JuMP extension, you " *
         "need to implement `build_constraint` to accomodate these arguments.",
     )
+    H = LinearAlgebra.Hermitian([x 1im; -1im -y])
     @test_throws_strip(
         err,
-        @constraint(
-            model,
-            Hermitian([x 1im; -1im -y]) in HermitianPSDCone(),
-            unknown_kw = 1,
-        ),
+        @constraint(model, H in HermitianPSDCone(), unknown_kw = 1),
     )
     return
-end
-
-function runtests()
-    for name in names(@__MODULE__; all = true)
-        if !startswith("$(name)", "test_")
-            continue
-        end
-        f = getfield(@__MODULE__, name)
-        @testset "$(name)" begin
-            f(Model, VariableRef)
-        end
-        if !startswith("$(name)", "test_Model_")
-            @testset "$(name)-JuMPExtension" begin
-                f(JuMPExtension.MyModel, JuMPExtension.MyVariableRef)
-            end
-        end
-    end
 end
 
 end

--- a/test/constraint.jl
+++ b/test/constraint.jl
@@ -1423,7 +1423,7 @@ function test_extension_Hermitian_PSD_constraint(
     _test_constraint_name_util(
         href,
         "href",
-        Vector{GenericAffExpr{ComplexF64,VariableRefType}},
+        Vector{GenericAffExpr{Float64,VariableRefType}},
         MOI.HermitianPositiveSemidefiniteConeTriangle,
     )
     c = constraint_object(href)


### PR DESCRIPTION
I started looking into https://github.com/jump-dev/JuMP.jl/issues/1711

This is a preliminary step to making the JuMPExtension tests more widely accessible. For a start, we need to know which tests to make available, and to have a standardized call signature for them.

I still need to figure out exactly what it would look like. Perhaps we could put them all in a separate submodule of the `tests/JuMPExtensionTests` and then packages could run 
```julia
include(joinpath(pathof(JuMP), "test", "JuMPExtensionTests", "JuMPExtensionTests.jl")
```