### PR TITLE
Improve error message thrown when = used instead of == in macro

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -750,7 +750,10 @@ function _constraint_macro(
     # Initial check of the positional arguments and get the model
     if length(pos_args) < 2
         if length(kw_args) > 0
-            _error("Not enough positional arguments")
+            _error(
+                "No constraint expression detected. If you are trying to " *
+                "construct an equality constraint, use `==` instead of `=`.",
+            )
         else
             _error("Not enough arguments")
         end

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -1679,6 +1679,18 @@ function test_constraint_not_enough_arguments()
     return
 end
 
+function test_constraint_no_constraint_expression_detected()
+    model = Model()
+    @variable(model, x)
+    err = ErrorException(
+        "In `@constraint(model, x = 2)`: No constraint expression detected. " *
+        "If you are trying to construct an equality constraint, use `==` " *
+        "instead of `=`.",
+    )
+    @test_macro_throws(err, @constraint(model, x = 2))
+    return
+end
+
 function test_objective_not_enough_arguments()
     model = Model()
     @test_macro_throws(


### PR DESCRIPTION
Closes #3177 