### PR TITLE
Improve error message for common case of using Bool instead of Bin

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1454,6 +1454,13 @@ function build_variable(
         )
     end
     for (key, _) in kwargs
+        if key == :Bool
+            _error(
+            "Unsupported keyword argument: $key.\n\nIf you intended to " *
+            "create a `{0, 1}` decision variable, use the `binary` keyword " *
+            "argument instead: `@variable(model, x, binary = true)`.",
+        )
+        end
         _error(
             "Unrecognized keyword argument: $key.\n\nIf you're trying " *
             "to create a JuMP extension, you need to implement " *
@@ -1542,6 +1549,19 @@ function build_variable(
         )
     end
     return ScalarVariable(info)
+end
+
+function build_variable(
+    _error::Function,
+    info::VariableInfo,
+    ::Type{Bool};
+    kwargs...,
+)
+    return _error(
+        "Unsupported positional argument `Bool`. If you intended to create a " *
+        "`{0, 1}` decision variable, use `Bin` instead. For example, " *
+        "`@variable(model, x, Bin)` or `@variable(model, x, binary = true)`.",
+    )
 end
 
 function build_variable(

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1456,10 +1456,10 @@ function build_variable(
     for (key, _) in kwargs
         if key == :Bool
             _error(
-            "Unsupported keyword argument: $key.\n\nIf you intended to " *
-            "create a `{0, 1}` decision variable, use the `binary` keyword " *
-            "argument instead: `@variable(model, x, binary = true)`.",
-        )
+                "Unsupported keyword argument: $key.\n\nIf you intended to " *
+                "create a `{0, 1}` decision variable, use the `binary` keyword " *
+                "argument instead: `@variable(model, x, binary = true)`.",
+            )
         end
         _error(
             "Unrecognized keyword argument: $key.\n\nIf you're trying " *

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -1779,4 +1779,23 @@ function test_nonlinear_flatten_expressions()
     return
 end
 
+function test_variable_Bool_argument()
+    model = Model()
+    err = ErrorException(
+        "In `@variable(model, x, Bool)`: " *
+        "Unsupported positional argument `Bool`. If you intended to create a " *
+        "`{0, 1}` decision variable, use `Bin` instead. For example, " *
+        "`@variable(model, x, Bin)` or `@variable(model, x, binary = true)`.",
+    )
+    @test_macro_throws(err, @variable(model, x, Bool))
+    err = ErrorException(
+        "In `@variable(model, x, Bool = true)`: " *
+        "Unsupported keyword argument: $key.\n\nIf you intended to " *
+        "create a `{0, 1}` decision variable, use the `binary` keyword " *
+        "argument instead: `@variable(model, x, binary = true)`.",
+    )
+    @test_macro_throws(err, @variable(model, x, Bool = true))
+    return
+end
+
 end  # module

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -1787,14 +1787,14 @@ function test_variable_Bool_argument()
         "`{0, 1}` decision variable, use `Bin` instead. For example, " *
         "`@variable(model, x, Bin)` or `@variable(model, x, binary = true)`.",
     )
-    @test_macro_throws(err, @variable(model, x, Bool))
+    @test_throws_strip(err, @variable(model, x, Bool))
     err = ErrorException(
         "In `@variable(model, x, Bool = true)`: " *
-        "Unsupported keyword argument: $key.\n\nIf you intended to " *
+        "Unsupported keyword argument: Bool.\n\nIf you intended to " *
         "create a `{0, 1}` decision variable, use the `binary` keyword " *
         "argument instead: `@variable(model, x, binary = true)`.",
     )
-    @test_macro_throws(err, @variable(model, x, Bool = true))
+    @test_throws_strip(err, @variable(model, x, Bool = true))
     return
 end
 


### PR DESCRIPTION
This PR was motivated by the discourse post:
https://discourse.julialang.org/t/how-to-declare-a-boolean-variable/41279

It is one of the top-10 most read posts on the JuMP section of the discourse forum, so it is obviously a common stumbling block, particularly because we support Int for integer variables.