### PR TITLE
Tidy import of packages and remove unnecessary prefixes

### DIFF
--- a/src/Containers/Containers.jl
+++ b/src/Containers/Containers.jl
@@ -17,6 +17,8 @@ necessarily integers.
 """
 module Containers
 
+import Base.Meta.isexpr
+
 # Arbitrary typed indices. Linear indexing not supported.
 struct IndexAnyCartesian <: Base.IndexStyle end
 Base.IndexStyle(::IndexAnyCartesian, ::IndexAnyCartesian) = IndexAnyCartesian()

--- a/src/Containers/macro.jl
+++ b/src/Containers/macro.jl
@@ -3,8 +3,6 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using Base.Meta: isexpr
-
 _get_name(c::Union{Symbol,AbstractString}) = c
 
 function _get_name(c::Expr)

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -15,8 +15,6 @@
 # Operator overloads in src/operators.jl
 #############################################################################
 
-import OrderedCollections
-
 function _add_or_set!(dict::OrderedDict{K,V}, k::K, v::V) where {K,V}
     # Adding zero terms to this dictionary leads to unacceptable performance
     # degradations. See, e.g., https://github.com/jump-dev/JuMP.jl/issues/1946.
@@ -528,8 +526,8 @@ function isequal_canonical(
     aff::GenericAffExpr{C,V},
     other::GenericAffExpr{C,V},
 ) where {C,V}
-    aff_nozeros = dropzeros(aff)
-    other_nozeros = dropzeros(other)
+    aff_nozeros = SparseArrays.dropzeros(aff)
+    other_nozeros = SparseArrays.dropzeros(other)
     # Note: This depends on equality of OrderedDicts ignoring order.
     # This is the current behavior, but it seems questionable.
     return isequal(aff_nozeros, other_nozeros)

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -738,7 +738,7 @@ function normalized_coefficient(
     T,
     F<:Union{MOI.ScalarAffineFunction{T},MOI.ScalarQuadraticFunction{T}},
 }
-    con = JuMP.constraint_object(con_ref)
+    con = constraint_object(con_ref)
     return _affine_coefficient(con.func, variable)
 end
 

--- a/src/copy.jl
+++ b/src/copy.jl
@@ -307,7 +307,7 @@ end
 _lift_variable_from_expression(expr) = expr
 
 function _lift_variable_from_expression(expr::Expr)
-    if Meta.isexpr(expr, :ref, 2) && expr.args[1] == :x
+    if isexpr(expr, :ref, 2) && expr.args[1] == :x
         return expr.args[2]
     end
     for i in 1:length(expr.args)
@@ -339,7 +339,7 @@ function _nlp_model_from_nlpblock(block::MOI.NLPBlockData, evaluator)
     model = MOI.Nonlinear.Model()
     for (i, bound) in enumerate(block.constraint_bounds)
         expr = MOI.constraint_expr(evaluator, i)
-        f = Meta.isexpr(expr, :comparison) ? expr.args[3] : expr.args[2]
+        f = isexpr(expr, :comparison) ? expr.args[3] : expr.args[2]
         MOI.Nonlinear.add_constraint(
             model,
             _lift_variable_from_expression(f),

--- a/src/feasibility_checker.jl
+++ b/src/feasibility_checker.jl
@@ -3,8 +3,6 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using LinearAlgebra
-
 function _last_primal_solution(model::Model)
     if !has_values(model)
         error(

--- a/src/lp_sensitivity2.jl
+++ b/src/lp_sensitivity2.jl
@@ -3,9 +3,6 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import SparseArrays
-import LinearAlgebra
-
 """
     SensitivityReport
 

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -11,12 +11,12 @@
 const _JuMPTypes = Union{AbstractJuMPScalar,NonlinearExpression}
 
 _float_type(::Type{<:Real}) = Float64
-_float_type(::Type{UniformScaling{T}}) where {T} = _float_type(T)
+_float_type(::Type{LinearAlgebra.UniformScaling{T}}) where {T} = _float_type(T)
 _float_type(::Type{<:Complex}) = Complex{Float64}
 
 _float(x::Real) = convert(Float64, x)
 _float(x::Complex) = convert(Complex{Float64}, x)
-_float(J::UniformScaling) = _float(J.λ)
+_float(J::LinearAlgebra.UniformScaling) = _float(J.λ)
 
 # Overloads
 #
@@ -303,7 +303,7 @@ end
 Base.:+(lhs::GenericQuadExpr) = lhs
 Base.:-(lhs::GenericQuadExpr) = map_coefficients(-, lhs)
 # GenericQuadExpr--_Constant
-# We don't do `+rhs` as `UniformScaling` does not support unary `+`
+# We don't do `+rhs` as `LinearAlgebra.UniformScaling` does not support unary `+`
 Base.:+(lhs::GenericQuadExpr, rhs::_Constant) = (+)(rhs, lhs)
 Base.:-(lhs::GenericQuadExpr, rhs::_Constant) = (+)(-rhs, lhs)
 Base.:*(lhs::GenericQuadExpr, rhs::_Constant) = (*)(rhs, lhs)

