### PR TITLE
Run MutableArithmetics tests with complex coefficients

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -11,7 +11,7 @@
 const _JuMPTypes = Union{AbstractJuMPScalar,NonlinearExpression}
 
 _float_type(::Type{<:Real}) = Float64
-_float_type(::Type{<:UniformScaling}) = Float64
+_float_type(::Type{UniformScaling{T}}) where {T} = _float_type(T)
 _float_type(::Type{<:Complex}) = Complex{Float64}
 
 _float(x::Real) = convert(Float64, x)
@@ -48,14 +48,14 @@ end
 # _Constant--_GenericAffOrQuadExpr
 function Base.:+(lhs::_Constant, rhs::_GenericAffOrQuadExpr)
     # If `lhs` is complex and `rhs` has real coefficients then the conversion is needed
-    T = _MA.promote_operation(+, typeof(lhs), typeof(rhs))
+    T = _MA.promote_operation(+, _float_type(typeof(lhs)), typeof(rhs))
     result = _MA.mutable_copy(convert(T, rhs))
     add_to_expression!(result, lhs)
     return result
 end
 function Base.:-(lhs::_Constant, rhs::_GenericAffOrQuadExpr)
     # If `lhs` is complex and `rhs` has real coefficients then the conversion is needed
-    T = _MA.promote_operation(+, typeof(lhs), typeof(rhs))
+    T = _MA.promote_operation(+, _float_type(typeof(lhs)), typeof(rhs))
     result = convert(T, -rhs)
     add_to_expression!(result, lhs)
     return result
@@ -63,7 +63,7 @@ end
 function Base.:*(lhs::_Constant, rhs::_GenericAffOrQuadExpr)
     if iszero(lhs)
         # If `lhs` is complex and `rhs` has real coefficients, `zero(rhs)` would not work
-        return zero(_MA.promote_operation(*, typeof(lhs), typeof(rhs)))
+        return zero(_MA.promote_operation(*, _float_type(typeof(lhs)), typeof(rhs)))
     else
         α = _constant_to_number(lhs)
         return map_coefficients(c -> α * c, rhs)

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -63,7 +63,9 @@ end
 function Base.:*(lhs::_Constant, rhs::_GenericAffOrQuadExpr)
     if iszero(lhs)
         # If `lhs` is complex and `rhs` has real coefficients, `zero(rhs)` would not work
-        return zero(_MA.promote_operation(*, _float_type(typeof(lhs)), typeof(rhs)))
+        return zero(
+            _MA.promote_operation(*, _float_type(typeof(lhs)), typeof(rhs)),
+        )
     else
         α = _constant_to_number(lhs)
         return map_coefficients(c -> α * c, rhs)

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -414,9 +414,9 @@ end
 
 function add_to_expression!(
     quad::GenericQuadExpr{C,V},
-    lhs::GenericAffExpr{C,V},
-    rhs::GenericAffExpr{C,V},
-) where {C,V}
+    lhs::GenericAffExpr{S,V},
+    rhs::GenericAffExpr{T,V},
+) where {C,S,T,V}
     lhs_length = length(linear_terms(lhs))
     rhs_length = length(linear_terms(rhs))
 

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -35,6 +35,10 @@ function test_complex_aff_expr()
     @variable(model, x)
     y = (1 + 2im) * x + 1
     @test typeof(y) == GenericAffExpr{Complex{Float64},VariableRef}
+    @test 1im + x == 1im + 1 * x
+    @test 1im + x == 1im + (1 + 0im) * x
+    @test 1im - x == -(1 + 0im)x + 1im
+    @test 1im - 1 * x == -1 * x + 1im
     return
 end
 

--- a/test/operator.jl
+++ b/test/operator.jl
@@ -259,10 +259,15 @@ function test_uniform_scaling(ModelType, ::Any)
     @test_expression_with_string 2I + x "x + 2"
     @test_expression_with_string I + (x + 1) "x + 2"
     @test_expression_with_string 2I - x "-x + 2"
+    @test_expression_with_string (2im * I) - x "(-1.0 - 0.0im) x + (0.0 + 2.0im)"
     @test_expression_with_string I - (x - 1) "-x + 2"
+    @test_expression_with_string (I * im) - (x - 1) "(-1.0 + 0.0im) x + (1.0 + 1.0im)"
     @test_expression_with_string I * x "x"
+    @test_expression_with_string (I * im) * x "(0.0 + 1.0im) x"
     @test_expression_with_string I * (x + 1) "x + 1"
+    @test_expression_with_string (I * im) * (x + 1) "(0.0 + 1.0im) x + (0.0 + 1.0im)"
     @test_expression_with_string (x + 1) * I "x + 1"
+    @test_expression_with_string (x + 1) * (I * im) "(0.0 + 1.0im) x + (0.0 + 1.0im)"
 end
 
 function test_basic_operators(ModelType, ::Any)


### PR DESCRIPTION
This has spotted a few bugs. Some of them where mismatch in the promotion tests that could have gone unnoticed if `promote_operation` was wrong as well so I added manual tests in `test/complex.jl` to make sure the operation is correct.