### PR TITLE
Adding generator min/max support for NLP

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -5,6 +5,8 @@
 
 _is_sum(s::Symbol) = (s == :sum) || (s == :∑) || (s == :Σ)
 _is_prod(s::Symbol) = (s == :prod) || (s == :∏)
+_is_max(s::Symbol) = (s == :max)
+_is_min(s::Symbol) = (s == :min)
 
 """
     _add_kw_args(call, kw_args)
@@ -1993,9 +1995,14 @@ function _parse_generator_expression(code, x, operators)
     y = gensym()
     y_expr, default = if _is_sum(x.args[1])
         :($y = Expr(:call, :+)), 0
-    else
-        @assert _is_prod(x.args[1])
+    elseif _is_prod(x.args[1])
         :($y = Expr(:call, :*)), 1
+    elseif _is_max(x.args[1])
+        :($y = Expr(:call, :max)), -Inf
+    elseif _is_min(x.args[1])
+        :($y = Expr(:call, :max)), Inf
+    else
+        error("Unsupported generator $(x.args[1]).")
     end
     block = _MA.rewrite_generator(
         x.args[2],

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -5,8 +5,6 @@
 
 _is_sum(s::Symbol) = (s == :sum) || (s == :∑) || (s == :Σ)
 _is_prod(s::Symbol) = (s == :prod) || (s == :∏)
-_is_max(s::Symbol) = (s == :max)
-_is_min(s::Symbol) = (s == :min)
 
 """
     _add_kw_args(call, kw_args)
@@ -1997,12 +1995,12 @@ function _parse_generator_expression(code, x, operators)
         :($y = Expr(:call, :+)), 0
     elseif _is_prod(x.args[1])
         :($y = Expr(:call, :*)), 1
-    elseif _is_max(x.args[1])
+    elseif x.args[1] == :maximum
         :($y = Expr(:call, :max)), -Inf
-    elseif _is_min(x.args[1])
-        :($y = Expr(:call, :max)), Inf
+    elseif x.args[1] == :minimum
+        :($y = Expr(:call, :min)), Inf
     else
-        error("Unsupported generator $(x.args[1]).")
+        error("Unsupported generator `:$(x.args[1])`")
     end
     block = _MA.rewrite_generator(
         x.args[2],

--- a/test/test_nlp.jl
+++ b/test/test_nlp.jl
@@ -372,6 +372,40 @@ function test_parse_prod()
     return
 end
 
+function test_parse_minimum()
+    model = Model()
+    @variable(model, x[1:2])
+    ex = @NLexpression(model, minimum(x[i] for i in 1:2))
+    @test sprint(show, ex) == "subexpression[1]: min(x[1], x[2])"
+    ex2 = @NLexpression(model, minimum(x[i] for i in 1:0))
+    @test sprint(show, ex2) == "subexpression[2]: Inf"
+    return
+end
+
+function test_parse_maximum()
+    model = Model()
+    @variable(model, x[1:2])
+    ex = @NLexpression(model, maximum(x[i] for i in 1:2))
+    @test sprint(show, ex) == "subexpression[1]: max(x[1], x[2])"
+    ex2 = @NLexpression(model, maximum(x[i] for i in 1:0))
+    @test sprint(show, ex2) == "subexpression[2]: -Inf"
+    return
+end
+
+function test_parse_unsupported_generator()
+    model = Model()
+    @variable(model, x[1:2])
+    @test_macro_throws(
+        ErrorException("Unsupported generator `:min`"),
+        @NLexpression(model, min(x[i] for i in 1:2)),
+    )
+    @test_macro_throws(
+        ErrorException("Unsupported generator `:max`"),
+        @NLexpression(model, max(x[i] for i in 1:2)),
+    )
+    return
+end
+
 function test_parse_subexpressions()
     m = Model()
     @variable(m, x)

--- a/test/test_nlp.jl
+++ b/test/test_nlp.jl
@@ -377,8 +377,10 @@ function test_parse_minimum()
     @variable(model, x[1:2])
     ex = @NLexpression(model, minimum(x[i] for i in 1:2))
     @test sprint(show, ex) == "subexpression[1]: min(x[1], x[2])"
-    ex2 = @NLexpression(model, minimum(x[i] for i in 1:0))
-    @test sprint(show, ex2) == "subexpression[2]: Inf"
+    err = ArgumentError(
+        "reducing over an empty collection in `minimum` is not allowed",
+    )
+    @test_throws err @NLexpression(model, minimum(x[i] for i in 1:0))
     return
 end
 
@@ -387,8 +389,10 @@ function test_parse_maximum()
     @variable(model, x[1:2])
     ex = @NLexpression(model, maximum(x[i] for i in 1:2))
     @test sprint(show, ex) == "subexpression[1]: max(x[1], x[2])"
-    ex2 = @NLexpression(model, maximum(x[i] for i in 1:0))
-    @test sprint(show, ex2) == "subexpression[2]: -Inf"
+    err = ArgumentError(
+        "reducing over an empty collection in `maximum` is not allowed",
+    )
+    @test_throws err @NLexpression(model, maximum(x[i] for i in 1:0))
     return
 end
 


### PR DESCRIPTION
`minimum/maximum`, and a multivariate `min/max` do not work for `NLExpressions`. This fixed that for us. Maybe I am also missing something.