### PR TITLE
Switch to LU factorization in lp_sensitivity_report

### DIFF
--- a/src/lp_sensitivity2.jl
+++ b/src/lp_sensitivity2.jl
@@ -90,13 +90,17 @@ function lp_sensitivity_report(model::Model; atol::Float64 = 1e-8)
     l_B = @view std_form.lower[basis.basic_cols]
     u_B = @view std_form.upper[basis.basic_cols]
 
-    B_fact = LinearAlgebra.lu(B)
-    d = Dict{Int,Vector{Float64}}(
-        # We call `collect` here because some Julia versions are missing sparse
-        # matrix \ sparse vector fallbacks.
-        j => B_fact \ collect(std_form.A[:, j]) for
-        j in 1:length(basis.basic_cols) if basis.basic_cols[j] == false
-    )
+    d = Dict{Int,Vector{Float64}}()
+    if size(B, 1) > 0
+        B_fact = LinearAlgebra.lu(B)
+        for j in 1:length(basis.basic_cols)
+            if basis.basic_cols[j] == false
+                # We call `collect` here because some Julia versions are missing
+                # sparse matrix \ sparse vector fallbacks.
+                d[j] = B_fact \ collect(std_form.A[:, j])
+            end
+        end
+    end
 
     report = SensitivityReport(
         Dict{ConstraintRef,Tuple{Float64,Float64}}(),

--- a/src/lp_sensitivity2.jl
+++ b/src/lp_sensitivity2.jl
@@ -90,7 +90,7 @@ function lp_sensitivity_report(model::Model; atol::Float64 = 1e-8)
     l_B = @view std_form.lower[basis.basic_cols]
     u_B = @view std_form.upper[basis.basic_cols]
 
-    B_fact = LinearAlgebra.factorize(B)
+    B_fact = LinearAlgebra.lu(B)
     d = Dict{Int,Vector{Float64}}(
         # We call `collect` here because some Julia versions are missing sparse
         # matrix \ sparse vector fallbacks.


### PR DESCRIPTION
@adow031 has a case where this factorization is failing, saying:

> If this shouldn't happen, I can give you the code to take a look at it (I couldn't find a simple case where this would happen) - but it's a bit of an edge case, so it's not a big deal for me.

```julia
Presolving model
0 rows, 0 cols, 0 nonzeros
0 rows, 0 cols, 0 nonzeros
Presolve : Reductions: rows 0(-3); columns 0(-5); elements 0(-8) - Reduced to empty
Solving the original LP from the solution after postsolve
Model   status      : Optimal
Objective value     : -1.0000000000e+00
HiGHS run time      :          0.03
Solving LP without presolve or with basis
Using EKK dual simplex solver - serial
  Iteration        Objective     Infeasibilities num(sum)
          0     0.0000000000e+00 Ph1: 0(0) 0s
          1     0.0000000000e+00 Pr: 0(0) 0s
Model   status      : Optimal
Simplex   iterations: 1
Objective value     :  0.0000000000e+00
HiGHS run time      :          0.04

ERROR: ZeroPivotException: factorization encountered one or more zero pivots. Consider switching to a pivoted LU factorization.
Stacktrace:
  [1] #ldlt!#10
    @ C:\Users\adow031\AppData\Local\Programs\Julia-1.8.3\share\julia\stdlib\v1.8\SuiteSparse\src\cholmod.jl:1308 [inlined]
  [2] ldlt!(F::SuiteSparse.CHOLMOD.Factor{Float64}, A::LinearAlgebra.Hermitian{Float64, SparseArrays.SparseMatrixCSC{Float64, Int64}}; shift::Float64, check::Bool)
    @ SuiteSparse.CHOLMOD C:\Users\adow031\AppData\Local\Programs\Julia-1.8.3\share\julia\stdlib\v1.8\SuiteSparse\src\cholmod.jl:1333
  [3] ldlt!
    @ C:\Users\adow031\AppData\Local\Programs\Julia-1.8.3\share\julia\stdlib\v1.8\SuiteSparse\src\cholmod.jl:1333 [inlined]
  [4] factorize
    @ C:\Users\adow031\AppData\Local\Programs\Julia-1.8.3\share\julia\stdlib\v1.8\SparseArrays\src\linalg.jl:1631 [inlined]
  [5] factorize(A::SparseArrays.SparseMatrixCSC{Float64, Int64})
    @ SparseArrays C:\Users\adow031\AppData\Local\Programs\Julia-1.8.3\share\julia\stdlib\v1.8\SparseArrays\src\linalg.jl:1609
  [6] lp_sensitivity_report(model::Model; atol::Float64)
    @ JuMP C:\Users\adow031\.julia\packages\JuMP\vuP7I\src\lp_sensitivity2.jl:93
  [7] lp_sensitivity_report
    @ C:\Users\adow031\.julia\packages\JuMP\vuP7I\src\lp_sensitivity2.jl:63 [inlined
```

I think we should be fine forcing `lu` here; we don't need the special casing for structured matrices. Not sure how to test a case where the `ldlt` was chosen and failed.