--- a/src/print.jl
+++ b/src/print.jl
@@ -618,7 +618,7 @@ function function_string(
             if j != 1
                 line *= " & "
             end
-            if A isa Symmetric && i > j
+            if A isa LinearAlgebra.Symmetric && i > j
                 line *= "\\cdot"
             else
                 line *= function_string(mode, A[i, j])

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -494,7 +494,7 @@ Base.hash(quad::GenericQuadExpr, h::UInt) = hash(quad.aff, hash(quad.terms, h))
 function SparseArrays.dropzeros(quad::GenericQuadExpr)
     quad_terms = copy(quad.terms)
     _drop_zeros!(quad_terms)
-    return GenericQuadExpr(dropzeros(quad.aff), quad_terms)
+    return GenericQuadExpr(SparseArrays.dropzeros(quad.aff), quad_terms)
 end
 
 # Check if two QuadExprs are equal regardless of the order, and after dropping zeros.
@@ -503,8 +503,8 @@ function isequal_canonical(
     quad::GenericQuadExpr{CoefType,VarType},
     other::GenericQuadExpr{CoefType,VarType},
 ) where {CoefType,VarType}
-    quad_nozeros = dropzeros(quad)
-    other_nozeros = dropzeros(other)
+    quad_nozeros = SparseArrays.dropzeros(quad)
+    other_nozeros = SparseArrays.dropzeros(other)
     return isequal(quad_nozeros, other_nozeros)
 end
 

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -148,7 +148,7 @@ function reshape_vector(
             matrix[j, i] = matrix[i, j] = vectorized_form[k]
         end
     end
-    return Symmetric(matrix)
+    return LinearAlgebra.Symmetric(matrix)
 end
 function reshape_set(
     ::MOI.PositiveSemidefiniteConeTriangle,
@@ -228,14 +228,14 @@ end
 
 # This is a special method because calling `Matrix(matrix)` accesses an undef
 # reference.
-function vectorize(matrix::UpperTriangular, ::SquareMatrixShape)
+function vectorize(matrix::LinearAlgebra.UpperTriangular, ::SquareMatrixShape)
     n = LinearAlgebra.checksquare(matrix)
     return [matrix[i, j] for j in 1:n for i in 1:n]
 end
 
 # This is a special method because calling `Matrix(matrix)` accesses an undef
 # reference.
-function vectorize(matrix::LowerTriangular, ::SquareMatrixShape)
+function vectorize(matrix::LinearAlgebra.LowerTriangular, ::SquareMatrixShape)
     n = LinearAlgebra.checksquare(matrix)
     return [matrix[i, j] for j in 1:n for i in 1:n]
 end
@@ -352,9 +352,11 @@ function value(
 end
 
 """
-    build_constraint(_error::Function, Q::Symmetric{V, M},
-                     ::PSDCone) where {V <: AbstractJuMPScalar,
-                                       M <: AbstractMatrix{V}}
+    build_constraint(
+        _error::Function,
+        Q::LinearAlgebra.Symmetric{V, M},
+        ::PSDCone,
+    ) where {V<:AbstractJuMPScalar,M<:AbstractMatrix{V}}
 
 Return a `VectorConstraint` of shape [`SymmetricMatrixShape`](@ref) constraining
 the matrix `Q` to be positive semidefinite.
@@ -375,7 +377,7 @@ var_psd = @constraint model Q in PSDCone()
 """
 function build_constraint(
     _error::Function,
-    Q::Symmetric{V,M},
+    Q::LinearAlgebra.Symmetric{V,M},
     ::PSDCone,
 ) where {V<:AbstractJuMPScalar,M<:AbstractMatrix{V}}
     n = LinearAlgebra.checksquare(Q)
@@ -553,7 +555,7 @@ end
 """
     build_constraint(
         _error::Function,
-        Q::Hermitian{V,M},
+        Q::LinearAlgebra.Hermitian{V,M},
         ::HermitianPSDCone,
     ) where {V<:AbstractJuMPScalar,M<:AbstractMatrix{V}}
 
@@ -562,12 +564,12 @@ the matrix `Q` to be Hermitian positive semidefinite.
 
 This function is used by the [`@constraint`](@ref) macros as follows:
 ```julia
-@constraint(model, Hermitian(Q) in HermitianPSDCone())
+@constraint(model, LinearAlgebra.Hermitian(Q) in HermitianPSDCone())
 ```
 """
 function build_constraint(
     ::Function,
-    Q::Hermitian{V,M},
+    Q::LinearAlgebra.Hermitian{V,M},
     ::HermitianPSDCone,
 ) where {V<:AbstractJuMPScalar,M<:AbstractMatrix{V}}
     n = LinearAlgebra.checksquare(Q)

--- a/src/solution_summary.jl
+++ b/src/solution_summary.jl
@@ -3,8 +3,6 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import Printf
-
 struct _SolutionSummary
     result::Int
     verbose::Bool


### PR DESCRIPTION
Our imports and prefixes were scattered throughout the source and often conflicted (both `using LinearAlgebra` and `import LinearAlgebra`, and some calls prefixed and some calls not).