### PR TITLE
Add support for generic number type

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -205,7 +205,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Update versions of the documentation (#3185)
  - Tidy the import of packages and remove unnecessary prefixes (#3186) (#3187)
  - Refactor `src/JuMP.jl` by moving methods into more relevant files (#3188)
- - Fix docstring of [`Model`](@ref) not appearing in the documentation (#3198)
+ - Fix docstring of `Model` not appearing in the documentation (#3198)
 
 ## Version 1.6.0 (January 1, 2023)
 

--- a/docs/src/developers/extensions.md
+++ b/docs/src/developers/extensions.md
@@ -339,14 +339,6 @@ julia> function JuMP.add_constraint(
             )
        end
 
-julia> function JuMP.model_convert(model::AbstractModel, rhs::MyConstraint)
-           return MyConstraint(
-                rhs.name,
-                model_convert(model, rhs.f),
-                model_convert(model, rhs.s),
-           )
-       end
-
 julia> @constraint(model, my_con, 2x <= 1, MyTag("my_prefix"))
 my_prefix[my_con] : 2 x - 1 ≤ 0
 ```

--- a/docs/src/developers/extensions.md
+++ b/docs/src/developers/extensions.md
@@ -339,8 +339,16 @@ julia> function JuMP.add_constraint(
             )
        end
 
+julia> function JuMP.model_convert(model::AbstractModel, rhs::MyConstraint)
+           return MyConstraint(
+                rhs.name,
+                model_convert(model, rhs.f),
+                model_convert(model, rhs.s),
+           )
+       end
+
 julia> @constraint(model, my_con, 2x <= 1, MyTag("my_prefix"))
-my_prefix[my_con] : 2 x - 1 ≤ false
+my_prefix[my_con] : 2 x - 1 ≤ 0
 ```
 
 ## The extension dictionary

--- a/docs/src/developers/extensions.md
+++ b/docs/src/developers/extensions.md
@@ -340,7 +340,7 @@ julia> function JuMP.add_constraint(
        end
 
 julia> @constraint(model, my_con, 2x <= 1, MyTag("my_prefix"))
-my_prefix[my_con] : 2 x - 1 ≤ 0
+my_prefix[my_con] : 2 x - 1 ≤ false
 ```
 
 ## The extension dictionary

--- a/docs/src/manual/complex.md
+++ b/docs/src/manual/complex.md
@@ -52,10 +52,10 @@ expression representing each variable:
 
 ```jldoctest complex_variables
 julia> typeof(real(x))
-AffExpr (alias for GenericAffExpr{Float64, VariableRef})
+AffExpr (alias for GenericAffExpr{Float64, GenericVariableRef{Float64}})
 
 julia> typeof(imag(x))
-AffExpr (alias for GenericAffExpr{Float64, VariableRef})
+AffExpr (alias for GenericAffExpr{Float64, GenericVariableRef{Float64}})
 ```
 
 To create an anonymous variable, use the `set` keyword argument:

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -927,7 +927,7 @@ julia> dual_start_value(con)
 julia> set_dual_start_value(con, 2)
 
 julia> dual_start_value(con)
-2.0
+2
 ```
 
 Vector-valued constraints require a vector:

--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -23,7 +23,7 @@ well as which solver to use and even solution information.
 
 ## Create a model
 
-Create a model by passing an optimizer to [`Model`](@ref):
+Create a model by passing an optimizer to [`GenericModel`](@ref):
 ```jldoctest
 julia> model = Model(HiGHS.Optimizer)
 A JuMP Model
@@ -56,7 +56,7 @@ julia> set_optimizer(model, HiGHS.Optimizer)
 ### What is the difference?
 
 For most models, there is no difference between passing the optimizer to
-[`Model`](@ref), and calling [`set_optimizer`](@ref).
+[`GenericModel`](@ref), and calling [`set_optimizer`](@ref).
 
 However, if an optimizer does not support a constraint in the model, the timing
 of when an error will be thrown can differ:
@@ -66,7 +66,7 @@ of when an error will be thrown can differ:
  * If you call [`set_optimizer`](@ref), an error will be thrown when you try to
    solve the model via [`optimize!`](@ref).
 
-Therefore, most users should pass an optimizer to [`Model`](@ref) because it
+Therefore, most users should pass an optimizer to [`GenericModel`](@ref) because it
 provides the earliest warning that your solver is not suitable for the model you
 are trying to build. However, if you are modifying a problem by adding and
 deleting different constraint types, you may need to use
@@ -115,7 +115,7 @@ The list of available solvers, along with the problem types they support, is ava
 
 Some solvers accept (or require) positional arguments such as a license
 environment or a path to a binary executable. For these solvers, you can pass
-a function to [`Model`](@ref) which takes zero arguments and returns an instance
+a function to [`GenericModel`](@ref) which takes zero arguments and returns an instance
 of the optimizer.
 
 A common use-case for this is passing an environment or sub-solver to the
@@ -177,6 +177,26 @@ false
 
 julia> model = Model(solver);
 ```
+
+## Changing the number types
+
+By default, the coefficients of affine and quadratic expressions are numbers
+of type either `Float64` or `Complex{Float64}` (see [Complex number support](@ref)).
+The type `Float64` can be changed using the [`GenericModel`](@ref) type parameter as follows:
+```jldoctest number_type
+julia> model = GenericModel{Rational{BigInt}}();
+
+julia> @variable(model, x)
+x
+
+julia> a = x / 3
+1//3 x
+
+julia> typeof(a)
+GenericAffExpr{Rational{BigInt}, GenericVariableRef{Rational{BigInt}}}
+```
+Note that this should mostly be used if the underlying solver actually solves
+the problem using a number type different from `Float64`.
 
 ## Print the model
 
@@ -416,7 +436,7 @@ reduced_cost(x)  # Works
     want to skip this section. You don't need to know how JuMP manages problems
     behind the scenes to create and solve JuMP models.
 
-A JuMP [`Model`](@ref) is a thin layer around a *backend* of type
+A JuMP [`GenericModel`](@ref) is a thin layer around a *backend* of type
 [`MOI.ModelLike`](@ref) that stores the optimization problem and acts as the
 optimization solver.
 
@@ -424,7 +444,7 @@ However, if you construct a model like `Model(HiGHS.Optimizer)`, the backend is
 not a `HiGHS.Optimizer`, but a more complicated object.
 
 From JuMP, the MOI backend can be accessed using the [`backend`](@ref) function.
-Let's see what the [`backend`](@ref) of a JuMP [`Model`](@ref) is:
+Let's see what the [`backend`](@ref) of a JuMP [`GenericModel`](@ref) is:
 ```jldoctest models_backends
 julia> model = Model(HiGHS.Optimizer);
 
@@ -499,7 +519,7 @@ A `CachingOptimizer` has two modes of operation:
   [`MOIU.attach_optimizer(::JuMP.Model)`](@ref). Attempting to perform
   an operation in the incorrect state results in an error.
 
-By default [`Model`](@ref) will create a `CachingOptimizer` in `AUTOMATIC` mode.
+By default [`GenericModel`](@ref) will create a `CachingOptimizer` in `AUTOMATIC` mode.
 
 ### LazyBridgeOptimizer
 

--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -198,6 +198,10 @@ GenericAffExpr{Rational{BigInt}, GenericVariableRef{Rational{BigInt}}}
 Note that this should mostly be used if the underlying solver actually solves
 the problem using a number type different from `Float64`.
 
+!!! warning
+    [Nonlinear Modeling](@ref) is currently only supported with `Float64` number
+    type.
+
 ## Print the model
 
 By default, `show(model)` will print a summary of the problem:

--- a/docs/src/manual/nlp.md
+++ b/docs/src/manual/nlp.md
@@ -650,7 +650,7 @@ julia> @NLconstraint(model, cons1, sin(x) <= 1);
 julia> @NLconstraint(model, cons2, x + 5 == 10);
 
 julia> typeof(cons1)
-NonlinearConstraintRef{ScalarShape} (alias for ConstraintRef{Model, MathOptInterface.Nonlinear.ConstraintIndex, ScalarShape})
+NonlinearConstraintRef{ScalarShape} (alias for ConstraintRef{GenericModel{Float64}, MathOptInterface.Nonlinear.ConstraintIndex, ScalarShape})
 
 julia> index(cons1)
 MathOptInterface.Nonlinear.ConstraintIndex(1)

--- a/docs/src/manual/variables.md
+++ b/docs/src/manual/variables.md
@@ -44,7 +44,7 @@ julia> @variable(model, x)
 x
 
 julia> typeof(x)
-VariableRef
+VariableRef (alias for GenericVariableRef{Float64})
 
 julia> num_variables(model)
 1
@@ -1230,7 +1230,7 @@ julia> y = Union{VariableRef,AffExpr}[
            j > i ? first(keys(x[i, j].terms)) : x[i, j]
            for i in 1:size(x, 1), j in 1:size(x, 2)
        ]
-2×2 Matrix{Union{VariableRef, AffExpr}}:
+2×2 Matrix{Union{AffExpr, VariableRef}}:
  0        x[1,2]
  -x[1,2]  0
 

--- a/docs/src/reference/extensions.md
+++ b/docs/src/reference/extensions.md
@@ -24,6 +24,7 @@ build_variable
 ```@docs
 build_constraint
 add_constraint
+model_convert
 AbstractShape
 shape
 reshape_vector

--- a/docs/src/reference/models.md
+++ b/docs/src/reference/models.md
@@ -6,7 +6,7 @@ the manual.
 ## Constructors
 
 ```@docs
-Model
+GenericModel
 direct_model
 ```
 
@@ -26,13 +26,14 @@ backend
 unsafe_backend
 name(::AbstractModel)
 solver_name
-Base.empty!(::Model)
-Base.isempty(::Model)
+Base.empty!(::GenericModel)
+Base.isempty(::GenericModel)
 mode
 object_dictionary
 unregister
 latex_formulation
 set_string_names_on_creation
+value_type
 ```
 
 ## Working with attributes
@@ -57,7 +58,7 @@ set_optimizer_attributes
 ## Copying
 
 ```@docs
-ReferenceMap
+GenericReferenceMap
 copy_model
 copy_extension_data
 Base.copy(::AbstractModel)
@@ -66,17 +67,17 @@ Base.copy(::AbstractModel)
 
 ```@docs
 write_to_file
-Base.write(::IO, ::Model; ::MOI.FileFormats.FileFormat)
+Base.write(::IO, ::GenericModel; ::MOI.FileFormats.FileFormat)
 read_from_file
-Base.read(::IO, ::Type{Model}; ::MOI.FileFormats.FileFormat)
+Base.read(::IO, ::Type{GenericModel{T}}; ::MOI.FileFormats.FileFormat) where {T}
 ```
 
 ## Caching Optimizer
 
 ```@docs
-MOIU.reset_optimizer(::JuMP.Model)
-MOIU.drop_optimizer(::JuMP.Model)
-MOIU.attach_optimizer(::JuMP.Model)
+MOIU.reset_optimizer(::JuMP.GenericModel)
+MOIU.drop_optimizer(::JuMP.GenericModel)
+MOIU.attach_optimizer(::JuMP.GenericModel)
 ```
 
 ## Bridge tools

--- a/docs/src/reference/variables.md
+++ b/docs/src/reference/variables.md
@@ -17,8 +17,8 @@ VariableRef
 num_variables
 all_variables
 owner_model
-index(::VariableRef)
-optimizer_index(::VariableRef)
+index(::GenericVariableRef)
+optimizer_index(::GenericVariableRef)
 check_belongs_to_model
 VariableNotOwned
 VariableConstrainedOnCreation

--- a/docs/src/tutorials/getting_started/getting_started_with_JuMP.jl
+++ b/docs/src/tutorials/getting_started/getting_started_with_JuMP.jl
@@ -135,7 +135,7 @@ using JuMP
 using HiGHS
 
 # JuMP builds problems incrementally in a `Model` object. Create a model by
-# passing an optimizer to the [`Model`](@ref) function:
+# passing an optimizer to the [`Model`](@ref GenericModel) function:
 
 model = Model(HiGHS.Optimizer)
 

--- a/docs/src/tutorials/getting_started/performance_tips.jl
+++ b/docs/src/tutorials/getting_started/performance_tips.jl
@@ -57,7 +57,7 @@ using HiGHS  # hide
 # At present, the majority of the latency problems are caused by JuMP's bridging
 # mechanism. If you only use constraints that are natively supported by the
 # solver, you can disable bridges by passing `add_bridges = false` to
-# [`Model`](@ref).
+# [`Model`](@ref GenericModel).
 
 model = Model(HiGHS.Optimizer; add_bridges = false)
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -73,7 +73,17 @@ An abstract type that should be subtyped for users creating JuMP extensions.
 """
 abstract type AbstractModel end
 
-mutable struct Model <: AbstractModel
+"""
+    value_type(::Type{<:Union{AbstractModel,AbstractVariableRef}})
+
+Return the return type of [`value`](@ref) for variables of that model. It
+defaults to `Float64` if it is not implemented.
+"""
+function value_type end
+
+value_type(::Type{<:AbstractModel}) = Float64
+
+mutable struct GenericModel{T} <: AbstractModel
     # In MANUAL and AUTOMATIC modes, CachingOptimizer.
     # In DIRECT mode, will hold an AbstractOptimizer.
     moi_backend::MOI.AbstractOptimizer
@@ -84,7 +94,7 @@ mutable struct Model <: AbstractModel
     # same bridge may be added many times so we store them in a `Set` instead
     # of, e.g., a `Vector`.
     bridge_types::Set{Any}
-    # Hook into a solve call...function of the form f(m::Model; kwargs...),
+    # Hook into a solve call...function of the form f(m::GenericModel; kwargs...),
     # where kwargs get passed along to subsequent solve calls.
     optimize_hook::Any
     # TODO: Document.
@@ -105,7 +115,9 @@ mutable struct Model <: AbstractModel
     set_string_names_on_creation::Bool
 end
 
-function Base.getproperty(model::Model, name::Symbol)
+value_type(::Type{GenericModel{T}}) where {T} = T
+
+function Base.getproperty(model::GenericModel, name::Symbol)
     if name == :nlp_data
         error(
             "The internal field `.nlp_data` was removed from `Model` in JuMP " *
@@ -123,26 +135,29 @@ function Base.getproperty(model::Model, name::Symbol)
 end
 
 """
-    Model()
+    GenericModel{T}()
 
-Return a new JuMP model without any optimizer; the model is stored in
-a cache.
+Return a new JuMP model of value type `T` without any optimizer; the model is
+stored in a cache.
 
 Use [`set_optimizer`](@ref) to set the optimizer before calling
 [`optimize!`](@ref).
 """
-function Model()
+function GenericModel{T}() where {T}
     caching_opt = MOIU.CachingOptimizer(
-        MOIU.UniversalFallback(MOIU.Model{Float64}()),
+        MOIU.UniversalFallback(MOIU.Model{T}()),
         MOIU.AUTOMATIC,
     )
-    return direct_model(caching_opt)
+    return direct_model(caching_opt, T)
 end
 
-"""
-    Model(optimizer_factory; add_bridges::Bool = true)
+const Model = GenericModel{Float64}
 
-Return a new JuMP model with the provided optimizer and bridge settings.
+"""
+    GenericModel{T}(optimizer_factory; add_bridges::Bool = true) where {T}
+
+Return a new JuMP model with the provided optimizer, bridge settings and
+[`value_type`](@ref) `T`.
 
 See [`set_optimizer`](@ref) for the description of the `optimizer_factory` and
 `add_bridges` arguments.
@@ -166,18 +181,21 @@ julia> import MultiObjectiveAlgorithms as MOA
 julia> model = Model(() -> MOA.Optimizer(HiGHS.Optimizer); add_bridges = false);
 ```
 """
-function Model((@nospecialize optimizer_factory); add_bridges::Bool = true)
-    model = Model()
+function GenericModel{T}(
+    (@nospecialize optimizer_factory);
+    add_bridges::Bool = true,
+) where {T}
+    model = GenericModel{T}()
     set_optimizer(model, optimizer_factory; add_bridges = add_bridges)
     return model
 end
 
 """
-    direct_model(backend::MOI.ModelLike)
+    direct_model(backend::MOI.ModelLike, T::Type = Float64)
 
 Return a new JuMP model using [`backend`](@ref) to store the model and solve it.
 
-As opposed to the [`Model`](@ref) constructor, no cache of the model is stored
+As opposed to the [`GenericModel`](@ref) constructor, no cache of the model is stored
 outside of [`backend`](@ref) and no bridges are automatically applied to
 [`backend`](@ref).
 
@@ -188,16 +206,16 @@ in mind the following implications of creating models using this *direct* mode:
 
 * When [`backend`](@ref) does not support an operation, such as modifying
   constraints or adding variables/constraints after solving, an error is
-  thrown. For models created using the [`Model`](@ref) constructor, such
+  thrown. For models created using the [`GenericModel`](@ref) constructor, such
   situations can be dealt with by storing the modifications in a cache and
   loading them into the optimizer when `optimize!` is called.
 * No constraint bridging is supported by default.
 * The optimizer used cannot be changed the model is constructed.
 * The model created cannot be copied.
 """
-function direct_model(backend::MOI.ModelLike)
+function direct_model(backend::MOI.ModelLike, T::Type = Float64)
     @assert MOI.is_empty(backend)
-    return Model(
+    return GenericModel{T}(
         backend,
         Dict{MOI.ConstraintIndex,AbstractShape}(),
         Set{Any}(),
@@ -254,10 +272,10 @@ function direct_model(factory::MOI.OptimizerWithAttributes)
     return direct_model(optimizer)
 end
 
-Base.broadcastable(model::Model) = Ref(model)
+Base.broadcastable(model::GenericModel) = Ref(model)
 
 """
-    backend(model::Model)
+    backend(model::GenericModel)
 
 Return the lower-level MathOptInterface model that sits underneath JuMP. This
 model depends on which operating mode JuMP is in (see [`mode`](@ref)).
@@ -281,10 +299,10 @@ the innermost optimizer, see [`unsafe_backend`](@ref). Alternatively, use
 
 See also: [`unsafe_backend`](@ref).
 """
-backend(model::Model) = model.moi_backend
+backend(model::GenericModel) = model.moi_backend
 
 """
-    unsafe_backend(model::Model)
+    unsafe_backend(model::GenericModel)
 
 Return the innermost optimizer associated with the JuMP model `model`.
 
@@ -375,7 +393,7 @@ julia> highs = backend(model)  # No need to call `attach_optimizer`.
 A HiGHS model with 1 columns and 0 rows.
 ```
 """
-unsafe_backend(model::Model) = unsafe_backend(backend(model))
+unsafe_backend(model::GenericModel) = unsafe_backend(backend(model))
 
 function unsafe_backend(model::MOIU.CachingOptimizer)
     if MOIU.state(model) == MOIU.NO_OPTIMIZER
@@ -400,19 +418,19 @@ function _moi_mode(model::MOIU.CachingOptimizer)
 end
 
 """
-    mode(model::Model)
+    mode(model::GenericModel)
 
 Return the [`ModelMode`](@ref) ([`DIRECT`](@ref), [`AUTOMATIC`](@ref), or
 [`MANUAL`](@ref)) of `model`.
 """
-function mode(model::Model)
+function mode(model::GenericModel)
     # The type of `backend(model)` is not type-stable, so we use a function
     # barrier (`_moi_mode`) to improve performance.
     return _moi_mode(backend(model))
 end
 
 """
-    set_string_names_on_creation(model::Model, value::Bool)
+    set_string_names_on_creation(model::GenericModel, value::Bool)
 
 Set the default argument of the `set_string_name` keyword in the
 [`@variable`](@ref) and [`@constraint`](@ref) macros to `value`. This is used to
@@ -423,12 +441,14 @@ By default, `value` is `true`. However, for larger models calling
 `set_string_names_on_creation(model, false)` can improve performance at the cost
 of reducing the readability of printing and solver log messages.
 """
-function set_string_names_on_creation(model::Model, value::Bool)
+function set_string_names_on_creation(model::GenericModel, value::Bool)
     model.set_string_names_on_creation = value
     return
 end
 
-set_string_names_on_creation(model::Model) = model.set_string_names_on_creation
+function set_string_names_on_creation(model::GenericModel)
+    return model.set_string_names_on_creation
+end
 
 set_string_names_on_creation(::AbstractModel) = true
 
@@ -439,7 +459,7 @@ function _moi_bridge_constraints(model::MOIU.CachingOptimizer)
 end
 
 """
-    bridge_constraints(model::Model)
+    bridge_constraints(model::GenericModel)
 
 When in direct mode, return `false`.
 
@@ -448,7 +468,7 @@ optimizer is set and unsupported constraints are automatically bridged
 to equivalent supported constraints when an appropriate transformation is
 available.
 """
-function bridge_constraints(model::Model)
+function bridge_constraints(model::GenericModel)
     # The type of `backend(model)` is not type-stable, so we use a function
     # barrier (`_moi_bridge_constraints`) to improve performance.
     return _moi_bridge_constraints(backend(model))
@@ -481,7 +501,7 @@ function _moi_call_bridge_function(
 end
 
 """
-     add_bridge(model::Model, BT::Type{<:MOI.Bridges.AbstractBridge})
+     add_bridge(model::AbstractModel, BT::Type{<:MOI.Bridges.AbstractBridge})
 
 Add `BT` to the list of bridges that can be used to transform unsupported
 constraints into an equivalent formulation using only constraints supported by
@@ -489,7 +509,7 @@ the optimizer.
 
 See also: [`remove_bridge`](@ref).
 """
-function add_bridge(model::Model, BT::Type{<:MOI.Bridges.AbstractBridge})
+function add_bridge(model::GenericModel, BT::Type{<:MOI.Bridges.AbstractBridge})
     push!(model.bridge_types, BT)
     _moi_call_bridge_function(
         MOI.Bridges.add_bridge,
@@ -500,7 +520,7 @@ function add_bridge(model::Model, BT::Type{<:MOI.Bridges.AbstractBridge})
 end
 
 """
-     remove_bridge(model::Model, BT::Type{<:MOI.Bridges.AbstractBridge})
+     remove_bridge(model::GenericModel, BT::Type{<:MOI.Bridges.AbstractBridge})
 
 Remove `BT` to the list of bridges that can be used to transform unsupported
 constraints into an equivalent formulation using only constraints supported by
@@ -508,13 +528,12 @@ the optimizer.
 
 See also: [`add_bridge`](@ref).
 """
-function remove_bridge(model::Model, BT::Type{<:MOI.Bridges.AbstractBridge})
+function remove_bridge(
+    model::GenericModel{T},
+    BT::Type{<:MOI.Bridges.AbstractBridge},
+) where {T}
     delete!(model.bridge_types, BT)
-    _moi_call_bridge_function(
-        MOI.Bridges.remove_bridge,
-        backend(model),
-        BT{Float64},
-    )
+    _moi_call_bridge_function(MOI.Bridges.remove_bridge, backend(model), BT{T})
     if mode(model) != DIRECT
         MOI.Utilities.reset_optimizer(model)
     end
@@ -522,7 +541,7 @@ function remove_bridge(model::Model, BT::Type{<:MOI.Bridges.AbstractBridge})
 end
 
 """
-     print_bridge_graph([io::IO,] model::Model)
+     print_bridge_graph([io::IO,] model::GenericModel)
 
 Print the hyper-graph containing all variable, constraint, and objective types
 that could be obtained by bridging the variables, constraints, and objectives
@@ -550,32 +569,32 @@ For more information, see Legat, B., Dowson, O., Garcia, J., and Lubin, M.
 (2020).  "MathOptInterface: a data structure for mathematical optimization
 problems." URL: [https://arxiv.org/abs/2002.03447](https://arxiv.org/abs/2002.03447)
 """
-function print_bridge_graph(io::IO, model::Model)
+function print_bridge_graph(io::IO, model::GenericModel)
     return _moi_call_bridge_function(backend(model)) do m
         return MOI.Bridges.print_graph(io, m)
     end
 end
 
-print_bridge_graph(model::Model) = print_bridge_graph(Base.stdout, model)
+print_bridge_graph(model::GenericModel) = print_bridge_graph(Base.stdout, model)
 
 """
-    print_active_bridges([io::IO = stdout,] model::Model)
+    print_active_bridges([io::IO = stdout,] model::GenericModel)
 
 Print a list of the variable, constraint, and objective bridges that are
 currently used in the model.
 """
-function print_active_bridges(io::IO, model::Model)
+function print_active_bridges(io::IO, model::GenericModel)
     return _moi_call_bridge_function(backend(model)) do m
         return MOI.Bridges.print_active_bridges(io, m)
     end
 end
 
 """
-    print_active_bridges([io::IO = stdout,] model::Model, ::Type{F}) where {F}
+    print_active_bridges([io::IO = stdout,] model::GenericModel, ::Type{F}) where {F}
 
 Print a list of bridges required for an objective function of type `F`.
 """
-function print_active_bridges(io::IO, model::Model, ::Type{F}) where {F}
+function print_active_bridges(io::IO, model::GenericModel, ::Type{F}) where {F}
     return _moi_call_bridge_function(backend(model)) do m
         return MOI.Bridges.print_active_bridges(io, m, moi_function_type(F))
     end
@@ -584,7 +603,7 @@ end
 """
     print_active_bridges(
         [io::IO = stdout,]
-        model::Model,
+        model::GenericModel,
         F::Type,
         S::Type{<:MOI.AbstractSet},
     )
@@ -593,7 +612,7 @@ Print a list of bridges required for a constraint of type `F`-in-`S`.
 """
 function print_active_bridges(
     io::IO,
-    model::Model,
+    model::GenericModel,
     F::Type,
     S::Type{<:MOI.AbstractSet},
 )
@@ -605,31 +624,35 @@ end
 """
     print_active_bridges(
         [io::IO = stdout,]
-        model::Model,
+        model::GenericModel,
         S::Type{<:MOI.AbstractSet},
     )
 
 Print a list of bridges required to add a variable constrained to the set `S`.
 """
-function print_active_bridges(io::IO, model::Model, S::Type{<:MOI.AbstractSet})
+function print_active_bridges(
+    io::IO,
+    model::GenericModel,
+    S::Type{<:MOI.AbstractSet},
+)
     return _moi_call_bridge_function(backend(model)) do m
         return MOI.Bridges.print_active_bridges(io, m, S)
     end
 end
 
-function print_active_bridges(model::Model, args...)
+function print_active_bridges(model::GenericModel, args...)
     return print_active_bridges(Base.stdout, model, args...)
 end
 
 """
-    empty!(model::Model)::Model
+    empty!(model::GenericModel)::GenericModel
 
 Empty the model, that is, remove all variables, constraints and model
 attributes but not optimizer attributes. Always return the argument.
 
 Note: removes extensions data.
 """
-function Base.empty!(model::Model)::Model
+function Base.empty!(model::GenericModel)::GenericModel
     # The method changes the Model object to, basically, the state it was when
     # created (if the optimizer was already pre-configured). The exceptions
     # are:
@@ -649,13 +672,13 @@ function Base.empty!(model::Model)::Model
 end
 
 """
-    isempty(model::Model)
+    isempty(model::GenericModel)
 
 Verifies whether the model is empty, that is, whether the MOI backend
 is empty and whether the model is in the same state as at its creation
 apart from optimizer attributes.
 """
-function Base.isempty(model::Model)
+function Base.isempty(model::GenericModel)
     return MOI.is_empty(model.moi_backend) &&
            isempty(model.shapes) &&
            model.nlp_model === nothing &&
@@ -665,7 +688,7 @@ function Base.isempty(model::Model)
 end
 
 """
-    object_dictionary(model::Model)
+    object_dictionary(model::GenericModel)
 
 Return the dictionary that maps the symbol name of a variable, constraint, or
 expression to the corresponding object.
@@ -676,10 +699,10 @@ For example, `@variable(model, x[1:2, 1:2])` registers the array of variables
 
 This method should be defined for any subtype of `AbstractModel`.
 """
-object_dictionary(model::Model) = model.obj_dict
+object_dictionary(model::GenericModel) = model.obj_dict
 
 """
-    unregister(model::Model, key::Symbol)
+    unregister(model::GenericModel, key::Symbol)
 
 Unregister the name `key` from `model` so that a new variable, constraint, or
 expression can be created with the same key.
@@ -771,11 +794,11 @@ function Base.haskey(model::AbstractModel, name::Symbol)
 end
 
 """
-    set_optimize_hook(model::Model, f::Union{Function,Nothing})
+    set_optimize_hook(model::GenericModel, f::Union{Function,Nothing})
 
 Set the function `f` as the optimize hook for `model`.
 
-`f` should have a signature `f(model::Model; kwargs...)`, where the `kwargs` are
+`f` should have a signature `f(model::GenericModel; kwargs...)`, where the `kwargs` are
 those passed to [`optimize!`](@ref).
 
 ## Notes
@@ -809,7 +832,7 @@ Stacktrace:
 [...]
 ```
 """
-set_optimize_hook(model::Model, f) = (model.optimize_hook = f)
+set_optimize_hook(model::GenericModel, f) = (model.optimize_hook = f)
 
 """
     AbstractJuMPScalar <: MutableArithmetics.AbstractMutable

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -79,8 +79,6 @@ abstract type AbstractModel end
 Return the return type of [`value`](@ref) for variables of that model. It
 defaults to `Float64` if it is not implemented.
 """
-function value_type end
-
 value_type(::Type{<:AbstractModel}) = Float64
 
 mutable struct GenericModel{T} <: AbstractModel

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -123,12 +123,16 @@ mutable struct GenericAffExpr{CoefType,VarType} <: AbstractJuMPScalar
 end
 
 """
-    variable_ref_type(::GenericAffExpr{C, V}) where {C, V}
+    variable_ref_type(::Union{GenericAffExpr{C,V},Type{GenericAffExpr{C,V}}}) where {C,V}
 
 A helper function used internally by JuMP and some JuMP extensions. Returns the
 variable type `V` from a [`GenericAffExpr`](@ref)
 """
-variable_ref_type(::GenericAffExpr{C,V}) where {C,V} = V
+function variable_ref_type(
+    ::Union{GenericAffExpr{C,V},Type{GenericAffExpr{C,V}}},
+) where {C,V}
+    return V
+end
 
 """
     GenericAffExpr(constant::V, kv::AbstractArray{Pair{K,V}}) where {K,V}
@@ -418,8 +422,8 @@ typically much more efficient than `expression += (*)(terms...)`. For example,
 
 Only a few methods are defined, mostly for internal use, and only for the cases
 when (1) they can be implemented efficiently and (2) `expression` is capable of
-storing the result. For example, `add_to_expression!(::AffExpr, ::VariableRef,
-::VariableRef)` is not defined because a `GenericAffExpr` cannot store the
+storing the result. For example, `add_to_expression!(::AffExpr, ::GenericVariableRef,
+::GenericVariableRef)` is not defined because a `GenericAffExpr` cannot store the
 product of two variables.
 """
 function add_to_expression! end
@@ -629,7 +633,9 @@ end
 # Note: No validation is performed that the variables in the AffExpr belong to
 # the same model. The verification is done in `check_belongs_to_model` which
 # should be called before calling `MOI.ScalarAffineFunction`.
-function MOI.ScalarAffineFunction(a::GenericAffExpr{C,VariableRef}) where {C}
+function MOI.ScalarAffineFunction(
+    a::GenericAffExpr{C,<:GenericVariableRef},
+) where {C}
     _assert_isfinite(a)
     terms = MOI.ScalarAffineTerm{C}[
         MOI.ScalarAffineTerm(t[1], index(t[2])) for t in linear_terms(a)
@@ -679,41 +685,55 @@ function moi_function_type(::Type{<:GenericAffExpr{T}}) where {T}
     return MOI.ScalarAffineFunction{T}
 end
 
-function GenericAffExpr{C,VariableRef}(
-    m::Model,
+function GenericAffExpr{C,GenericVariableRef{T}}(
+    m::GenericModel{T},
     f::MOI.ScalarAffineFunction,
-) where {C}
-    aff = GenericAffExpr{C,VariableRef}(f.constant)
+) where {C,T}
+    aff = GenericAffExpr{C,GenericVariableRef{T}}(f.constant)
     for t in f.terms
-        add_to_expression!(aff, t.coefficient, VariableRef(m, t.variable))
+        add_to_expression!(
+            aff,
+            t.coefficient,
+            GenericVariableRef(m, t.variable),
+        )
     end
     return aff
 end
 
 function jump_function_type(
-    ::Model,
-    ::Type{MOI.ScalarAffineFunction{T}},
-) where {T}
-    return GenericAffExpr{T,VariableRef}
+    ::GenericModel{T},
+    ::Type{MOI.ScalarAffineFunction{C}},
+) where {C,T}
+    return GenericAffExpr{C,GenericVariableRef{T}}
 end
 
-function jump_function(model::Model, f::MOI.ScalarAffineFunction{T}) where {T}
-    return GenericAffExpr{T,VariableRef}(model, f)
+function jump_function(
+    model::GenericModel{T},
+    f::MOI.ScalarAffineFunction{C},
+) where {C,T}
+    return GenericAffExpr{C,GenericVariableRef{T}}(model, f)
 end
 
 function jump_function_type(
-    ::Model,
-    ::Type{MOI.VectorAffineFunction{T}},
-) where {T}
-    return Vector{GenericAffExpr{T,VariableRef}}
+    ::GenericModel{T},
+    ::Type{MOI.VectorAffineFunction{C}},
+) where {C,T}
+    return Vector{GenericAffExpr{C,GenericVariableRef{T}}}
 end
 
-function jump_function(model::Model, f::MOI.VectorAffineFunction{T}) where {T}
-    ret = GenericAffExpr{T,VariableRef}[]
+function jump_function(
+    model::GenericModel{T},
+    f::MOI.VectorAffineFunction{C},
+) where {T,C}
+    ret = GenericAffExpr{C,GenericVariableRef{T}}[]
     for scalar_f in MOIU.eachscalar(f)
-        g = GenericAffExpr{T,VariableRef}(scalar_f.constant)
+        g = GenericAffExpr{C,GenericVariableRef{T}}(scalar_f.constant)
         for t in scalar_f.terms
-            add_to_expression!(g, t.coefficient, VariableRef(model, t.variable))
+            add_to_expression!(
+                g,
+                t.coefficient,
+                GenericVariableRef(model, t.variable),
+            )
         end
         push!(ret, g)
     end
@@ -750,8 +770,8 @@ function _fill_vaf!(
 end
 
 function MOI.VectorAffineFunction(
-    affs::Vector{GenericAffExpr{C,VariableRef}},
-) where {C}
+    affs::Vector{GenericAffExpr{C,GenericVariableRef{T}}},
+) where {C,T}
     len = 0
     for aff in affs
         len += length(linear_terms(aff))

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -9,12 +9,12 @@
 #############################################################################
 
 """
-    callback_node_status(cb_data, model::Model)
+    callback_node_status(cb_data, model::GenericModel)
 
 Return an [`MOI.CallbackNodeStatusCode`](@ref) enum, indicating if the current
 primal solution available from [`callback_value`](@ref) is integer feasible.
 """
-function callback_node_status(cb_data, model::Model)
+function callback_node_status(cb_data, model::GenericModel)
     # TODO(odow):
     # MOI defines `is_set_by_optimize(::CallbackNodeStatus) = true`.
     # This causes problems for JuMP because it checks the termination_status to
@@ -28,14 +28,14 @@ function callback_node_status(cb_data, model::Model)
 end
 
 """
-    callback_value(cb_data, x::VariableRef)
+    callback_value(cb_data, x::GenericVariableRef)
 
 Return the primal solution of a variable inside a callback.
 
 `cb_data` is the argument to the callback function, and the type is dependent on
 the solver.
 """
-function callback_value(cb_data, x::VariableRef)
+function callback_value(cb_data, x::GenericVariableRef)
     # TODO(odow):
     # MOI defines `is_set_by_optimize(::CallbackVariablePrimal) = true`.
     # This causes problems for JuMP because it checks the termination_status to
@@ -67,24 +67,28 @@ function callback_value(cb_data, expr::Union{GenericAffExpr,GenericQuadExpr})
     end
 end
 
-function MOI.submit(model::Model, cb::MOI.LazyConstraint, con::ScalarConstraint)
+function MOI.submit(
+    model::GenericModel,
+    cb::MOI.LazyConstraint,
+    con::ScalarConstraint,
+)
     return MOI.submit(backend(model), cb, moi_function(con.func), con.set)
 end
 
-function MOI.submit(model::Model, cb::MOI.UserCut, con::ScalarConstraint)
+function MOI.submit(model::GenericModel, cb::MOI.UserCut, con::ScalarConstraint)
     return MOI.submit(backend(model), cb, moi_function(con.func), con.set)
 end
 
 function MOI.submit(
-    model::Model,
+    model::GenericModel{T},
     cb::MOI.HeuristicSolution,
-    variables::Vector{VariableRef},
+    variables::Vector{GenericVariableRef{T}},
     values::Vector{<:Real},
-)
+) where {T}
     return MOI.submit(
         backend(model),
         cb,
         index.(variables),
-        convert(Vector{Float64}, values),
+        convert(Vector{T}, values),
     )
 end

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -577,10 +577,8 @@ representing the function and the `set` field contains the MOI set.
 See also the [documentation](@ref Constraints) on JuMP's representation of
 constraints for more background.
 """
-struct ScalarConstraint{
-    F<:Union{Number,AbstractJuMPScalar},
-    S<:MOI.AbstractScalarSet,
-} <: AbstractConstraint
+struct ScalarConstraint{F<:AbstractJuMPScalar,S<:MOI.AbstractScalarSet} <:
+       AbstractConstraint
     func::F
     set::S
 end
@@ -614,7 +612,7 @@ See also the [documentation](@ref Constraints) on JuMP's representation of
 constraints.
 """
 struct VectorConstraint{
-    F<:Union{Number,AbstractJuMPScalar},
+    F<:AbstractJuMPScalar,
     S<:MOI.AbstractVectorSet,
     Shape<:AbstractShape,
 } <: AbstractConstraint
@@ -1472,10 +1470,10 @@ end
 
 """
     relax_with_penalty!(
-        model::GenericModel,
-        [penalties::Dict{ConstraintRef,Float64}];
+        model::GenericModel{T},
+        [penalties::Dict{ConstraintRef,T}];
         [default::Union{Nothing,Real} = nothing,]
-    )
+    ) where {T}
 
 Destructively modify the model in-place to create a penalized relaxation of the
 constraints.

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -1068,7 +1068,7 @@ See also: [`result_count`](@ref), [`shadow_price`](@ref).
 function dual(
     con_ref::ConstraintRef{M,<:MOI.ConstraintIndex};
     result::Int = 1,
-) where {M}
+) where {M<:AbstractModel}
     return reshape_vector(
         _constraint_dual(con_ref, result, value_type(M)),
         dual_shape(con_ref.shape),

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -994,7 +994,7 @@ evaluation of `2x + 3y`.
 function value(
     con_ref::ConstraintRef{M,<:MOI.ConstraintIndex};
     result::Int = 1,
-) where {M}
+) where {M<:AbstractModel}
     return reshape_vector(
         _constraint_primal(con_ref, result, value_type(M)),
         con_ref.shape,

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -577,8 +577,10 @@ representing the function and the `set` field contains the MOI set.
 See also the [documentation](@ref Constraints) on JuMP's representation of
 constraints for more background.
 """
-struct ScalarConstraint{F<:Union{Number,AbstractJuMPScalar},S<:MOI.AbstractScalarSet} <:
-       AbstractConstraint
+struct ScalarConstraint{
+    F<:Union{Number,AbstractJuMPScalar},
+    S<:MOI.AbstractScalarSet,
+} <: AbstractConstraint
     func::F
     set::S
 end

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -577,7 +577,7 @@ representing the function and the `set` field contains the MOI set.
 See also the [documentation](@ref Constraints) on JuMP's representation of
 constraints for more background.
 """
-struct ScalarConstraint{F<:AbstractJuMPScalar,S<:MOI.AbstractScalarSet} <:
+struct ScalarConstraint{F<:Union{Number,AbstractJuMPScalar},S<:MOI.AbstractScalarSet} <:
        AbstractConstraint
     func::F
     set::S
@@ -612,7 +612,7 @@ See also the [documentation](@ref Constraints) on JuMP's representation of
 constraints.
 """
 struct VectorConstraint{
-    F<:AbstractJuMPScalar,
+    F<:Union{Number,AbstractJuMPScalar},
     S<:MOI.AbstractVectorSet,
     Shape<:AbstractShape,
 } <: AbstractConstraint

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -693,6 +693,7 @@ function add_constraint(
     con::AbstractConstraint,
     name::String = "",
 )
+    con = model_convert(model, con)
     # The type of backend(model) is unknown so we directly redirect to another
     # function.
     check_belongs_to_model(con, model)

--- a/src/copy.jl
+++ b/src/copy.jl
@@ -29,26 +29,28 @@ function copy_extension_data(data, ::AbstractModel, ::AbstractModel)
 end
 
 """
-    ReferenceMap
+    GenericReferenceMap{T}
 
 Mapping between variable and constraint reference of a model and its copy. The
 reference of the copied model can be obtained by indexing the map with the
 reference of the corresponding reference of the original model.
 """
-struct ReferenceMap
-    model::Model
+struct GenericReferenceMap{T}
+    model::GenericModel{T}
     index_map::MOIU.IndexMap
 end
 
-function Base.getindex(map::ReferenceMap, vref::VariableRef)
+const ReferenceMap = GenericReferenceMap{Float64}
+
+function Base.getindex(map::GenericReferenceMap, vref::GenericVariableRef)
     return VariableRef(map.model, map.index_map[index(vref)])
 end
 
-function Base.getindex(map::ReferenceMap, cref::ConstraintRef)
+function Base.getindex(map::GenericReferenceMap, cref::ConstraintRef)
     return ConstraintRef(map.model, map.index_map[index(cref)], cref.shape)
 end
 
-function Base.getindex(map::ReferenceMap, expr::GenericAffExpr)
+function Base.getindex(map::GenericReferenceMap, expr::GenericAffExpr)
     result = zero(expr)
     for (coef, var) in linear_terms(expr)
         add_to_expression!(result, coef, map[var])
@@ -57,7 +59,7 @@ function Base.getindex(map::ReferenceMap, expr::GenericAffExpr)
     return result
 end
 
-function Base.getindex(map::ReferenceMap, expr::GenericQuadExpr)
+function Base.getindex(map::GenericReferenceMap, expr::GenericQuadExpr)
     aff = map[expr.aff]
     terms = [
         UnorderedPair(map[key.a], map[key.b]) => val for
@@ -66,9 +68,11 @@ function Base.getindex(map::ReferenceMap, expr::GenericQuadExpr)
     return GenericQuadExpr(aff, terms)
 end
 
-Base.getindex(map::ReferenceMap, val::AbstractArray) = getindex.(map, val)
+function Base.getindex(map::GenericReferenceMap, val::AbstractArray)
+    return getindex.(map, val)
+end
 
-Base.broadcastable(reference_map::ReferenceMap) = Ref(reference_map)
+Base.broadcastable(reference_map::GenericReferenceMap) = Ref(reference_map)
 
 # Return a Boolean if the filtering function (1st argument) indicates that the whole value should
 # be copied over.
@@ -87,13 +91,13 @@ function _should_copy_complete_object(
 end # all(filter_constraints.(value))
 
 """
-    copy_model(model::Model; filter_constraints::Union{Nothing, Function}=nothing)
+    copy_model(model::GenericModel; filter_constraints::Union{Nothing, Function}=nothing)
 
-Return a copy of the model `model` and a [`ReferenceMap`](@ref) that can be used
-to obtain the variable and constraint reference of the new model corresponding
-to a given `model`'s reference. A [`Base.copy(::AbstractModel)`](@ref) method
-has also been implemented, it is similar to `copy_model` but does not return
-the reference map.
+Return a copy of the model `model` and a [`GenericReferenceMap`](@ref) that can
+be used to obtain the variable and constraint reference of the new model
+corresponding to a given `model`'s reference. A
+[`Base.copy(::AbstractModel)`](@ref) method has also been implemented, it is
+similar to `copy_model` but does not return the reference map.
 
 If the `filter_constraints` argument is given, only the constraints for which
 this function returns `true` will be copied. This function is given a
@@ -102,7 +106,7 @@ constraint reference as argument.
 ## Note
 
 Model copy is not supported in `DIRECT` mode, i.e. when a model is constructed
-using the [`direct_model`](@ref) constructor instead of the [`Model`](@ref)
+using the [`direct_model`](@ref) constructor instead of the [`GenericModel`](@ref)
 constructor. Moreover, independently on whether an optimizer was provided at
 model construction, the new model will have no optimizer, i.e., an optimizer
 will have to be provided to the new model in the [`optimize!`](@ref) call.
@@ -132,7 +136,7 @@ cref : x = 2.0
 ```
 """
 function copy_model(
-    model::Model;
+    model::GenericModel;
     filter_constraints::Union{Nothing,Function} = nothing,
 )
     if mode(model) == DIRECT
@@ -168,7 +172,7 @@ function copy_model(
         )
     end
 
-    reference_map = ReferenceMap(new_model, index_map)
+    reference_map = GenericReferenceMap(new_model, index_map)
 
     for (name, value) in object_dictionary(model)
         if _should_copy_complete_object(filter_constraints, value)
@@ -206,7 +210,7 @@ and its copy.
 ## Note
 
 Model copy is not supported in `DIRECT` mode, i.e. when a model is constructed
-using the [`direct_model`](@ref) constructor instead of the [`Model`](@ref)
+using the [`direct_model`](@ref) constructor instead of the [`GenericModel`](@ref)
 constructor. Moreover, independently on whether an optimizer was provided at
 model construction, the new model will have no optimizer, i.e., an optimizer
 will have to be provided to the new model in the [`optimize!`](@ref) call.
@@ -241,11 +245,12 @@ function Base.copy(model::AbstractModel)
 end
 
 """
-    copy_conflict(model::Model)
+    copy_conflict(model::GenericModel)
 
 Return a copy of the current conflict for the model `model` and a
-[`ReferenceMap`](@ref) that can be used to obtain the variable and constraint
-reference of the new model corresponding to a given `model`'s reference.
+[`GenericReferenceMap`](@ref) that can be used to obtain the variable and
+constraint reference of the new model corresponding to a given `model`'s
+reference.
 
 This is a convenience function that provides a filtering function for
 [`copy_model`](@ref).
@@ -253,7 +258,7 @@ This is a convenience function that provides a filtering function for
 ## Note
 
 Model copy is not supported in `DIRECT` mode, i.e. when a model is constructed
-using the [`direct_model`](@ref) constructor instead of the [`Model`](@ref)
+using the [`direct_model`](@ref) constructor instead of the [`GenericModel`](@ref)
 constructor. Moreover, independently on whether an optimizer was provided at
 model construction, the new model will have no optimizer, i.e., an optimizer
 will have to be provided to the new model in the [`optimize!`](@ref) call.
@@ -298,7 +303,7 @@ Subject to
  c2 : x ≤ 1.0
 ```
 """
-function copy_conflict(model::Model)
+function copy_conflict(model::GenericModel)
     filter_constraints =
         (cref) ->
             MOI.get(model, MOI.ConstraintConflictStatus(), cref) !=
@@ -311,13 +316,13 @@ end
 # Calling `deepcopy` over a JuMP model is not supported, nor planned to be
 # supported, because it would involve making a deep copy of the underlying
 # solver (behind a C pointer).
-function Base.deepcopy(::Model)
+function Base.deepcopy(::GenericModel)
     return error(
         "`JuMP.Model` does not support `deepcopy` as the reference to the underlying solver cannot be deep copied, use `copy` instead.",
     )
 end
 
-function MOI.copy_to(dest::MOI.ModelLike, src::Model)
+function MOI.copy_to(dest::MOI.ModelLike, src::GenericModel)
     if nonlinear_model(src) !== nothing
         # Re-set the NLP block in-case things have changed since last
         # solve.
@@ -331,7 +336,7 @@ function MOI.copy_to(dest::MOI.ModelLike, src::Model)
     return MOI.copy_to(dest, backend(src))
 end
 
-function MOI.copy_to(dest::Model, src::MOI.ModelLike)
+function MOI.copy_to(dest::GenericModel, src::MOI.ModelLike)
     index_map = MOI.copy_to(backend(dest), src)
     if MOI.NLPBlock() in MOI.get(src, MOI.ListOfModelAttributesSet())
         block = MOI.get(src, MOI.NLPBlock())

--- a/src/feasibility_checker.jl
+++ b/src/feasibility_checker.jl
@@ -74,7 +74,7 @@ end
 """
     primal_feasibility_report(
         point::Function,
-        model::GenericModel{t};
+        model::GenericModel{T};
         atol::T = zero(T),
         skip_missing::Bool = false,
     ) where {T}

--- a/src/feasibility_checker.jl
+++ b/src/feasibility_checker.jl
@@ -3,7 +3,7 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-function _last_primal_solution(model::Model)
+function _last_primal_solution(model::GenericModel)
     if !has_values(model)
         error(
             "No primal solution is available. You must provide a point at " *
@@ -15,11 +15,11 @@ end
 
 """
     primal_feasibility_report(
-        model::Model,
-        point::AbstractDict{VariableRef,Float64} = _last_primal_solution(model),
-        atol::Float64 = 0.0,
+        model::GenericModel{T},
+        point::AbstractDict{GenericVariableRef{T},T} = _last_primal_solution(model),
+        atol::T = zero(T),
         skip_missing::Bool = false,
-    )::Dict{Any,Float64}
+    )::Dict{Any,T}
 
 Given a dictionary `point`, which maps variables to primal values, return a
 dictionary whose keys are the constraints with an infeasibility greater than the
@@ -50,11 +50,11 @@ Dict{Any,Float64} with 1 entry:
 ```
 """
 function primal_feasibility_report(
-    model::Model,
-    point::AbstractDict{VariableRef,Float64} = _last_primal_solution(model);
-    atol::Float64 = 0.0,
+    model::GenericModel{T},
+    point::AbstractDict{GenericVariableRef{T},T} = _last_primal_solution(model);
+    atol::T = zero(T),
     skip_missing::Bool = false,
-)
+) where {T}
     return primal_feasibility_report(
         model;
         atol = atol,
@@ -74,10 +74,10 @@ end
 """
     primal_feasibility_report(
         point::Function,
-        model::Model;
-        atol::Float64 = 0.0,
+        model::GenericModel{t};
+        atol::T = zero(T),
         skip_missing::Bool = false,
-    )
+    ) where {T}
 
 A form of `primal_feasibility_report` where a function is passed as the first
 argument instead of a dictionary as the second argument.
@@ -98,11 +98,11 @@ Dict{Any,Float64} with 1 entry:
 """
 function primal_feasibility_report(
     point::Function,
-    model::Model;
-    atol::Float64 = 0.0,
+    model::GenericModel{T};
+    atol::T = zero(T),
     skip_missing::Bool = false,
-)
-    violated_constraints = Dict{Any,Float64}()
+) where {T}
+    violated_constraints = Dict{Any,T}()
     for (F, S) in list_of_constraint_types(model)
         _add_infeasible_constraints(
             model,
@@ -131,16 +131,16 @@ function primal_feasibility_report(
 end
 
 function _add_infeasible_constraints(
-    model::Model,
+    model::GenericModel{T},
     ::Type{F},
     ::Type{S},
-    violated_constraints::Dict{Any,Float64},
+    violated_constraints::Dict{Any,T},
     point_f::Function,
-    atol::Float64,
-) where {F,S}
+    atol::T,
+) where {T,F,S}
     for con in all_constraints(model, F, S)
         obj = constraint_object(con)
-        d = _distance_to_set(value.(point_f, obj.func), obj.set)
+        d = _distance_to_set(value.(point_f, obj.func), obj.set, T)
         if d > atol
             violated_constraints[con] = d
         end
@@ -149,17 +149,17 @@ function _add_infeasible_constraints(
 end
 
 function _add_infeasible_nonlinear_constraints(
-    model::Model,
-    violated_constraints::Dict{Any,Float64},
+    model::GenericModel{T},
+    violated_constraints::Dict{Any,T},
     point_f::Function,
-    atol::Float64,
-)
+    atol::T,
+) where {T}
     evaluator = NLPEvaluator(model)
     MOI.initialize(evaluator, Symbol[])
     g = zeros(num_nonlinear_constraints(model))
     MOI.eval_constraint(evaluator, g, point_f.(all_variables(model)))
     for (i, (index, constraint)) in enumerate(evaluator.model.constraints)
-        d = _distance_to_set(g[i], constraint.set)
+        d = _distance_to_set(g[i], constraint.set, T)
         if d > atol
             cref = ConstraintRef(model, index, ScalarShape())
             violated_constraints[cref] = d
@@ -168,5 +168,5 @@ function _add_infeasible_nonlinear_constraints(
     return
 end
 
-_distance_to_set(::Missing, set) = 0.0
-_distance_to_set(point, set) = MOI.Utilities.distance_to_set(point, set)
+_distance_to_set(::Missing, set, ::Type{T}) where {T} = zero(T)
+_distance_to_set(point, set, ::Type) = MOI.Utilities.distance_to_set(point, set)

--- a/src/file_formats.jl
+++ b/src/file_formats.jl
@@ -14,8 +14,8 @@ end
 
 _throw_write_to_file_explanatory_message(err) = rethrow(err)
 
-function _copy_to_bridged_model(f::Function, model::Model)
-    inner = MOI.instantiate(f; with_bridge_type = Float64)
+function _copy_to_bridged_model(f::Function, model::GenericModel{T}) where {T}
+    inner = MOI.instantiate(f; with_bridge_type = T)
     try
         MOI.copy_to(inner, model)
     catch err
@@ -30,7 +30,7 @@ end
 
 """
     write_to_file(
-        model::Model,
+        model::GenericModel,
         filename::String;
         format::MOI.FileFormats.FileFormat = MOI.FileFormats.FORMAT_AUTOMATIC,
         kwargs...,
@@ -44,7 +44,7 @@ If the filename ends in `.bz2`, it will be compressed using BZip2.
 Other `kwargs` are passed to the `Model` constructor of the chosen format.
 """
 function write_to_file(
-    model::Model,
+    model::GenericModel,
     filename::String;
     format::MOI.FileFormats.FileFormat = MOI.FileFormats.FORMAT_AUTOMATIC,
     kwargs...,
@@ -63,7 +63,7 @@ end
 """
     Base.write(
         io::IO,
-        model::Model;
+        model::GenericModel;
         format::MOI.FileFormats.FileFormat = MOI.FileFormats.FORMAT_MOF,
         kwargs...,
     )
@@ -74,7 +74,7 @@ Other `kwargs` are passed to the `Model` constructor of the chosen format.
 """
 function Base.write(
     io::IO,
-    model::Model;
+    model::GenericModel;
     format::MOI.FileFormats.FileFormat = MOI.FileFormats.FORMAT_MOF,
     kwargs...,
 )
@@ -118,7 +118,7 @@ end
 """
     Base.read(
         io::IO,
-        ::Type{Model};
+        ::Type{<:GenericModel};
         format::MOI.FileFormats.FileFormat,
         kwargs...,
     )
@@ -129,16 +129,16 @@ Other `kwargs` are passed to the `Model` constructor of the chosen format.
 """
 function Base.read(
     io::IO,
-    ::Type{Model};
+    ::Type{GenericModel{T}};
     format::MOI.FileFormats.FileFormat,
     kwargs...,
-)
+) where {T}
     if format == MOI.FileFormats.FORMAT_AUTOMATIC
         error("Unable to infer the file format from an IO stream.")
     end
     src = MOI.FileFormats.Model(; format = format, kwargs...)
     read!(io, src)
-    model = Model()
+    model = GenericModel{T}()
     MOI.copy_to(model, src)
     return model
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -724,6 +724,7 @@ function _clear_constant!(expr::Union{GenericAffExpr,GenericQuadExpr})
     add_to_expression!(expr, -offset)
     return expr, offset
 end
+
 function _clear_constant!(α::Number)
     return zero(α), α
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -728,6 +728,7 @@ end
 function _clear_constant!(α::Number)
     return zero(α), α
 end
+
 function build_constraint(
     ::Function,
     expr::Union{Number,GenericAffExpr,GenericQuadExpr},

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -718,6 +718,7 @@ function build_constraint(
 )
     return ScalarConstraint(v, set)
 end
+
 function _clear_constant!(expr::Union{GenericAffExpr,GenericQuadExpr})
     offset = constant(expr)
     add_to_expression!(expr, -offset)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -878,6 +878,31 @@ function build_constraint(
     )
 end
 
+"""
+    model_convert(model, con::AbstractConstraint)
+
+Convert the coefficients and constants of functions and sets of `con` to
+`value_type(typeof(model))`.
+
+    model_convert(model, set::MOI.AbstractSet)
+
+Convert the constants of `set` to `value_type(typeof(model))`.
+
+    model_convert(model, func::Union{Number,AbstractJuMPScalar})
+
+Convert the coefficients and constants of `func` to
+`value_type(typeof(model))`.
+
+!!! note
+    In the `@constraint` macro, a constraint with first built with
+    [`build_constraint`](@ref), as [`build_constraint`](@ref) does not
+    have the `model` as argument, the coefficients or constants of the
+    function or set might be different that `value_type(model)`.
+    These are converted in `model_convert` before the constraint is
+    passed to [`add_constraint`](@ref).
+"""
+function model_convert end
+
 model_convert(model, set::MOI.AbstractVectorSet) = set
 
 function model_convert(model, set::MOI.AbstractScalarSet)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -742,6 +742,7 @@ function build_constraint(
         return ScalarConstraint(expr, set)
     end
 end
+
 function build_constraint(
     _error::Function,
     ::_MA.Zero,

--- a/src/mutable_arithmetics.jl
+++ b/src/mutable_arithmetics.jl
@@ -32,7 +32,7 @@ function _MA.promote_operation(
     C::Type{<:_Constant},
     V::Type{<:AbstractVariableRef},
 )
-    return GenericAffExpr{_float_type(C),V}
+    return GenericAffExpr{_complex_convert_type(value_type(V), C),V}
 end
 
 function _MA.promote_operation(
@@ -40,7 +40,7 @@ function _MA.promote_operation(
     V::Type{<:AbstractVariableRef},
     C::Type{<:_Constant},
 )
-    return GenericAffExpr{_float_type(C),V}
+    return GenericAffExpr{_complex_convert_type(value_type(V), C),V}
 end
 
 function _MA.promote_operation(
@@ -66,7 +66,7 @@ function _MA.promote_operation(
     ::Type{V},
     ::Type{V},
 ) where {V<:AbstractVariableRef}
-    return GenericAffExpr{Float64,V}
+    return GenericAffExpr{value_type(V),V}
 end
 
 function _MA.promote_operation(
@@ -114,7 +114,7 @@ function _MA.promote_operation(
     ::Type{V},
     ::Type{V},
 ) where {V<:AbstractVariableRef}
-    return GenericQuadExpr{Float64,V}
+    return GenericQuadExpr{value_type(V),V}
 end
 
 function _MA.promote_operation(
@@ -219,10 +219,10 @@ end
 
 function _MA.operate!(
     ::typeof(_MA.sub_mul),
-    expr::_GenericAffOrQuadExpr,
+    expr::_GenericAffOrQuadExpr{T},
     x::_Scalar,
-)
-    return add_to_expression!(expr, -1.0, x)
+) where {T}
+    return add_to_expression!(expr, -one(T), x)
 end
 
 function _MA.operate!(

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -5,7 +5,7 @@
 
 """
     nonlinear_model(
-        model::Model;
+        model::GenericModel;
         force::Bool = false,
     )::Union{MOI.Nonlinear.Model,Nothing}
 
@@ -15,7 +15,7 @@ otherwise return `nothing`.
 If `force`, always return a [`MOI.Nonlinear.Model`](@ref), and if one does not
 exist for the model, create an empty one.
 """
-function nonlinear_model(model::Model; force::Bool = false)
+function nonlinear_model(model::GenericModel; force::Bool = false)
     if force
         _init_NLP(model)
     end
@@ -486,11 +486,11 @@ function delete(model::Model, c::NonlinearConstraintRef)
 end
 
 """
-    num_nonlinear_constraints(model::Model)
+    num_nonlinear_constraints(model::GenericModel)
 
 Returns the number of nonlinear constraints associated with the `model`.
 """
-function num_nonlinear_constraints(model::Model)
+function num_nonlinear_constraints(model::GenericModel)
     nlp_model = nonlinear_model(model)
     if nlp_model === nothing
         return 0

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -5,7 +5,7 @@
 
 """
     nonlinear_model(
-        model::Model;
+        model::GenericModel;
         force::Bool = false,
     )::Union{MOI.Nonlinear.Model,Nothing}
 
@@ -15,14 +15,14 @@ otherwise return `nothing`.
 If `force`, always return a [`MOI.Nonlinear.Model`](@ref), and if one does not
 exist for the model, create an empty one.
 """
-function nonlinear_model(model::Model; force::Bool = false)
+function nonlinear_model(model::GenericModel; force::Bool = false)
     if force
         _init_NLP(model)
     end
     return model.nlp_model
 end
 
-function _init_NLP(model::Model)
+function _init_NLP(model::GenericModel)
     if model.nlp_model === nothing
         model.nlp_model = MOI.Nonlinear.Model()
     end
@@ -51,7 +51,7 @@ end
 function MOI.Nonlinear.parse_expression(
     model::MOI.Nonlinear.Model,
     expr::MOI.Nonlinear.Expression,
-    x::VariableRef,
+    x::GenericVariableRef,
     parent::Int,
 )
     MOI.Nonlinear.parse_expression(model, expr, index(x), parent)
@@ -61,16 +61,16 @@ end
 function MOI.Nonlinear.parse_expression(
     model::MOI.Nonlinear.Model,
     expr::MOI.Nonlinear.Expression,
-    x::GenericAffExpr,
+    x::GenericAffExpr{T},
     parent::Int,
-)
+) where {T}
     sum_id = model.operators.multivariate_operator_to_id[:+]
     prod_id = model.operators.multivariate_operator_to_id[:*]
     call_multi = MOI.Nonlinear.NODE_CALL_MULTIVARIATE
     n_terms = length(x.terms) + !iszero(x.constant)
     if n_terms == 0
         # If `x` is empty, then substitute `0.0` as the expression.
-        MOI.Nonlinear.parse_expression(model, expr, 0.0, parent)
+        MOI.Nonlinear.parse_expression(model, expr, zero(T), parent)
         return
     elseif n_terms == 1
         # If `x` contains 1 term, then we don't need the leading `+` operator.
@@ -97,16 +97,16 @@ end
 function MOI.Nonlinear.parse_expression(
     model::MOI.Nonlinear.Model,
     expr::MOI.Nonlinear.Expression,
-    x::QuadExpr,
+    x::GenericQuadExpr{T},
     parent::Int,
-)
+) where {T}
     sum_id = model.operators.multivariate_operator_to_id[:+]
     prod_id = model.operators.multivariate_operator_to_id[:*]
     call_multi = MOI.Nonlinear.NODE_CALL_MULTIVARIATE
     n_terms = length(x.terms) + !iszero(x.aff)
     if n_terms == 0
         # If `x` is empty, then substitute `0.0` as the expression.
-        MOI.Nonlinear.parse_expression(model, expr, 0.0, parent)
+        MOI.Nonlinear.parse_expression(model, expr, zero(T), parent)
         return
     elseif n_terms == 1
         # If `x` contains 1 term, then we don't need the leading `+` operator.
@@ -135,7 +135,7 @@ end
 
 """
     set_nonlinear_objective(
-        model::Model,
+        model::GenericModel,
         sense::MOI.OptimizationSense,
         expr::Expr,
     )
@@ -161,7 +161,11 @@ julia> @variable(model, x);
 julia> set_nonlinear_objective(model, MIN_SENSE, :(\$(x) + \$(x)^2))
 ```
 """
-function set_nonlinear_objective(model::Model, sense::MOI.OptimizationSense, x)
+function set_nonlinear_objective(
+    model::GenericModel,
+    sense::MOI.OptimizationSense,
+    x,
+)
     _init_NLP(model)
     set_objective_sense(model, sense)
     MOI.Nonlinear.set_objective(model.nlp_model, x)
@@ -169,12 +173,12 @@ function set_nonlinear_objective(model::Model, sense::MOI.OptimizationSense, x)
 end
 
 """
-    _nlp_objective_function(model::Model)
+    _nlp_objective_function(model::GenericModel)
 
 Returns the nonlinear objective function or `nothing` if no nonlinear objective
 function is set.
 """
-function _nlp_objective_function(model::Model)
+function _nlp_objective_function(model::GenericModel)
     if model.nlp_model === nothing
         return nothing
     end
@@ -193,7 +197,7 @@ A struct to represent a nonlinear parameter.
 Create a parameter using [`@NLparameter`](@ref).
 """
 struct NonlinearParameter <: AbstractJuMPScalar
-    model::Model
+    model::GenericModel
     index::Int
 end
 
@@ -207,9 +211,9 @@ function MOI.Nonlinear.parse_expression(
     return MOI.Nonlinear.parse_expression(model, expr, index, parent)
 end
 
-function add_nonlinear_parameter(model::Model, value::Real)
+function add_nonlinear_parameter(model::GenericModel{T}, value::Real) where {T}
     _init_NLP(model)
-    p = MOI.Nonlinear.add_parameter(model.nlp_model, Float64(value))
+    p = MOI.Nonlinear.add_parameter(model.nlp_model, convert(T, value))
     return NonlinearParameter(model, p.value)
 end
 
@@ -278,7 +282,7 @@ A struct to represent a nonlinear expression.
 Create an expression using [`@NLexpression`](@ref).
 """
 struct NonlinearExpression <: AbstractJuMPScalar
-    model::Model
+    model::GenericModel
     index::Int
 end
 
@@ -300,7 +304,7 @@ Return the index of the nonlinear expression associated with `ex`.
 index(ex::NonlinearExpression) = MOI.Nonlinear.ExpressionIndex(ex.index)
 
 """
-    add_nonlinear_expression(model::Model, expr::Expr)
+    add_nonlinear_expression(model::GenericModel, expr::Expr)
 
 Add a nonlinear expression `expr` to `model`.
 
@@ -322,7 +326,7 @@ julia> add_nonlinear_expression(model, :(\$(x) + \$(x)^2))
 subexpression[1]: x + x ^ 2.0
 ```
 """
-function add_nonlinear_expression(model::Model, ex)
+function add_nonlinear_expression(model::GenericModel, ex)
     _init_NLP(model)
     index = MOI.Nonlinear.add_expression(model.nlp_model, ex)
     return NonlinearExpression(model, index.value)
@@ -353,12 +357,12 @@ This avoids the need to rewrite the nonlinear expressions from MOI_VARIABLE to
 VARIABLE, as well as eagerly computing the `var_value` for every variable. We
 use a `cache` so we don't have to recompute variables we have already seen.
 """
-struct _VariableValueMap{F} <: AbstractDict{MOI.VariableIndex,Float64}
-    model::Model
+struct _VariableValueMap{T,F} <: AbstractDict{MOI.VariableIndex,T}
+    model::GenericModel{T}
     value::F
-    cache::Dict{MOI.VariableIndex,Float64}
-    function _VariableValueMap(model, value::F) where {F}
-        return new{F}(model, value, Dict{MOI.VariableIndex,Float64}())
+    cache::Dict{MOI.VariableIndex,T}
+    function _VariableValueMap(model::GenericModel{T}, value::F) where {T,F}
+        return new{T,F}(model, value, Dict{MOI.VariableIndex,T}())
     end
 end
 
@@ -394,11 +398,16 @@ const NonlinearConstraintIndex = MOI.Nonlinear.ConstraintIndex
 const NonlinearConstraintRef =
     ConstraintRef{Model,MOI.Nonlinear.ConstraintIndex}
 
-function _normalize_constraint_expr(lhs::Real, body, rhs::Real)
-    return Float64(lhs), body, Float64(rhs)
+function _normalize_constraint_expr(
+    ::Type{T},
+    lhs::Real,
+    body,
+    rhs::Real,
+) where {T}
+    return convert(T, lhs), body, convert(T, rhs)
 end
 
-function _normalize_constraint_expr(lhs, body, rhs)
+function _normalize_constraint_expr(::Type, lhs, body, rhs)
     return error(
         "Interval constraint contains non-constant left- or right-hand " *
         "sides. Reformulate as two separate constraints, or move all " *
@@ -406,31 +415,39 @@ function _normalize_constraint_expr(lhs, body, rhs)
     )
 end
 
-_normalize_constraint_expr(lhs, rhs::Real) = lhs, Float64(rhs)
+function _normalize_constraint_expr(::Type{T}, lhs, rhs::Real) where {T}
+    return lhs, convert(T, rhs)
+end
 
-_normalize_constraint_expr(lhs, rhs) = Expr(:call, :-, lhs, rhs), 0.0
+function _normalize_constraint_expr(::Type{T}, lhs, rhs) where {T}
+    return Expr(:call, :-, lhs, rhs), zero(T)
+end
 
-function _expr_to_constraint(expr::Expr)
+function _expr_to_constraint(::Type{T}, expr::Expr) where {T}
     if isexpr(expr, :comparison)
         @assert expr.args[2] == expr.args[4]
         @assert expr.args[2] in (:<=, :>=)
-        lhs, body, rhs =
-            _normalize_constraint_expr(expr.args[1], expr.args[3], expr.args[5])
+        lhs, body, rhs = _normalize_constraint_expr(
+            T,
+            expr.args[1],
+            expr.args[3],
+            expr.args[5],
+        )
         return body, MOI.Interval(lhs, rhs)
     end
-    lhs, rhs = _normalize_constraint_expr(expr.args[2], expr.args[3])
+    lhs, rhs = _normalize_constraint_expr(T, expr.args[2], expr.args[3])
     if expr.args[1] == :<=
-        return :($lhs - $rhs), MOI.LessThan(0.0)
+        return :($lhs - $rhs), MOI.LessThan(zero(T))
     elseif expr.args[1] == :>=
-        return :($lhs - $rhs), MOI.GreaterThan(0.0)
+        return :($lhs - $rhs), MOI.GreaterThan(zero(T))
     else
         @assert expr.args[1] == :(==)
-        return :($lhs - $rhs), MOI.EqualTo(0.0)
+        return :($lhs - $rhs), MOI.EqualTo(zero(T))
     end
 end
 
 """
-    add_nonlinear_constraint(model::Model, expr::Expr)
+    add_nonlinear_constraint(model::GenericModel, expr::Expr)
 
 Add a nonlinear constraint described by the Julia expression `ex` to `model`.
 
@@ -452,19 +469,19 @@ julia> add_nonlinear_constraint(model, :(\$(x) + \$(x)^2 <= 1))
 (x + x ^ 2.0) - 1.0 ≤ 0
 ```
 """
-function add_nonlinear_constraint(model::Model, ex::Expr)
+function add_nonlinear_constraint(model::GenericModel{T}, ex::Expr) where {T}
     _init_NLP(model)
-    f, set = _expr_to_constraint(ex)
+    f, set = _expr_to_constraint(T, ex)
     c = MOI.Nonlinear.add_constraint(model.nlp_model, f, set)
     return ConstraintRef(model, c, ScalarShape())
 end
 
 """
-    is_valid(model::Model, c::NonlinearConstraintRef)
+    is_valid(model::GenericModel, c::NonlinearConstraintRef)
 
 Return `true` if `c` refers to a valid nonlinear constraint in `model`.
 """
-function is_valid(model::Model, c::NonlinearConstraintRef)
+function is_valid(model::GenericModel, c::NonlinearConstraintRef)
     if model !== c.model
         return false
     end
@@ -474,11 +491,11 @@ function is_valid(model::Model, c::NonlinearConstraintRef)
 end
 
 """
-    delete(model::Model, c::NonlinearConstraintRef)
+    delete(model::GenericModel, c::NonlinearConstraintRef)
 
 Delete the nonlinear constraint `c` from `model`.
 """
-function delete(model::Model, c::NonlinearConstraintRef)
+function delete(model::GenericModel, c::NonlinearConstraintRef)
     _init_NLP(model)
     index = MOI.Nonlinear.ConstraintIndex(c.index.value)
     MOI.Nonlinear.delete(model.nlp_model, index)
@@ -486,11 +503,11 @@ function delete(model::Model, c::NonlinearConstraintRef)
 end
 
 """
-    num_nonlinear_constraints(model::Model)
+    num_nonlinear_constraints(model::GenericModel)
 
 Returns the number of nonlinear constraints associated with the `model`.
 """
-function num_nonlinear_constraints(model::Model)
+function num_nonlinear_constraints(model::GenericModel)
     nlp_model = nonlinear_model(model)
     if nlp_model === nothing
         return 0
@@ -499,12 +516,12 @@ function num_nonlinear_constraints(model::Model)
 end
 
 """
-    all_nonlinear_constraints(model::Model)
+    all_nonlinear_constraints(model::GenericModel)
 
 Return a vector of all nonlinear constraint references in the model in the
 order they were added to the model.
 """
-function all_nonlinear_constraints(model::Model)
+function all_nonlinear_constraints(model::GenericModel)
     nlp_model = nonlinear_model(model)
     if nlp_model === nothing
         return NonlinearConstraintRef[]
@@ -567,19 +584,19 @@ function dual(c::NonlinearConstraintRef)
 end
 
 """
-    nonlinear_dual_start_value(model::Model)
+    nonlinear_dual_start_value(model::GenericModel)
 
 Return the current value of the MOI attribute [`MOI.NLPBlockDualStart`](@ref).
 """
-function nonlinear_dual_start_value(model::Model)
+function nonlinear_dual_start_value(model::GenericModel)
     return MOI.get(model, MOI.NLPBlockDualStart())
 end
 
 """
     set_nonlinear_dual_start_value(
-        model::Model,
-        start::Union{Nothing,Vector{Float64}},
-    )
+        model::GenericModel{T},
+        start::Union{Nothing,Vector{T}},
+    ) where {T}
 
 Set the value of the MOI attribute [`MOI.NLPBlockDualStart`](@ref).
 
@@ -619,7 +636,10 @@ julia> nonlinear_dual_start_value(model)
   1.0
 ```
 """
-function set_nonlinear_dual_start_value(model::Model, start::Vector{Float64})
+function set_nonlinear_dual_start_value(
+    model::GenericModel{T},
+    start::Vector{T},
+) where {T}
     _init_NLP(model)
     N = num_nonlinear_constraints(model)
     if length(start) != N
@@ -634,25 +654,25 @@ function set_nonlinear_dual_start_value(model::Model, start::Vector{Float64})
     return
 end
 
-function set_nonlinear_dual_start_value(model::Model, start::Nothing)
+function set_nonlinear_dual_start_value(model::GenericModel, start::Nothing)
     MOI.set(model, MOI.NLPBlockDualStart(), start)
     return
 end
 
 """
     register(
-        model::Model,
+        model::GenericModel{T},
         op::Symbol,
         dimension::Integer,
         f::Function;
         autodiff:Bool = false,
-    )
+    ) where {T}
 
 Register the user-defined function `f` that takes `dimension` arguments in
 `model` as the symbol `op`.
 
 The function `f` must support all subtypes of `Real` as arguments. Do not assume
-that the inputs are `Float64`.
+that the inputs are `T`.
 
 ## Notes
 
@@ -695,7 +715,7 @@ julia> @NLobjective(model, Min, g(x[1], x[2]))
 ```
 """
 function register(
-    model::Model,
+    model::GenericModel,
     op::Symbol,
     dimension::Integer,
     f::Function;
@@ -711,19 +731,19 @@ end
 
 """
     register(
-        model::Model,
+        model::GenericModel{T},
         s::Symbol,
         dimension::Integer,
         f::Function,
         ∇f::Function;
         autodiff:Bool = false,
-    )
+    ) where {T}
 
 Register the user-defined function `f` that takes `dimension` arguments in
 `model` as the symbol `s`. In addition, provide a gradient function `∇f`.
 
 The functions `f`and `∇f` must support all subtypes of `Real` as arguments. Do
-not assume that the inputs are `Float64`.
+not assume that the inputs are `T`.
 
 ## Notes
 
@@ -781,7 +801,7 @@ julia> @NLobjective(model, Min, g(x[1], x[2]))
 ```
 """
 function register(
-    model::Model,
+    model::GenericModel,
     op::Symbol,
     dimension::Integer,
     f::Function,
@@ -807,13 +827,13 @@ end
 
 """
     register(
-        model::Model,
+        model::GenericModel{T},
         s::Symbol,
         dimension::Integer,
         f::Function,
         ∇f::Function,
         ∇²f::Function,
-    )
+    ) where {T}
 
 Register the user-defined function `f` that takes `dimension` arguments in
 `model` as the symbol `s`. In addition, provide a gradient function `∇f` and a
@@ -825,7 +845,7 @@ derivatives of the function `f` respectively.
 ## Notes
 
  * Because automatic differentiation is not used, you can assume the inputs are
-   all `Float64`.
+   all `T`.
  * This method will throw an error if `dimension > 1`.
  * `s` does not have to be the same symbol as `f`, but it is generally more
    readable if it is.
@@ -854,7 +874,7 @@ julia> @NLobjective(model, Min, foo(x))
 ```
 """
 function register(
-    model::Model,
+    model::GenericModel,
     op::Symbol,
     dimension::Integer,
     f::Function,
@@ -868,7 +888,7 @@ end
 
 """
     NLPEvaluator(
-        model::Model,
+        model::GenericModel,
         _differentiation_backend::MOI.Nonlinear.AbstractAutomaticDifferentiation =
             MOI.Nonlinear.SparseReverseMode(),
     )
@@ -887,7 +907,7 @@ Pass `_differentiation_backend` to specify the differentiation backend used to
 compute derivatives.
 """
 function NLPEvaluator(
-    model::Model;
+    model::GenericModel;
     _differentiation_backend::MOI.Nonlinear.AbstractAutomaticDifferentiation = MOI.Nonlinear.SparseReverseMode(),
 )
     _init_NLP(model)

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -353,11 +353,11 @@ This avoids the need to rewrite the nonlinear expressions from MOI_VARIABLE to
 VARIABLE, as well as eagerly computing the `var_value` for every variable. We
 use a `cache` so we don't have to recompute variables we have already seen.
 """
-struct _VariableValueMap{F} <: AbstractDict{MOI.VariableIndex,T}
+struct _VariableValueMap{F} <: AbstractDict{MOI.VariableIndex,Float64}
     model::Model
     value::F
     cache::Dict{MOI.VariableIndex,Float64}
-    function _VariableValueMap(model::Model, value::F) where {F}
+    function _VariableValueMap(model, value::F) where {F}
         return new{F}(model, value, Dict{MOI.VariableIndex,Float64}())
     end
 end
@@ -406,11 +406,11 @@ function _normalize_constraint_expr(lhs, body, rhs)
     )
 end
 
-function _normalize_constraint_expr(lhs, rhs::Real) where {T}
+function _normalize_constraint_expr(lhs, rhs::Real)
     return lhs, Float64(rhs)
 end
 
-function _normalize_constraint_expr(lhs, rhs) where {T}
+function _normalize_constraint_expr(lhs, rhs)
     return Expr(:call, :-, lhs, rhs), 0.0
 end
 
@@ -581,9 +581,9 @@ end
 
 """
     set_nonlinear_dual_start_value(
-        model::Model{T},
-        start::Union{Nothing,Vector{T}},
-    ) where {T}
+        model::Model,
+        start::Union{Nothing,Vector{Float64}},
+    )
 
 Set the value of the MOI attribute [`MOI.NLPBlockDualStart`](@ref).
 
@@ -623,10 +623,7 @@ julia> nonlinear_dual_start_value(model)
   1.0
 ```
 """
-function set_nonlinear_dual_start_value(
-    model::Model{T},
-    start::Vector{T},
-) where {T}
+function set_nonlinear_dual_start_value(model::Model, start::Vector)
     _init_NLP(model)
     N = num_nonlinear_constraints(model)
     if length(start) != N
@@ -648,12 +645,12 @@ end
 
 """
     register(
-        model::Model{T},
+        model::Model,
         op::Symbol,
         dimension::Integer,
         f::Function;
         autodiff:Bool = false,
-    ) where {T}
+    )
 
 Register the user-defined function `f` that takes `dimension` arguments in
 `model` as the symbol `op`.
@@ -718,13 +715,13 @@ end
 
 """
     register(
-        model::Model{T},
+        model::Model,
         s::Symbol,
         dimension::Integer,
         f::Function,
         ∇f::Function;
         autodiff:Bool = false,
-    ) where {T}
+    )
 
 Register the user-defined function `f` that takes `dimension` arguments in
 `model` as the symbol `s`. In addition, provide a gradient function `∇f`.

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -406,13 +406,9 @@ function _normalize_constraint_expr(lhs, body, rhs)
     )
 end
 
-function _normalize_constraint_expr(lhs, rhs::Real)
-    return lhs, Float64(rhs)
-end
+_normalize_constraint_expr(lhs, rhs::Real) = lhs, Float64(rhs)
 
-function _normalize_constraint_expr(lhs, rhs)
-    return Expr(:call, :-, lhs, rhs), 0.0
-end
+_normalize_constraint_expr(lhs, rhs) = Expr(:call, :-, lhs, rhs), 0.0
 
 function _expr_to_constraint(expr::Expr)
     if isexpr(expr, :comparison)
@@ -623,7 +619,7 @@ julia> nonlinear_dual_start_value(model)
   1.0
 ```
 """
-function set_nonlinear_dual_start_value(model::Model, start::Vector)
+function set_nonlinear_dual_start_value(model::Model, start::Vector{Float64})
     _init_NLP(model)
     N = num_nonlinear_constraints(model)
     if length(start) != N
@@ -656,7 +652,7 @@ Register the user-defined function `f` that takes `dimension` arguments in
 `model` as the symbol `op`.
 
 The function `f` must support all subtypes of `Real` as arguments. Do not assume
-that the inputs are `T`.
+that the inputs are `Float64`.
 
 ## Notes
 
@@ -727,7 +723,7 @@ Register the user-defined function `f` that takes `dimension` arguments in
 `model` as the symbol `s`. In addition, provide a gradient function `∇f`.
 
 The functions `f`and `∇f` must support all subtypes of `Real` as arguments. Do
-not assume that the inputs are `T`.
+not assume that the inputs are `Float64`.
 
 ## Notes
 
@@ -811,13 +807,13 @@ end
 
 """
     register(
-        model::Model{T},
+        model::Model,
         s::Symbol,
         dimension::Integer,
         f::Function,
         ∇f::Function,
         ∇²f::Function,
-    ) where {T}
+    )
 
 Register the user-defined function `f` that takes `dimension` arguments in
 `model` as the symbol `s`. In addition, provide a gradient function `∇f` and a
@@ -829,7 +825,7 @@ derivatives of the function `f` respectively.
 ## Notes
 
  * Because automatic differentiation is not used, you can assume the inputs are
-   all `T`.
+   all `Float64`.
  * This method will throw an error if `dimension > 1`.
  * `s` does not have to be the same symbol as `f`, but it is generally more
    readable if it is.

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -10,18 +10,18 @@
 # This file contains objective-related functions
 
 """
-    relative_gap(model::Model)
+    relative_gap(model::GenericModel)
 
 Return the final relative optimality gap after a call to `optimize!(model)`.
 Exact value depends upon implementation of MathOptInterface.RelativeGap()
 by the particular solver used for optimization.
 """
-function relative_gap(model::Model)::Float64
+function relative_gap(model::GenericModel{T})::T where {T}
     return MOI.get(model, MOI.RelativeGap())
 end
 
 """
-    objective_bound(model::Model)
+    objective_bound(model::GenericModel)
 
 Return the best known bound on the optimal objective value after a call to
 `optimize!(model)`.
@@ -32,12 +32,12 @@ vector-valued objectives, it returns a `Vector{Float64}`.
 In the case of a vector-valued objective, this returns the _ideal point_, that
 is, the point obtained if each objective was optimized independently.
 """
-function objective_bound(model::Model)::Union{Float64,Vector{Float64}}
+function objective_bound(model::GenericModel{T})::Union{T,Vector{T}} where {T}
     return MOI.get(model, MOI.ObjectiveBound())
 end
 
 """
-    objective_value(model::Model; result::Int = 1)
+    objective_value(model::GenericModel; result::Int = 1)
 
 Return the objective value associated with result index `result` of the
 most-recent solution returned by the solver.
@@ -48,14 +48,14 @@ vector-valued objectives, it returns a `Vector{Float64}`.
 See also: [`result_count`](@ref).
 """
 function objective_value(
-    model::Model;
+    model::GenericModel{T};
     result::Int = 1,
-)::Union{Float64,Vector{Float64}}
+)::Union{T,Vector{T}} where {T}
     return MOI.get(model, MOI.ObjectiveValue(result))
 end
 
 """
-    dual_objective_value(model::Model; result::Int = 1)
+    dual_objective_value(model::GenericModel; result::Int = 1)
 
 Return the value of the objective of the dual problem associated with result
 index `result` of the most-recent solution returned by the solver.
@@ -65,36 +65,39 @@ not support this attribute.
 
 See also: [`result_count`](@ref).
 """
-function dual_objective_value(model::Model; result::Int = 1)::Float64
+function dual_objective_value(
+    model::GenericModel{T};
+    result::Int = 1,
+)::T where {T}
     return MOI.get(model, MOI.DualObjectiveValue(result))
 end
 
 """
-    objective_sense(model::Model)::MOI.OptimizationSense
+    objective_sense(model::GenericModel)::MOI.OptimizationSense
 
 Return the objective sense.
 """
-function objective_sense(model::Model)
+function objective_sense(model::GenericModel)
     return MOI.get(model, MOI.ObjectiveSense())::MOI.OptimizationSense
 end
 
 """
-    set_objective_sense(model::Model, sense::MOI.OptimizationSense)
+    set_objective_sense(model::GenericModel, sense::MOI.OptimizationSense)
 
 Sets the objective sense of the model to the given sense. See
 [`set_objective_function`](@ref) to set the objective function. These are
 low-level functions; the recommended way to set the objective is with the
 [`@objective`](@ref) macro.
 """
-function set_objective_sense(model::Model, sense::MOI.OptimizationSense)
+function set_objective_sense(model::GenericModel, sense::MOI.OptimizationSense)
     return MOI.set(model, MOI.ObjectiveSense(), sense)
 end
 
 """
-    set_objective_function(model::Model, func::MOI.AbstractFunction)
-    set_objective_function(model::Model, func::AbstractJuMPScalar)
-    set_objective_function(model::Model, func::Real)
-    set_objective_function(model::Model, func::Vector{<:AbstractJuMPScalar})
+    set_objective_function(model::GenericModel, func::MOI.AbstractFunction)
+    set_objective_function(model::GenericModel, func::AbstractJuMPScalar)
+    set_objective_function(model::GenericModel, func::Real)
+    set_objective_function(model::GenericModel, func::Vector{<:AbstractJuMPScalar})
 
 Sets the objective function of the model to the given function. See
 [`set_objective_sense`](@ref) to set the objective sense. These are low-level
@@ -103,7 +106,7 @@ functions; the recommended way to set the objective is with the
 """
 function set_objective_function end
 
-function set_objective_function(model::Model, func::MOI.AbstractFunction)
+function set_objective_function(model::GenericModel, func::MOI.AbstractFunction)
     attr = MOI.ObjectiveFunction{typeof(func)}()
     if !MOI.supports(backend(model), attr)
         error(
@@ -121,23 +124,20 @@ function set_objective_function(model::Model, func::MOI.AbstractFunction)
     return
 end
 
-function set_objective_function(model::Model, func::AbstractJuMPScalar)
+function set_objective_function(model::GenericModel, func::AbstractJuMPScalar)
     check_belongs_to_model(func, model)
     return set_objective_function(model, moi_function(func))
 end
 
-function set_objective_function(model::Model, func::Real)
+function set_objective_function(model::GenericModel{T}, func::Real) where {T}
     return set_objective_function(
         model,
-        MOI.ScalarAffineFunction(
-            MOI.ScalarAffineTerm{Float64}[],
-            Float64(func),
-        ),
+        MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{T}[], convert(T, func)),
     )
 end
 
 function set_objective_function(
-    model::Model,
+    model::GenericModel,
     func::AbstractVector{<:AbstractJuMPScalar},
 )
     for f in func
@@ -176,11 +176,11 @@ function set_objective(model::AbstractModel, sense::MOI.OptimizationSense, func)
 end
 
 """
-    objective_function_type(model::Model)::AbstractJuMPScalar
+    objective_function_type(model::GenericModel)::AbstractJuMPScalar
 
 Return the type of the objective function.
 """
-function objective_function_type(model::Model)
+function objective_function_type(model::GenericModel)
     return jump_function_type(
         model,
         MOI.get(backend(model), MOI.ObjectiveFunctionType()),
@@ -189,7 +189,7 @@ end
 
 """
     objective_function(
-        model::Model,
+        model::GenericModel,
         T::Type = objective_function_type(model),
     )
 
@@ -229,38 +229,38 @@ ERROR: InexactError: convert(MathOptInterface.VariableIndex, MathOptInterface.Sc
 ```
 """
 function objective_function(
-    model::Model,
+    model::GenericModel,
     ::Type{F},
 ) where {F<:MOI.AbstractFunction}
     func = MOI.get(backend(model), MOI.ObjectiveFunction{F}())::F
     return jump_function(model, func)
 end
 
-function objective_function(model::Model, ::Type{T}) where {T}
+function objective_function(model::GenericModel, ::Type{T}) where {T}
     return objective_function(model, moi_function_type(T))
 end
 
-function objective_function(model::Model)
+function objective_function(model::GenericModel)
     F = MOI.get(backend(model), MOI.ObjectiveFunctionType())
     return objective_function(model, F)
 end
 
 """
-    set_objective_coefficient(model::Model, variable::VariableRef, coefficient::Real)
+    set_objective_coefficient(model::GenericModel, variable::GenericVariableRef, coefficient::Real)
 
 Set the linear objective coefficient associated with `Variable` to `coefficient`.
 
 Note: this function will throw an error if a nonlinear objective is set.
 """
 function set_objective_coefficient(
-    model::Model,
-    variable::VariableRef,
+    model::GenericModel{T},
+    variable::GenericVariableRef,
     coeff::Real,
-)
+) where {T}
     if _nlp_objective_function(model) !== nothing
         error("A nonlinear objective is already set in the model")
     end
-    coeff = convert(Float64, coeff)::Float64
+    coeff = convert(T, coeff)::T
     obj_fct_type = objective_function_type(model)
     if obj_fct_type == VariableRef
         # Promote the objective function to be an affine expression.

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -48,7 +48,7 @@ end
 
 """
     set_optimizer_attribute(
-        model::Union{Model,MOI.OptimizerWithAttributes},
+        model::Union{GenericModel,MOI.OptimizerWithAttributes},
         attr::Union{AbstractString,MOI.AbstractOptimizerAttribute},
         value,
     )
@@ -76,7 +76,7 @@ set_optimizer_attribute(model, attr, value) = set_attribute(model, attr, value)
 
 """
     set_optimizer_attributes(
-        model::Union{Model,MOI.OptimizerWithAttributes},
+        model::Union{GenericModel,MOI.OptimizerWithAttributes},
         pairs::Pair...,
     )
 
@@ -110,7 +110,7 @@ julia> set_optimizer_attribute(model, "max_iter", 100)
 ```
 """
 function set_optimizer_attributes(
-    model::Union{Model,MOI.OptimizerWithAttributes},
+    model::Union{GenericModel,MOI.OptimizerWithAttributes},
     pairs::Pair...,
 )
     for (name, value) in pairs
@@ -121,7 +121,7 @@ end
 
 """
     get_optimizer_attribute(
-        model::Union{Model,MOI.OptimizerWithAttributes},
+        model::Union{GenericModel,MOI.OptimizerWithAttributes},
         attr::Union{AbstractString,MOI.AbstractOptimizerAttribute},
     )
 
@@ -150,31 +150,31 @@ false
 get_optimizer_attribute(model, attr) = get_attribute(model, attr)
 
 """
-    set_silent(model::Model)
+    set_silent(model::GenericModel)
 
 Takes precedence over any other attribute controlling verbosity and requires the
 solver to produce no output.
 
 See also: [`unset_silent`](@ref).
 """
-function set_silent(model::Model)
+function set_silent(model::GenericModel)
     return MOI.set(model, MOI.Silent(), true)
 end
 
 """
-    unset_silent(model::Model)
+    unset_silent(model::GenericModel)
 
 Neutralize the effect of the `set_silent` function and let the solver attributes
 control the verbosity.
 
 See also: [`set_silent`](@ref).
 """
-function unset_silent(model::Model)
+function unset_silent(model::GenericModel)
     return MOI.set(model, MOI.Silent(), false)
 end
 
 """
-    set_time_limit_sec(model::Model, limit::Float64)
+    set_time_limit_sec(model::GenericModel, limit::Float64)
 
 Set the time limit (in seconds) of the solver.
 
@@ -183,27 +183,27 @@ Can be unset using [`unset_time_limit_sec`](@ref) or with `limit` set to
 
 See also: [`unset_time_limit_sec`](@ref), [`time_limit_sec`](@ref).
 """
-function set_time_limit_sec(model::Model, limit::Real)
+function set_time_limit_sec(model::GenericModel, limit::Real)
     return MOI.set(model, MOI.TimeLimitSec(), convert(Float64, limit))
 end
 
-function set_time_limit_sec(model::Model, ::Nothing)
+function set_time_limit_sec(model::GenericModel, ::Nothing)
     return unset_time_limit_sec(model)
 end
 
 """
-    unset_time_limit_sec(model::Model)
+    unset_time_limit_sec(model::GenericModel)
 
 Unset the time limit of the solver.
 
 See also: [`set_time_limit_sec`](@ref), [`time_limit_sec`](@ref).
 """
-function unset_time_limit_sec(model::Model)
+function unset_time_limit_sec(model::GenericModel)
     return MOI.set(model, MOI.TimeLimitSec(), nothing)
 end
 
 """
-    time_limit_sec(model::Model)
+    time_limit_sec(model::GenericModel)
 
 Return the time limit (in seconds) of the `model`.
 
@@ -211,7 +211,7 @@ Returns `nothing` if unset.
 
 See also: [`set_time_limit_sec`](@ref), [`unset_time_limit_sec`](@ref).
 """
-function time_limit_sec(model::Model)
+function time_limit_sec(model::GenericModel)
     return MOI.get(model, MOI.TimeLimitSec())
 end
 
@@ -228,7 +228,7 @@ function _try_get_solver_name(model_like)
 end
 
 """
-    solver_name(model::Model)
+    solver_name(model::GenericModel)
 
 If available, returns the `SolverName` property of the underlying optimizer.
 
@@ -238,7 +238,7 @@ optimizer is attached.
 Returns `"SolverName() attribute not implemented by the optimizer."` if the
 attribute is not implemented.
 """
-function solver_name(model::Model)
+function solver_name(model::GenericModel)
     if mode(model) != DIRECT && MOIU.state(backend(model)) == MOIU.NO_OPTIMIZER
         return "No optimizer attached."
     end
@@ -246,7 +246,7 @@ function solver_name(model::Model)
 end
 
 """
-    error_if_direct_mode(model::Model, func::Symbol)
+    error_if_direct_mode(model::GenericModel, func::Symbol)
 
 Errors if `model` is in direct mode during a call from the function named
 `func`.
@@ -254,7 +254,7 @@ Errors if `model` is in direct mode during a call from the function named
 Used internally within JuMP, or by JuMP extensions who do not want to support
 models in direct mode.
 """
-function error_if_direct_mode(model::Model, func::Symbol)
+function error_if_direct_mode(model::GenericModel, func::Symbol)
     if mode(model) == DIRECT
         error("The `$func` function is not supported in DIRECT mode.")
     end
@@ -264,14 +264,14 @@ end
 # These methods directly map to CachingOptimizer methods.
 
 """
-    MOIU.reset_optimizer(model::Model, optimizer::MOI.AbstractOptimizer)
+    MOIU.reset_optimizer(model::GenericModel, optimizer::MOI.AbstractOptimizer)
 
 Call `MOIU.reset_optimizer` on the backend of `model`.
 
 Cannot be called in direct mode.
 """
 function MOIU.reset_optimizer(
-    model::Model,
+    model::GenericModel,
     optimizer::MOI.AbstractOptimizer,
     ::Bool = true,
 )
@@ -281,39 +281,39 @@ function MOIU.reset_optimizer(
 end
 
 """
-    MOIU.reset_optimizer(model::Model)
+    MOIU.reset_optimizer(model::GenericModel)
 
 Call `MOIU.reset_optimizer` on the backend of `model`.
 
 Cannot be called in direct mode.
 """
-function MOIU.reset_optimizer(model::Model)
+function MOIU.reset_optimizer(model::GenericModel)
     error_if_direct_mode(model, :reset_optimizer)
     MOIU.reset_optimizer(backend(model))
     return
 end
 
 """
-    MOIU.drop_optimizer(model::Model)
+    MOIU.drop_optimizer(model::GenericModel)
 
 Call `MOIU.drop_optimizer` on the backend of `model`.
 
 Cannot be called in direct mode.
 """
-function MOIU.drop_optimizer(model::Model)
+function MOIU.drop_optimizer(model::GenericModel)
     error_if_direct_mode(model, :drop_optimizer)
     MOIU.drop_optimizer(backend(model))
     return
 end
 
 """
-    MOIU.attach_optimizer(model::Model)
+    MOIU.attach_optimizer(model::GenericModel)
 
 Call `MOIU.attach_optimizer` on the backend of `model`.
 
 Cannot be called in direct mode.
 """
-function MOIU.attach_optimizer(model::Model)
+function MOIU.attach_optimizer(model::GenericModel)
     error_if_direct_mode(model, :attach_optimizer)
     MOIU.attach_optimizer(backend(model))
     return
@@ -321,7 +321,7 @@ end
 
 """
     set_optimizer(
-        model::Model,
+        model::GenericModel,
         optimizer_factory;
         add_bridges::Bool = true,
     )
@@ -352,14 +352,13 @@ julia> set_optimizer(model, HiGHS.Optimizer; add_bridges = false)
 ```
 """
 function set_optimizer(
-    model::Model,
+    model::GenericModel{T},
     (@nospecialize optimizer_constructor);
     add_bridges::Bool = true,
-)
+) where {T}
     error_if_direct_mode(model, :set_optimizer)
     if add_bridges
-        optimizer =
-            MOI.instantiate(optimizer_constructor; with_bridge_type = Float64)
+        optimizer = MOI.instantiate(optimizer_constructor; with_bridge_type = T)
         for bridge_type in model.bridge_types
             _moi_call_bridge_function(
                 MOI.Bridges.add_bridge,
@@ -379,7 +378,7 @@ end
 
 """
     optimize!(
-        model::Model;
+        model::GenericModel;
         ignore_optimize_hook = (model.optimize_hook === nothing),
         _differentiation_backend::MOI.Nonlinear.AbstractAutomaticDifferentiation =
             MOI.Nonlinear.SparseReverseMode(),
@@ -408,7 +407,7 @@ If you require only `:ExprGraph`, it is more efficient to pass
 `_differentiation_backend = MOI.Nonlinear.ExprGraphOnly()`.
 """
 function optimize!(
-    model::Model;
+    model::GenericModel;
     ignore_optimize_hook = (model.optimize_hook === nothing),
     _differentiation_backend::MOI.Nonlinear.AbstractAutomaticDifferentiation = MOI.Nonlinear.SparseReverseMode(),
     kwargs...,
@@ -456,7 +455,7 @@ function optimize!(
 end
 
 """
-    compute_conflict!(model::Model)
+    compute_conflict!(model::GenericModel)
 
 Compute a conflict if the model is infeasible. If an optimizer has not
 been set yet (see [`set_optimizer`](@ref)), a [`NoOptimizer`](@ref)
@@ -466,7 +465,7 @@ The status of the conflict can be checked with the `MOI.ConflictStatus`
 model attribute. Then, the status for each constraint can be queried with
 the `MOI.ConstraintConflictStatus` attribute.
 """
-function compute_conflict!(model::Model)
+function compute_conflict!(model::GenericModel)
     if mode(model) != DIRECT && MOIU.state(backend(model)) == MOIU.NO_OPTIMIZER
         throw(NoOptimizer())
     end
@@ -475,16 +474,16 @@ function compute_conflict!(model::Model)
 end
 
 """
-    termination_status(model::Model)
+    termination_status(model::GenericModel)
 
 Return a [`MOI.TerminationStatusCode`](@ref) describing why the solver stopped
 (i.e., the [`MOI.TerminationStatus`](@ref) attribute).
 """
-function termination_status(model::Model)
+function termination_status(model::GenericModel)
     return MOI.get(model, MOI.TerminationStatus())::MOI.TerminationStatusCode
 end
 
-function MOI.get(model::Model, attr::MOI.TerminationStatus)
+function MOI.get(model::GenericModel, attr::MOI.TerminationStatus)
     if model.is_model_dirty && mode(model) != DIRECT
         return MOI.OPTIMIZE_NOT_CALLED
     end
@@ -492,12 +491,12 @@ function MOI.get(model::Model, attr::MOI.TerminationStatus)
 end
 
 """
-    result_count(model::Model)
+    result_count(model::GenericModel)
 
 Return the number of results available to query after a call to
 [`optimize!`](@ref).
 """
-function result_count(model::Model)::Int
+function result_count(model::GenericModel)::Int
     if termination_status(model) == MOI.OPTIMIZE_NOT_CALLED
         return 0
     end
@@ -505,19 +504,22 @@ function result_count(model::Model)::Int
 end
 
 """
-    raw_status(model::Model)
+    raw_status(model::GenericModel)
 
 Return the reason why the solver stopped in its own words (i.e., the
 MathOptInterface model attribute `RawStatusString`).
 """
-function raw_status(model::Model)
+function raw_status(model::GenericModel)
     if MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
         return "optimize not called"
     end
     return MOI.get(model, MOI.RawStatusString())
 end
 
-function MOI.get(model::Model, attr::Union{MOI.PrimalStatus,MOI.DualStatus})
+function MOI.get(
+    model::GenericModel,
+    attr::Union{MOI.PrimalStatus,MOI.DualStatus},
+)
     if model.is_model_dirty && mode(model) != DIRECT
         return MOI.NO_SOLUTION
     end
@@ -525,7 +527,7 @@ function MOI.get(model::Model, attr::Union{MOI.PrimalStatus,MOI.DualStatus})
 end
 
 """
-    primal_status(model::Model; result::Int = 1)
+    primal_status(model::GenericModel; result::Int = 1)
 
 Return a [`MOI.ResultStatusCode`](@ref) describing the status of the most recent
 primal solution of the solver (i.e., the [`MOI.PrimalStatus`](@ref) attribute)
@@ -533,12 +535,12 @@ associated with the result index `result`.
 
 See also: [`result_count`](@ref).
 """
-function primal_status(model::Model; result::Int = 1)
+function primal_status(model::GenericModel; result::Int = 1)
     return MOI.get(model, MOI.PrimalStatus(result))::MOI.ResultStatusCode
 end
 
 """
-    dual_status(model::Model; result::Int = 1)
+    dual_status(model::GenericModel; result::Int = 1)
 
 Return a [`MOI.ResultStatusCode`](@ref) describing the status of the most recent
 dual solution of the solver (i.e., the [`MOI.DualStatus`](@ref) attribute)
@@ -546,64 +548,64 @@ associated with the result index `result`.
 
 See also: [`result_count`](@ref).
 """
-function dual_status(model::Model; result::Int = 1)
+function dual_status(model::GenericModel; result::Int = 1)
     return MOI.get(model, MOI.DualStatus(result))::MOI.ResultStatusCode
 end
 
 """
-    solve_time(model::Model)
+    solve_time(model::GenericModel)
 
 If available, returns the solve time reported by the solver.
 Returns "ArgumentError: ModelLike of type `Solver.Optimizer` does not support
 accessing the attribute MathOptInterface.SolveTimeSec()" if the attribute is
 not implemented.
 """
-function solve_time(model::Model)
+function solve_time(model::GenericModel)
     return MOI.get(model, MOI.SolveTimeSec())
 end
 
 """
-    simplex_iterations(model::Model)
+    simplex_iterations(model::GenericModel)
 
 Gets the cumulative number of simplex iterations during the most-recent
 optimization.
 
 Solvers must implement `MOI.SimplexIterations()` to use this function.
 """
-function simplex_iterations(model::Model)
+function simplex_iterations(model::GenericModel)
     return MOI.get(model, MOI.SimplexIterations())
 end
 
 """
-    barrier_iterations(model::Model)
+    barrier_iterations(model::GenericModel)
 
 Gets the cumulative number of barrier iterations during the most recent
 optimization.
 
 Solvers must implement `MOI.BarrierIterations()` to use this function.
 """
-function barrier_iterations(model::Model)
+function barrier_iterations(model::GenericModel)
     return MOI.get(model, MOI.BarrierIterations())
 end
 
 """
-    node_count(model::Model)
+    node_count(model::GenericModel)
 
 Gets the total number of branch-and-bound nodes explored during the most recent
 optimization in a Mixed Integer Program.
 
 Solvers must implement `MOI.NodeCount()` to use this function.
 """
-function node_count(model::Model)
+function node_count(model::GenericModel)
     return MOI.get(model, MOI.NodeCount())
 end
 
 """
-    get(model::Model, attr::MathOptInterface.AbstractOptimizerAttribute)
+    get(model::GenericModel, attr::MathOptInterface.AbstractOptimizerAttribute)
 
 Return the value of the attribute `attr` from the model's MOI backend.
 """
-function MOI.get(model::Model, attr::MOI.AbstractOptimizerAttribute)
+function MOI.get(model::GenericModel, attr::MOI.AbstractOptimizerAttribute)
     return MOI.get(backend(model), attr)
 end
 
@@ -617,7 +619,7 @@ struct OptimizeNotCalled <: Exception end
 """
     struct NoOptimizer <: Exception end
 
-No optimizer is set. The optimizer can be provided to the [`Model`](@ref)
+No optimizer is set. The optimizer can be provided to the [`GenericModel`](@ref)
 constructor or by calling [`set_optimizer`](@ref).
 """
 struct NoOptimizer <: Exception end
@@ -641,11 +643,11 @@ function _moi_get_result(model::MOIU.CachingOptimizer, args...)
 end
 
 """
-    get(model::Model, attr::MathOptInterface.AbstractModelAttribute)
+    get(model::GenericModel, attr::MathOptInterface.AbstractModelAttribute)
 
 Return the value of the attribute `attr` from the model's MOI backend.
 """
-function MOI.get(model::Model, attr::MOI.AbstractModelAttribute)
+function MOI.get(model::GenericModel, attr::MOI.AbstractModelAttribute)
     if !MOI.is_set_by_optimize(attr)
         return MOI.get(backend(model), attr)
     elseif model.is_model_dirty && mode(model) != DIRECT
@@ -661,9 +663,9 @@ function MOI.get(model::Model, attr::MOI.AbstractModelAttribute)
 end
 
 function MOI.get(
-    model::Model,
+    model::GenericModel,
     attr::MOI.AbstractVariableAttribute,
-    v::VariableRef,
+    v::GenericVariableRef,
 )
     check_belongs_to_model(v, model)
     if !MOI.is_set_by_optimize(attr)
@@ -681,7 +683,7 @@ function MOI.get(
 end
 
 function MOI.get(
-    model::Model,
+    model::GenericModel,
     attr::MOI.AbstractConstraintAttribute,
     cr::ConstraintRef,
 )
@@ -700,22 +702,22 @@ function MOI.get(
     return _moi_get_result(backend(model), attr, index(cr))
 end
 
-function MOI.set(m::Model, attr::MOI.AbstractOptimizerAttribute, value)
+function MOI.set(m::GenericModel, attr::MOI.AbstractOptimizerAttribute, value)
     m.is_model_dirty = true
     MOI.set(backend(m), attr, value)
     return
 end
 
-function MOI.set(m::Model, attr::MOI.AbstractModelAttribute, value)
+function MOI.set(m::GenericModel, attr::MOI.AbstractModelAttribute, value)
     m.is_model_dirty = true
     MOI.set(backend(m), attr, value)
     return
 end
 
 function MOI.set(
-    model::Model,
+    model::GenericModel,
     attr::MOI.AbstractVariableAttribute,
-    v::VariableRef,
+    v::GenericVariableRef,
     value,
 )
     check_belongs_to_model(v, model)
@@ -724,7 +726,7 @@ function MOI.set(
 end
 
 function MOI.set(
-    model::Model,
+    model::GenericModel,
     attr::MOI.AbstractConstraintAttribute,
     cr::ConstraintRef,
     value,
@@ -735,8 +737,8 @@ function MOI.set(
 end
 
 """
-    get_attribute(model::Model, attr::MOI.AbstractModelAttribute)
-    get_attribute(x::VariableRef, attr::MOI.AbstractVariableAttribute)
+    get_attribute(model::GenericModel, attr::MOI.AbstractModelAttribute)
+    get_attribute(x::GenericVariableRef, attr::MOI.AbstractVariableAttribute)
     get_attribute(cr::ConstraintRef, attr::MOI.AbstractConstraintAttribute)
 
 Get the value of a solver-specifc attribute `attr`.
@@ -766,11 +768,14 @@ julia> get_attribute(c, MOI.ConstraintName())
 "c"
 ```
 """
-function get_attribute(model::Model, attr::MOI.AbstractModelAttribute)
+function get_attribute(model::GenericModel, attr::MOI.AbstractModelAttribute)
     return MOI.get(model, attr)
 end
 
-function get_attribute(x::VariableRef, attr::MOI.AbstractVariableAttribute)
+function get_attribute(
+    x::GenericVariableRef,
+    attr::MOI.AbstractVariableAttribute,
+)
     return MOI.get(owner_model(x), attr, x)
 end
 
@@ -836,8 +841,8 @@ function get_attribute(
 end
 
 """
-    set_attribute(model::Model, attr::MOI.AbstractModelAttribute, value)
-    set_attribute(x::VariableRef, attr::MOI.AbstractVariableAttribute, value)
+    set_attribute(model::GenericModel, attr::MOI.AbstractModelAttribute, value)
+    set_attribute(x::GenericVariableRef, attr::MOI.AbstractVariableAttribute, value)
     set_attribute(cr::ConstraintRef, attr::MOI.AbstractConstraintAttribute, value)
 
 Set the value of a solver-specifc attribute `attr` to `value`.
@@ -864,13 +869,17 @@ julia> set_attribute(x, MOI.VariableName(), "x_new")
 julia> set_attribute(c, MOI.ConstraintName(), "c_new")
 ```
 """
-function set_attribute(model::Model, attr::MOI.AbstractModelAttribute, value)
+function set_attribute(
+    model::GenericModel,
+    attr::MOI.AbstractModelAttribute,
+    value,
+)
     MOI.set(model, attr, value)
     return
 end
 
 function set_attribute(
-    x::VariableRef,
+    x::GenericVariableRef,
     attr::MOI.AbstractVariableAttribute,
     value,
 )
@@ -1031,15 +1040,17 @@ function _moi_optimizer_index(
 end
 
 """
-    optimizer_index(x::VariableRef)::MOI.VariableIndex
-    optimizer_index(x::ConstraintRef{Model})::MOI.ConstraintIndex
+    optimizer_index(x::GenericVariableRef)::MOI.VariableIndex
+    optimizer_index(x::ConstraintRef{<:GenericModel})::MOI.ConstraintIndex
 
 Return the index that corresponds to `x` in the optimizer model.
 
 Throws [`NoOptimizer`](@ref) if no optimizer is set, and throws an
 `ErrorException` if the optimizer is set but is not attached.
 """
-function optimizer_index(x::Union{VariableRef,ConstraintRef{Model}})
+function optimizer_index(
+    x::Union{GenericVariableRef,ConstraintRef{<:GenericModel}},
+)
     model = owner_model(x)
     if mode(model) == DIRECT
         return index(x)
@@ -1049,7 +1060,7 @@ end
 
 """
     set_start_values(
-        model::Model;
+        model::GenericModel;
         variable_primal_start::Union{Nothing,Function} = value,
         constraint_primal_start::Union{Nothing,Function} = value,
         constraint_dual_start::Union{Nothing,Function} = dual,
@@ -1101,13 +1112,13 @@ The default is [`dual`](@ref).
 This function controls the dual starting solution for the nonlinear constraints
 It is equivalent to calling [`set_nonlinear_dual_start_value`](@ref).
 
-If it is a function, it must have the form `nonlinear_dual_start(model::Model)`
+If it is a function, it must have the form `nonlinear_dual_start(model::GenericModel)`
 that returns a vector corresponding to the dual start of the constraints.
 
 The default is [`nonlinear_dual_start_value`](@ref).
 """
 function set_start_values(
-    model::Model;
+    model::GenericModel;
     variable_primal_start::Union{Nothing,Function} = value,
     constraint_primal_start::Union{Nothing,Function} = value,
     constraint_dual_start::Union{Nothing,Function} = dual,

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -52,6 +52,18 @@ mutable struct GenericQuadExpr{CoefType,VarType} <: AbstractJuMPScalar
 end
 
 """
+    variable_ref_type(::Union{GenericQuadExpr{C,V},Type{GenericQuadExpr{C,V}}}) where {C,V}
+
+A helper function used internally by JuMP and some JuMP extensions. Returns the
+variable type `V` from a [`GenericQuadExpr`](@ref)
+"""
+function variable_ref_type(
+    ::Union{GenericQuadExpr{C,V},Type{GenericQuadExpr{C,V}}},
+) where {C,V}
+    return V
+end
+
+"""
     GenericQuadExpr(
         aff::GenericAffExpr{V,K},
         kv::AbstractArray{Pair{UnorderedPair{K},V}}
@@ -583,8 +595,8 @@ function _moi_quadratic_term(t::Tuple)
     )
 end
 function MOI.ScalarQuadraticFunction(
-    q::GenericQuadExpr{C,VariableRef},
-) where {C}
+    q::GenericQuadExpr{C,GenericVariableRef{T}},
+) where {C,T}
     _assert_isfinite(q)
     qterms = MOI.ScalarQuadraticTerm{C}[
         _moi_quadratic_term(t) for t in quad_terms(q)
@@ -599,12 +611,12 @@ function moi_function_type(::Type{<:GenericQuadExpr{T}}) where {T}
     return MOI.ScalarQuadraticFunction{T}
 end
 
-function GenericQuadExpr{C,VariableRef}(
-    m::Model,
+function GenericQuadExpr{C,GenericVariableRef{T}}(
+    m::GenericModel{T},
     f::MOI.ScalarQuadraticFunction,
-) where {C}
-    quad = GenericQuadExpr{C,VariableRef}(
-        GenericAffExpr{C,VariableRef}(
+) where {C,T}
+    quad = GenericQuadExpr{C,GenericVariableRef{T}}(
+        GenericAffExpr{C,GenericVariableRef{T}}(
             m,
             MOI.ScalarAffineFunction(f.affine_terms, f.constant),
         ),
@@ -616,34 +628,40 @@ function GenericQuadExpr{C,VariableRef}(
         if v1 == v2
             coef /= 2
         end
-        add_to_expression!(quad, coef, VariableRef(m, v1), VariableRef(m, v2))
+        add_to_expression!(
+            quad,
+            coef,
+            GenericVariableRef{T}(m, v1),
+            GenericVariableRef{T}(m, v2),
+        )
     end
     return quad
 end
 function jump_function_type(
-    ::Model,
-    ::Type{MOI.ScalarQuadraticFunction{T}},
-) where {T}
-    return GenericQuadExpr{T,VariableRef}
+    ::GenericModel{T},
+    ::Type{MOI.ScalarQuadraticFunction{C}},
+) where {C,T}
+    return GenericQuadExpr{C,GenericVariableRef{T}}
 end
 function jump_function(
-    model::Model,
-    f::MOI.ScalarQuadraticFunction{T},
-) where {T}
-    return GenericQuadExpr{T,VariableRef}(model, f)
+    model::GenericModel{T},
+    f::MOI.ScalarQuadraticFunction{C},
+) where {C,T}
+    return GenericQuadExpr{C,GenericVariableRef{T}}(model, f)
 end
 function jump_function_type(
-    ::Model,
-    ::Type{MOI.VectorQuadraticFunction{T}},
-) where {T}
-    return Vector{GenericQuadExpr{T,VariableRef}}
+    ::GenericModel{T},
+    ::Type{MOI.VectorQuadraticFunction{C}},
+) where {C,T}
+    return Vector{GenericQuadExpr{C,GenericVariableRef{T}}}
 end
 function jump_function(
-    model::Model,
-    f::MOI.VectorQuadraticFunction{T},
-) where {T}
-    return GenericQuadExpr{T,VariableRef}[
-        GenericQuadExpr{T,VariableRef}(model, f) for f in MOIU.eachscalar(f)
+    model::GenericModel{T},
+    f::MOI.VectorQuadraticFunction{C},
+) where {C,T}
+    return GenericQuadExpr{C,GenericVariableRef{T}}[
+        GenericQuadExpr{C,GenericVariableRef{T}}(model, f) for
+        f in MOIU.eachscalar(f)
     ]
 end
 
@@ -671,8 +689,8 @@ function _fill_vqf!(
 end
 
 function MOI.VectorQuadraticFunction(
-    quads::Vector{GenericQuadExpr{C,VariableRef}},
-) where {C}
+    quads::Vector{GenericQuadExpr{C,GenericVariableRef{T}}},
+) where {C,T}
     num_quadratic_terms = sum(quad -> length(quad_terms(quad)), quads)
     quadratic_terms =
         Vector{MOI.VectorQuadraticTerm{C}}(undef, num_quadratic_terms)

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -199,8 +199,9 @@ struct SOS1{T} <: AbstractVectorSet
         return new{T}(convert(Vector{T}, weights))
     end
 end
-SOS1() = SOS1{Int}()
-SOS1(weights) = SOS1{eltype(weights)}(weights)
+
+SOS1(weights::AbstractVector = Int[]) = SOS1{eltype(weights)}(weights)
+
 function moi_set(set::SOS1{T}, dim::Int) where {T}
     if length(set.weights) == 0
         return MOI.SOS1{T}(collect(1:dim))
@@ -230,10 +231,11 @@ struct SOS2{T} <: AbstractVectorSet
         return new{T}(convert(Vector{T}, weights))
     end
 end
+
 # `Int` is chosen as a placeholder, and it is replaced by the `value_type`
 # converted by `model_convert` when adding to the model.
-SOS2() = SOS2{Int}()
-SOS2(weights) = SOS2{eltype(weights)}(weights)
+SOS2(weights::AbstractVector = Int[]) = SOS2{eltype(weights)}(weights)
+
 function moi_set(set::SOS2{T}, dim::Int) where {T}
     if length(set.weights) == 0
         return MOI.SOS2{T}(collect(1:dim))

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -193,17 +193,19 @@ they should be unique values. The *k*th element in the set corresponds to the
 for a description of SOS constraints and their potential uses.
 This is a shortcut for the `MathOptInterface.SOS1` set.
 """
-struct SOS1 <: AbstractVectorSet
-    weights::Vector{Float64}
-    function SOS1(weights::AbstractVector = Float64[])
-        return new(convert(Vector{Float64}, weights))
+struct SOS1{T} <: AbstractVectorSet
+    weights::Vector{T}
+    function SOS1{T}(weights::AbstractVector = T[]) where {T}
+        return new{T}(convert(Vector{T}, weights))
     end
 end
-function moi_set(set::SOS1, dim::Int)
+SOS1() = SOS1{Int}()
+SOS1(weights) = SOS1{eltype(weights)}(weights)
+function moi_set(set::SOS1{T}, dim::Int) where {T}
     if length(set.weights) == 0
-        return MOI.SOS1(collect(1:1.0:dim))
+        return MOI.SOS1{T}(collect(1:dim))
     elseif length(set.weights) == dim
-        return MOI.SOS1(set.weights)
+        return MOI.SOS1{T}(set.weights)
     else
         error("Weight vector in SOS1 is not of length $(dim).")
     end
@@ -222,17 +224,19 @@ See [here](http://lpsolve.sourceforge.net/5.5/SOS.htm) for a description of SOS
 constraints and their potential uses.
 This is a shortcut for the `MathOptInterface.SOS2` set.
 """
-struct SOS2 <: AbstractVectorSet
-    weights::Vector{Float64}
-    function SOS2(weights::AbstractVector = Float64[])
-        return new(convert(Vector{Float64}, weights))
+struct SOS2{T} <: AbstractVectorSet
+    weights::Vector{T}
+    function SOS2{T}(weights::AbstractVector = T[]) where {T}
+        return new{T}(convert(Vector{T}, weights))
     end
 end
-function moi_set(set::SOS2, dim::Int)
+SOS2() = SOS2{Int}()
+SOS2(weights) = SOS2{eltype(weights)}(weights)
+function moi_set(set::SOS2{T}, dim::Int) where {T}
     if length(set.weights) == 0
-        return MOI.SOS2(collect(1:1.0:dim))
+        return MOI.SOS2{T}(collect(1:dim))
     elseif length(set.weights) == dim
-        return MOI.SOS2(set.weights)
+        return MOI.SOS2{T}(set.weights)
     else
         error("Weight vector in SOS2 is not of length $(dim).")
     end

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -230,6 +230,8 @@ struct SOS2{T} <: AbstractVectorSet
         return new{T}(convert(Vector{T}, weights))
     end
 end
+# `Int` is chosen as a placeholder, and it is replaced by the `value_type`
+# converted by `model_convert` when adding to the model.
 SOS2() = SOS2{Int}()
 SOS2(weights) = SOS2{eltype(weights)}(weights)
 function moi_set(set::SOS2{T}, dim::Int) where {T}
@@ -301,8 +303,8 @@ struct Semicontinuous{T} <: AbstractScalarSet
     end
 end
 
-function moi_set(set::Semicontinuous)
-    return MOI.Semicontinuous{Float64}(set.lower, set.upper)
+function moi_set(set::Semicontinuous{T}) where {T}
+    return MOI.Semicontinuous{T}(set.lower, set.upper)
 end
 
 """
@@ -337,6 +339,6 @@ struct Semiinteger{T} <: AbstractScalarSet
     end
 end
 
-function moi_set(set::Semiinteger)
-    return MOI.Semiinteger{Float64}(set.lower, set.upper)
+function moi_set(set::Semiinteger{T}) where {T}
+    return MOI.Semiinteger{T}(set.lower, set.upper)
 end

--- a/src/solution_summary.jl
+++ b/src/solution_summary.jl
@@ -3,7 +3,7 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-struct _SolutionSummary
+struct _SolutionSummary{T}
     result::Int
     verbose::Bool
     solver::String
@@ -16,21 +16,27 @@ struct _SolutionSummary
     has_values::Bool
     has_duals::Bool
     # Candidate solution
-    objective_value::Union{Missing,Float64,Vector{Float64}}
-    objective_bound::Union{Missing,Float64,Vector{Float64}}
-    relative_gap::Union{Missing,Float64}
-    dual_objective_value::Union{Missing,Float64}
-    primal_solution::Union{Missing,Dict{String,Float64}}
-    dual_solution::Union{Missing,Dict{String,Float64}}
+    objective_value::Union{Missing,T,Vector{T}}
+    objective_bound::Union{Missing,T,Vector{T}}
+    relative_gap::Union{Missing,T}
+    dual_objective_value::Union{Missing,T}
+    primal_solution::Union{Missing,Dict{String,T}}
+    dual_solution::Union{Missing,Dict{String,T}}
     # Work counters
     solve_time::Union{Missing,Float64}
     barrier_iterations::Union{Missing,Int}
     simplex_iterations::Union{Missing,Int}
     node_count::Union{Missing,Int}
+    # The default construction `_SolutionSummary(...)` wouldn't work
+    # as `T` would be unbound if `missing` is passed for all possible fields
+    # hence `Aqua` complains.
+    function _SolutionSummary{T}(args...) where {T}
+        return new{T}(args...)
+    end
 end
 
 """
-    solution_summary(model::Model; result::Int = 1, verbose::Bool = false)
+    solution_summary(model::GenericModel; result::Int = 1, verbose::Bool = false)
 
 Return a struct that can be used print a summary of the solution in result
 `result`.
@@ -86,11 +92,15 @@ julia> foo(model)
 * Work counters
 ```
 """
-function solution_summary(model::Model; result::Int = 1, verbose::Bool = false)
+function solution_summary(
+    model::GenericModel{T};
+    result::Int = 1,
+    verbose::Bool = false,
+) where {T}
     num_results = result_count(model)
     has_primal = has_values(model; result = result)
     has_dual = has_duals(model; result = result)
-    return _SolutionSummary(
+    return _SolutionSummary{T}(
         result,
         verbose,
         solver_name(model),
@@ -211,7 +221,7 @@ function _show_work_counters_summary(io::IO, summary::_SolutionSummary)
 end
 
 function _get_solution_dict(model, result)
-    dict = Dict{String,Float64}()
+    dict = Dict{String,value_type(typeof(model))}()
     for x in all_variables(model)
         variable_name = name(x)
         if !isempty(variable_name)
@@ -222,7 +232,7 @@ function _get_solution_dict(model, result)
 end
 
 function _get_constraint_dict(model, result)
-    dict = Dict{String,Float64}()
+    dict = Dict{String,value_type(typeof(model))}()
     for (F, S) in list_of_constraint_types(model)
         for constraint in all_constraints(model, F, S)
             constraint_name = name(constraint)
@@ -243,8 +253,8 @@ function _try_get(f, model)
 end
 
 _print_if_not_missing(io, header, ::Missing) = nothing
-_print_if_not_missing(io, header, value::Int) = println(io, header, value)
-function _print_if_not_missing(io, header, value::Real)
+_print_if_not_missing(io, header, value::Real) = println(io, header, value)
+function _print_if_not_missing(io, header, value::AbstractFloat)
     println(io, header, Printf.@sprintf("%.5e", value))
     return
 end

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -4,11 +4,12 @@
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 """
-    num_variables(model::Model)::Int64
+    num_variables(model::GenericModel)::Int64
 
 Returns number of variables in `model`.
 """
-num_variables(model::Model)::Int64 = MOI.get(model, MOI.NumberOfVariables())
+num_variables(model::GenericModel)::Int64 =
+    MOI.get(model, MOI.NumberOfVariables())
 
 """
     AbstractVariable
@@ -214,7 +215,11 @@ with variables of type `V<:AbstractVariableRef` and coefficients of type `T`
 """
 abstract type AbstractVariableRef <: AbstractJuMPScalar end
 
+variable_ref_type(V::Type{<:AbstractVariableRef}) = V
 variable_ref_type(v::AbstractVariableRef) = typeof(v)
+
+value_type(::Type{<:AbstractVariableRef}) = Float64
+
 Base.conj(v::AbstractVariableRef) = v
 Base.real(v::AbstractVariableRef) = v
 Base.imag(v::AbstractVariableRef) = zero(v)
@@ -222,13 +227,22 @@ Base.abs2(v::AbstractVariableRef) = v^2
 Base.isreal(::AbstractVariableRef) = true
 
 """
-    VariableRef <: AbstractVariableRef
+    GenericVariableRef <: AbstractVariableRef
 
 Holds a reference to the model and the corresponding MOI.VariableIndex.
 """
-struct VariableRef <: AbstractVariableRef
-    model::Model
+struct GenericVariableRef{T} <: AbstractVariableRef
+    model::GenericModel{T}
     index::MOI.VariableIndex
+end
+
+const VariableRef = GenericVariableRef{Float64}
+
+value_type(::Type{GenericVariableRef{T}}) where {T} = T
+function variable_ref_type(
+    ::Union{GenericModel{T},Type{GenericModel{T}}},
+) where {T}
+    return GenericVariableRef{T}
 end
 
 # `AbstractVariableRef` types must override the default `owner_model` if the field
@@ -283,37 +297,56 @@ function check_belongs_to_model(v::AbstractVariableRef, model::AbstractModel)
     end
 end
 
-Base.iszero(::VariableRef) = false
-Base.copy(v::VariableRef) = VariableRef(v.model, v.index)
-Base.broadcastable(v::VariableRef) = Ref(v)
+Base.iszero(::GenericVariableRef) = false
+function Base.copy(v::GenericVariableRef{T}) where {T}
+    return GenericVariableRef{T}(v.model, v.index)
+end
+Base.broadcastable(v::GenericVariableRef) = Ref(v)
 
 Base.zero(v::AbstractVariableRef) = zero(typeof(v))
 
 function Base.zero(::Type{V}) where {V<:AbstractVariableRef}
-    return zero(GenericAffExpr{Float64,V})
+    return zero(GenericAffExpr{value_type(V),V})
 end
 
 Base.one(v::AbstractVariableRef) = one(typeof(v))
 
 function Base.one(::Type{V}) where {V<:AbstractVariableRef}
-    return one(GenericAffExpr{Float64,V})
+    return one(GenericAffExpr{value_type(V),V})
 end
 
 """
-    coefficient(v1::VariableRef, v2::VariableRef)
+    coefficient(v1::GenericVariableRef{T}, v2::GenericVariableRef{T}) where {T}
 
-Return `1.0` if `v1 == v2`, and `0.0` otherwise.
+Return `one(T)` if `v1 == v2`, and `zero(T)` otherwise.
 
 This is a fallback for other [`coefficient`](@ref) methods to simplify code in
 which the expression may be a single variable.
 """
-coefficient(v1::VariableRef, v2::VariableRef) = (v1 == v2 ? 1.0 : 0.0)
-coefficient(v1::VariableRef, v2::VariableRef, v3::VariableRef) = 0.0
+function coefficient(
+    v1::GenericVariableRef{T},
+    v2::GenericVariableRef{T},
+) where {T}
+    if v1 == v2
+        return one(T)
+    else
+        return zero(T)
+    end
+end
+function coefficient(
+    ::GenericVariableRef{T},
+    ::GenericVariableRef{T},
+    ::GenericVariableRef{T},
+) where {T}
+    return zero(T)
+end
 
-isequal_canonical(v::VariableRef, other::VariableRef) = isequal(v, other)
+function isequal_canonical(v::GenericVariableRef, other::GenericVariableRef)
+    return isequal(v, other)
+end
 
 """
-    delete(model::Model, variable_ref::VariableRef)
+    delete(model::GenericModel, variable_ref::GenericVariableRef)
 
 Delete the variable associated with `variable_ref` from the model `model`.
 
@@ -343,7 +376,7 @@ Stacktrace:
 [...]
 ```
 """
-function delete(model::Model, variable_ref::VariableRef)
+function delete(model::GenericModel, variable_ref::GenericVariableRef)
     if model !== owner_model(variable_ref)
         error(
             "The variable reference you are trying to delete does not " *
@@ -356,7 +389,7 @@ function delete(model::Model, variable_ref::VariableRef)
 end
 
 """
-    delete(model::Model, variable_refs::Vector{VariableRef})
+    delete(model::GenericModel, variable_refs::Vector{<:GenericVariableRef})
 
 Delete the variables associated with `variable_refs` from the model `model`.
 Solvers may implement methods for deleting multiple variables that are
@@ -364,7 +397,10 @@ more efficient than repeatedly calling the single variable delete method.
 
 See also: [`unregister`](@ref)
 """
-function delete(model::Model, variable_refs::Vector{VariableRef})
+function delete(
+    model::GenericModel,
+    variable_refs::Vector{<:GenericVariableRef},
+)
     if any(model !== owner_model(v) for v in variable_refs)
         error(
             "A variable reference you are trying to delete does not " *
@@ -377,11 +413,11 @@ function delete(model::Model, variable_refs::Vector{VariableRef})
 end
 
 """
-    is_valid(model::Model, variable_ref::VariableRef)
+    is_valid(model::GenericModel, variable_ref::GenericVariableRef)
 
 Return `true` if `variable` refers to a valid variable in `model`.
 """
-function is_valid(model::Model, variable_ref::VariableRef)
+function is_valid(model::GenericModel, variable_ref::GenericVariableRef)
     return model === owner_model(variable_ref) &&
            MOI.is_valid(backend(model), variable_ref.index)
 end
@@ -389,24 +425,28 @@ end
 # The default hash is slow. It's important for the performance of AffExpr to
 # define our own.
 # https://github.com/jump-dev/MathOptInterface.jl/issues/234#issuecomment-366868878
-function Base.hash(v::VariableRef, h::UInt)
+function Base.hash(v::GenericVariableRef, h::UInt)
     return hash(objectid(owner_model(v)), hash(v.index.value, h))
 end
 
-function Base.isequal(v1::VariableRef, v2::VariableRef)
+function Base.isequal(v1::GenericVariableRef, v2::GenericVariableRef)
     return owner_model(v1) === owner_model(v2) && v1.index == v2.index
 end
 
 """
-    index(v::VariableRef)::MOI.VariableIndex
+    index(v::GenericVariableRef)::MOI.VariableIndex
 
 Return the index of the variable that corresponds to `v` in the MOI backend.
 """
-index(v::VariableRef) = v.index
+index(v::GenericVariableRef) = v.index
 
-function VariableRef(m::Model)
-    index = MOI.add_variable(backend(m))
-    return VariableRef(m, index)
+function GenericVariableRef{T}(model::GenericModel{T}) where {T}
+    index = MOI.add_variable(backend(model))
+    return GenericVariableRef{T}(model, index)
+end
+
+function GenericVariableRef(model::GenericModel{T}) where {T}
+    return GenericVariableRef{T}(model)
 end
 
 """
@@ -430,20 +470,23 @@ julia> VariableRef(c) == x
 true
 ```
 """
-function VariableRef(
+function GenericVariableRef{T}(
     c::ConstraintRef{<:AbstractModel,<:MOI.ConstraintIndex{MOI.VariableIndex}},
-)
-    return VariableRef(owner_model(c), MOI.VariableIndex(index(c).value))
+) where {T}
+    return GenericVariableRef{T}(
+        owner_model(c),
+        MOI.VariableIndex(index(c).value),
+    )
 end
 
 # Name setter/getters
 # These functions need to be implemented for all `AbstractVariableRef`s
 """
-    name(v::VariableRef)::String
+    name(v::GenericVariableRef)::String
 
 Get a variable's name attribute.
 """
-function name(v::VariableRef)
+function name(v::GenericVariableRef)
     model = owner_model(v)
     if !MOI.supports(backend(model), MOI.VariableName(), MOI.VariableIndex)
         return ""
@@ -452,11 +495,11 @@ function name(v::VariableRef)
 end
 
 """
-    set_name(v::VariableRef, s::AbstractString)
+    set_name(v::GenericVariableRef, s::AbstractString)
 
 Set a variable's name attribute.
 """
-function set_name(v::VariableRef, s::String)
+function set_name(v::GenericVariableRef, s::String)
     MOI.set(owner_model(v), MOI.VariableName(), v, s)
     return
 end
@@ -492,7 +535,7 @@ Stacktrace:
  [2] get(::MOIU.Model{Float64}, ::Type{MathOptInterface.VariableIndex}, ::String) at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/model.jl:222
  [3] get at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/universalfallback.jl:201 [inlined]
  [4] get(::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.AbstractOptimizer,MathOptInterface.Utilities.UniversalFallback{MOIU.Model{Float64}}}, ::Type{MathOptInterface.VariableIndex}, ::String) at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/cachingoptimizer.jl:490
- [5] variable_by_name(::Model, ::String) at /home/blegat/.julia/dev/JuMP/src/variables.jl:268
+ [5] variable_by_name(::GenericModel, ::String) at /home/blegat/.julia/dev/JuMP/src/variables.jl:268
  [6] top-level scope at none:0
 
 julia> var = @variable(model, base_name="y")
@@ -517,22 +560,22 @@ julia> variable_by_name(model, "u[2]")
 u[2]
 ```
 """
-function variable_by_name(model::Model, name::String)
+function variable_by_name(model::GenericModel, name::String)
     index = MOI.get(backend(model), MOI.VariableIndex, name)
     if index === nothing
         return nothing
     end
-    return VariableRef(model, index)
+    return GenericVariableRef(model, index)
 end
 
-MOI.VariableIndex(v::VariableRef) = index(v)
+MOI.VariableIndex(v::GenericVariableRef) = index(v)
 
 moi_function(variable::AbstractVariableRef) = index(variable)
 
 moi_function_type(::Type{<:AbstractVariableRef}) = MOI.VariableIndex
 
 # Note: No validation is performed that the variables belong to the same model.
-function MOI.VectorOfVariables(vars::Vector{VariableRef})
+function MOI.VectorOfVariables(vars::Vector{<:GenericVariableRef})
     return MOI.VectorOfVariables(index.(vars))
 end
 
@@ -544,18 +587,34 @@ function moi_function_type(::Type{<:Vector{<:AbstractVariableRef}})
     return MOI.VectorOfVariables
 end
 
-function jump_function_type(::Model, ::Type{MOI.VectorOfVariables})
-    return Vector{VariableRef}
+function jump_function_type(
+    ::GenericModel{T},
+    ::Type{MOI.VectorOfVariables},
+) where {T}
+    return Vector{GenericVariableRef{T}}
 end
 
-function jump_function(model::Model, variables::MOI.VectorOfVariables)
-    return VariableRef[VariableRef(model, v) for v in variables.variables]
+function jump_function(
+    model::GenericModel{T},
+    variables::MOI.VectorOfVariables,
+) where {T}
+    return GenericVariableRef{T}[
+        GenericVariableRef{T}(model, v) for v in variables.variables
+    ]
 end
 
-jump_function_type(::Model, ::Type{MOI.VariableIndex}) = VariableRef
+function jump_function_type(
+    ::GenericModel{T},
+    ::Type{MOI.VariableIndex},
+) where {T}
+    return GenericVariableRef{T}
+end
 
-function jump_function(model::Model, variable::MOI.VariableIndex)
-    return VariableRef(model, variable)
+function jump_function(
+    model::GenericModel{T},
+    variable::MOI.VariableIndex,
+) where {T}
+    return GenericVariableRef{T}(model, variable)
 end
 
 ## Bound setter/getters
@@ -563,7 +622,7 @@ end
 # lower bounds
 
 """
-    has_lower_bound(v::VariableRef)
+    has_lower_bound(v::GenericVariableRef)
 
 Return `true` if `v` has a lower bound. If `true`, the lower bound can be
 queried with [`lower_bound`](@ref).
@@ -571,24 +630,24 @@ queried with [`lower_bound`](@ref).
 See also [`LowerBoundRef`](@ref), [`lower_bound`](@ref),
 [`set_lower_bound`](@ref), [`delete_lower_bound`](@ref).
 """
-function has_lower_bound(v::VariableRef)
+function has_lower_bound(v::GenericVariableRef)
     return _moi_has_lower_bound(backend(owner_model(v)), v)
 end
 
 # _moi_* methods allow us to work around the type instability of the backend of
 # a model.
-function _moi_has_lower_bound(moi_backend, v::VariableRef)
+function _moi_has_lower_bound(moi_backend, v::GenericVariableRef)
     return MOI.is_valid(moi_backend, _lower_bound_index(v))
 end
 
-function _lower_bound_index(v::VariableRef)
-    return MOI.ConstraintIndex{MOI.VariableIndex,MOI.GreaterThan{Float64}}(
+function _lower_bound_index(v::GenericVariableRef{T}) where {T}
+    return MOI.ConstraintIndex{MOI.VariableIndex,MOI.GreaterThan{T}}(
         index(v).value,
     )
 end
 
 """
-    set_lower_bound(v::VariableRef, lower::Number)
+    set_lower_bound(v::GenericVariableRef, lower::Number)
 
 Set the lower bound of a variable. If one does not exist, create a new lower
 bound constraint.
@@ -596,7 +655,7 @@ bound constraint.
 See also [`LowerBoundRef`](@ref), [`has_lower_bound`](@ref),
 [`lower_bound`](@ref), [`delete_lower_bound`](@ref).
 """
-function set_lower_bound(v::VariableRef, lower::Number)
+function set_lower_bound(v::GenericVariableRef, lower::Number)
     if !isfinite(lower)
         error(
             "Unable to set lower bound to $(lower). To remove the bound, use " *
@@ -609,8 +668,12 @@ function set_lower_bound(v::VariableRef, lower::Number)
     return
 end
 
-function _moi_set_lower_bound(moi_backend, v::VariableRef, lower::Number)
-    new_set = MOI.GreaterThan(convert(Float64, lower))
+function _moi_set_lower_bound(
+    moi_backend,
+    v::GenericVariableRef{T},
+    lower::Number,
+) where {T}
+    new_set = MOI.GreaterThan(convert(T, lower))
     if _moi_has_lower_bound(moi_backend, v)
         cindex = _lower_bound_index(v)
         MOI.set(moi_backend, MOI.ConstraintSet(), cindex, new_set)
@@ -622,7 +685,7 @@ function _moi_set_lower_bound(moi_backend, v::VariableRef, lower::Number)
 end
 
 """
-    LowerBoundRef(v::VariableRef)
+    LowerBoundRef(v::GenericVariableRef)
 
 Return a constraint reference to the lower bound constraint of `v`. Errors if
 one does not exist.
@@ -630,43 +693,43 @@ one does not exist.
 See also [`has_lower_bound`](@ref), [`lower_bound`](@ref),
 [`set_lower_bound`](@ref), [`delete_lower_bound`](@ref).
 """
-function LowerBoundRef(v::VariableRef)
+function LowerBoundRef(v::GenericVariableRef)
     return ConstraintRef(owner_model(v), _lower_bound_index(v), ScalarShape())
 end
 
 """
-    delete_lower_bound(v::VariableRef)
+    delete_lower_bound(v::GenericVariableRef)
 
 Delete the lower bound constraint of a variable.
 
 See also [`LowerBoundRef`](@ref), [`has_lower_bound`](@ref),
 [`lower_bound`](@ref), [`set_lower_bound`](@ref).
 """
-function delete_lower_bound(variable_ref::VariableRef)
+function delete_lower_bound(variable_ref::GenericVariableRef)
     delete(owner_model(variable_ref), LowerBoundRef(variable_ref))
     return
 end
 
 """
-    lower_bound(v::VariableRef)
+    lower_bound(v::GenericVariableRef)
 
 Return the lower bound of a variable. Error if one does not exist.
 
 See also [`LowerBoundRef`](@ref), [`has_lower_bound`](@ref),
 [`set_lower_bound`](@ref), [`delete_lower_bound`](@ref).
 """
-function lower_bound(v::VariableRef)
+function lower_bound(v::GenericVariableRef{T}) where {T}
     if !has_lower_bound(v)
         error("Variable $(v) does not have a lower bound.")
     end
     set = MOI.get(owner_model(v), MOI.ConstraintSet(), LowerBoundRef(v))
-    return set.lower::Float64
+    return set.lower::T
 end
 
 # upper bounds
 
 """
-    has_upper_bound(v::VariableRef)
+    has_upper_bound(v::GenericVariableRef)
 
 Return `true` if `v` has a upper bound. If `true`, the upper bound can be
 queried with [`upper_bound`](@ref).
@@ -674,22 +737,22 @@ queried with [`upper_bound`](@ref).
 See also [`UpperBoundRef`](@ref), [`upper_bound`](@ref),
 [`set_upper_bound`](@ref), [`delete_upper_bound`](@ref).
 """
-function has_upper_bound(v::VariableRef)
+function has_upper_bound(v::GenericVariableRef)
     return _moi_has_upper_bound(backend(owner_model(v)), v)
 end
 
-function _moi_has_upper_bound(moi_backend, v::VariableRef)
+function _moi_has_upper_bound(moi_backend, v::GenericVariableRef)
     return MOI.is_valid(moi_backend, _upper_bound_index(v))
 end
 
-function _upper_bound_index(v::VariableRef)
-    return MOI.ConstraintIndex{MOI.VariableIndex,MOI.LessThan{Float64}}(
+function _upper_bound_index(v::GenericVariableRef{T}) where {T}
+    return MOI.ConstraintIndex{MOI.VariableIndex,MOI.LessThan{T}}(
         index(v).value,
     )
 end
 
 """
-    set_upper_bound(v::VariableRef, upper::Number)
+    set_upper_bound(v::GenericVariableRef, upper::Number)
 
 Set the upper bound of a variable. If one does not exist, create an upper bound
 constraint.
@@ -697,7 +760,7 @@ constraint.
 See also [`UpperBoundRef`](@ref), [`has_upper_bound`](@ref),
 [`upper_bound`](@ref), [`delete_upper_bound`](@ref).
 """
-function set_upper_bound(v::VariableRef, upper::Number)
+function set_upper_bound(v::GenericVariableRef, upper::Number)
     if !isfinite(upper)
         error(
             "Unable to set upper bound to $(upper). To remove the bound, use " *
@@ -710,8 +773,12 @@ function set_upper_bound(v::VariableRef, upper::Number)
     return
 end
 
-function _moi_set_upper_bound(moi_backend, v::VariableRef, upper::Number)
-    new_set = MOI.LessThan(convert(Float64, upper))
+function _moi_set_upper_bound(
+    moi_backend,
+    v::GenericVariableRef{T},
+    upper::Number,
+) where {T}
+    new_set = MOI.LessThan(convert(T, upper))
     if _moi_has_upper_bound(moi_backend, v)
         cindex = _upper_bound_index(v)
         MOI.set(moi_backend, MOI.ConstraintSet(), cindex, new_set)
@@ -723,7 +790,7 @@ function _moi_set_upper_bound(moi_backend, v::VariableRef, upper::Number)
 end
 
 """
-    UpperBoundRef(v::VariableRef)
+    UpperBoundRef(v::GenericVariableRef)
 
 Return a constraint reference to the upper bound constraint of `v`. Errors if
 one does not exist.
@@ -731,65 +798,63 @@ one does not exist.
 See also [`has_upper_bound`](@ref), [`upper_bound`](@ref),
 [`set_upper_bound`](@ref), [`delete_upper_bound`](@ref).
 """
-function UpperBoundRef(v::VariableRef)
+function UpperBoundRef(v::GenericVariableRef)
     return ConstraintRef(owner_model(v), _upper_bound_index(v), ScalarShape())
 end
 
 """
-    delete_upper_bound(v::VariableRef)
+    delete_upper_bound(v::GenericVariableRef)
 
 Delete the upper bound constraint of a variable.
 
 See also [`UpperBoundRef`](@ref), [`has_upper_bound`](@ref),
 [`upper_bound`](@ref), [`set_upper_bound`](@ref).
 """
-function delete_upper_bound(variable_ref::VariableRef)
+function delete_upper_bound(variable_ref::GenericVariableRef)
     delete(owner_model(variable_ref), UpperBoundRef(variable_ref))
     return
 end
 
 """
-    upper_bound(v::VariableRef)
+    upper_bound(v::GenericVariableRef)
 
 Return the upper bound of a variable. Error if one does not exist.
 
 See also [`UpperBoundRef`](@ref), [`has_upper_bound`](@ref),
 [`set_upper_bound`](@ref), [`delete_upper_bound`](@ref).
 """
-function upper_bound(v::VariableRef)
+function upper_bound(v::GenericVariableRef{T}) where {T}
     if !has_upper_bound(v)
         error("Variable $(v) does not have an upper bound.")
     end
     set = MOI.get(owner_model(v), MOI.ConstraintSet(), UpperBoundRef(v))
-    return set.upper::Float64
+    return set.upper::T
 end
 
 # fixed value
 
 """
-    is_fixed(v::VariableRef)
+    is_fixed(v::GenericVariableRef)
 
 Return `true` if `v` is a fixed variable. If `true`, the fixed value can be
 queried with [`fix_value`](@ref).
 
 See also [`FixRef`](@ref), [`fix_value`](@ref), [`fix`](@ref), [`unfix`](@ref).
 """
-function is_fixed(v::VariableRef)
+function is_fixed(v::GenericVariableRef)
     return _moi_is_fixed(backend(owner_model(v)), v)
 end
 
-function _moi_is_fixed(moi_backend, v::VariableRef)
+function _moi_is_fixed(moi_backend, v::GenericVariableRef)
     return MOI.is_valid(moi_backend, _fix_index(v))
 end
 
-function _fix_index(v::VariableRef)
-    return MOI.ConstraintIndex{MOI.VariableIndex,MOI.EqualTo{Float64}}(
-        index(v).value,
-    )
+function _fix_index(v::GenericVariableRef{T}) where {T}
+    return MOI.ConstraintIndex{MOI.VariableIndex,MOI.EqualTo{T}}(index(v).value)
 end
 
 """
-    fix(v::VariableRef, value::Number; force::Bool = false)
+    fix(v::GenericVariableRef, value::Number; force::Bool = false)
 
 Fix a variable to a value. Update the fixing constraint if one exists, otherwise
 create a new one.
@@ -802,7 +867,7 @@ after a call to [`unfix`](@ref).
 See also [`FixRef`](@ref), [`is_fixed`](@ref), [`fix_value`](@ref),
 [`unfix`](@ref).
 """
-function fix(variable::VariableRef, value::Number; force::Bool = false)
+function fix(variable::GenericVariableRef, value::Number; force::Bool = false)
     if !isfinite(value)
         error("Unable to fix variable to $(value)")
     end
@@ -814,11 +879,11 @@ end
 
 function _moi_fix(
     moi_backend,
-    variable::VariableRef,
+    variable::GenericVariableRef{T},
     value::Number,
     force::Bool,
-)
-    new_set = MOI.EqualTo(convert(Float64, value))
+) where {T}
+    new_set = MOI.EqualTo(convert(T, value))
     if _moi_is_fixed(moi_backend, variable)  # Update existing fixing constraint.
         c_index = _fix_index(variable)
         MOI.set(moi_backend, MOI.ConstraintSet(), c_index, new_set)
@@ -846,32 +911,32 @@ function _moi_fix(
 end
 
 """
-    unfix(v::VariableRef)
+    unfix(v::GenericVariableRef)
 
 Delete the fixing constraint of a variable.
 
 See also [`FixRef`](@ref), [`is_fixed`](@ref), [`fix_value`](@ref),
 [`fix`](@ref).
 """
-function unfix(variable_ref::VariableRef)
+function unfix(variable_ref::GenericVariableRef)
     delete(owner_model(variable_ref), FixRef(variable_ref))
     return
 end
 
 """
-    fix_value(v::VariableRef)
+    fix_value(v::GenericVariableRef)
 
 Return the value to which a variable is fixed. Error if one does not exist.
 
 See also [`FixRef`](@ref), [`is_fixed`](@ref), [`fix`](@ref), [`unfix`](@ref).
 """
-function fix_value(v::VariableRef)
+function fix_value(v::GenericVariableRef{T}) where {T}
     set = MOI.get(owner_model(v), MOI.ConstraintSet(), FixRef(v))
-    return set.value::Float64
+    return set.value::T
 end
 
 """
-    FixRef(v::VariableRef)
+    FixRef(v::GenericVariableRef)
 
 Return a constraint reference to the constraint fixing the value of `v`. Errors
 if one does not exist.
@@ -879,44 +944,44 @@ if one does not exist.
 See also [`is_fixed`](@ref), [`fix_value`](@ref), [`fix`](@ref),
 [`unfix`](@ref).
 """
-function FixRef(v::VariableRef)
+function FixRef(v::GenericVariableRef)
     return ConstraintRef(owner_model(v), _fix_index(v), ScalarShape())
 end
 
 """
-    is_integer(v::VariableRef)
+    is_integer(v::GenericVariableRef)
 
 Return `true` if `v` is constrained to be integer.
 
 See also [`IntegerRef`](@ref), [`set_integer`](@ref), [`unset_integer`](@ref).
 """
-function is_integer(v::VariableRef)
+function is_integer(v::GenericVariableRef)
     return _moi_is_integer(backend(owner_model(v)), v)
 end
 
-function _moi_is_integer(moi_backend, v::VariableRef)
+function _moi_is_integer(moi_backend, v::GenericVariableRef)
     return MOI.is_valid(moi_backend, _integer_index(v))
 end
 
-function _integer_index(v::VariableRef)
+function _integer_index(v::GenericVariableRef)
     return MOI.ConstraintIndex{MOI.VariableIndex,MOI.Integer}(index(v).value)
 end
 
 """
-    set_integer(variable_ref::VariableRef)
+    set_integer(variable_ref::GenericVariableRef)
 
 Add an integrality constraint on the variable `variable_ref`.
 
 See also [`IntegerRef`](@ref), [`is_integer`](@ref), [`unset_integer`](@ref).
 """
-function set_integer(v::VariableRef)
+function set_integer(v::GenericVariableRef)
     model = owner_model(v)
     model.is_model_dirty = true
     _moi_set_integer(backend(model), v)
     return
 end
 
-function _moi_set_integer(moi_backend, variable_ref::VariableRef)
+function _moi_set_integer(moi_backend, variable_ref::GenericVariableRef)
     if _moi_is_integer(moi_backend, variable_ref)
         return
     elseif _moi_is_binary(moi_backend, variable_ref)
@@ -930,57 +995,57 @@ function _moi_set_integer(moi_backend, variable_ref::VariableRef)
 end
 
 """
-    unset_integer(variable_ref::VariableRef)
+    unset_integer(variable_ref::GenericVariableRef)
 
 Remove the integrality constraint on the variable `variable_ref`.
 
 See also [`IntegerRef`](@ref), [`is_integer`](@ref), [`set_integer`](@ref).
 """
-function unset_integer(variable_ref::VariableRef)
+function unset_integer(variable_ref::GenericVariableRef)
     delete(owner_model(variable_ref), IntegerRef(variable_ref))
     return
 end
 
 """
-    IntegerRef(v::VariableRef)
+    IntegerRef(v::GenericVariableRef)
 
 Return a constraint reference to the constraint constraining `v` to be integer.
 Errors if one does not exist.
 
 See also [`is_integer`](@ref), [`set_integer`](@ref), [`unset_integer`](@ref).
 """
-function IntegerRef(v::VariableRef)
+function IntegerRef(v::GenericVariableRef)
     return ConstraintRef(owner_model(v), _integer_index(v), ScalarShape())
 end
 
 """
-    is_binary(v::VariableRef)
+    is_binary(v::GenericVariableRef)
 
 Return `true` if `v` is constrained to be binary.
 
 See also [`BinaryRef`](@ref), [`set_binary`](@ref), [`unset_binary`](@ref).
 """
-function is_binary(v::VariableRef)
+function is_binary(v::GenericVariableRef)
     return _moi_is_binary(backend(owner_model(v)), v)
 end
 
-function _moi_is_binary(moi_backend, v::VariableRef)
+function _moi_is_binary(moi_backend, v::GenericVariableRef)
     return MOI.is_valid(moi_backend, _binary_index(v))
 end
 
-function _binary_index(v::VariableRef)
+function _binary_index(v::GenericVariableRef)
     return MOI.ConstraintIndex{MOI.VariableIndex,MOI.ZeroOne}(index(v).value)
 end
 
 """
-    set_binary(v::VariableRef)
+    set_binary(v::GenericVariableRef)
 
 Add a constraint on the variable `v` that it must take values in the set
 ``\\{0,1\\}``.
 
 See also [`BinaryRef`](@ref), [`is_binary`](@ref), [`unset_binary`](@ref).
 """
-function set_binary(v::VariableRef)
+function set_binary(v::GenericVariableRef)
     model = owner_model(v)
     model.is_model_dirty = true
     _moi_set_binary(backend(model), v)
@@ -1001,31 +1066,31 @@ function _moi_set_binary(moi_backend, variable_ref)
 end
 
 """
-    unset_binary(variable_ref::VariableRef)
+    unset_binary(variable_ref::GenericVariableRef)
 
 Remove the binary constraint on the variable `variable_ref`.
 
 See also [`BinaryRef`](@ref), [`is_binary`](@ref), [`set_binary`](@ref).
 """
-function unset_binary(variable_ref::VariableRef)
+function unset_binary(variable_ref::GenericVariableRef)
     delete(owner_model(variable_ref), BinaryRef(variable_ref))
     return
 end
 
 """
-    BinaryRef(v::VariableRef)
+    BinaryRef(v::GenericVariableRef)
 
 Return a constraint reference to the constraint constraining `v` to be binary.
 Errors if one does not exist.
 
 See also [`is_binary`](@ref), [`set_binary`](@ref), [`unset_binary`](@ref).
 """
-function BinaryRef(v::VariableRef)
+function BinaryRef(v::GenericVariableRef)
     return ConstraintRef(owner_model(v), _binary_index(v), ScalarShape())
 end
 
 """
-    start_value(v::VariableRef)
+    start_value(v::GenericVariableRef)
 
 Return the start value (MOI attribute `VariablePrimalStart`) of the variable
 `v`.
@@ -1034,7 +1099,7 @@ Note: `VariablePrimalStart`s are sometimes called "MIP-starts" or "warmstarts".
 
 See also [`set_start_value`](@ref).
 """
-function start_value(v::VariableRef)::Union{Nothing,Float64}
+function start_value(v::GenericVariableRef{T})::Union{Nothing,T} where {T}
     return MOI.get(owner_model(v), MOI.VariablePrimalStart(), v)
 end
 
@@ -1047,8 +1112,11 @@ See also [`set_start_value`](@ref).
 """
 has_start_value(v::AbstractVariableRef)::Bool = start_value(v) !== nothing
 
+_convert_if_something(::Type{T}, x) where {T} = convert(T, x)
+_convert_if_something(::Type, ::Nothing) = nothing
+
 """
-    set_start_value(variable::VariableRef, value::Union{Real,Nothing})
+    set_start_value(variable::GenericVariableRef, value::Union{Real,Nothing})
 
 Set the start value (MOI attribute `VariablePrimalStart`) of the `variable` to
 `value`.
@@ -1059,15 +1127,26 @@ Note: `VariablePrimalStart`s are sometimes called "MIP-starts" or "warmstarts".
 
 See also [`start_value`](@ref).
 """
-function set_start_value(variable::VariableRef, value::Union{Nothing,Float64})
-    MOI.set(owner_model(variable), MOI.VariablePrimalStart(), variable, value)
+function set_start_value(
+    variable::GenericVariableRef{T},
+    value::Union{Nothing,Real},
+) where {T}
+    MOI.set(
+        owner_model(variable),
+        MOI.VariablePrimalStart(),
+        variable,
+        _convert_if_something(T, value),
+    )
     return
 end
 
-set_start_value(x::VariableRef, v::Number) = set_start_value(x, Float64(v))
+function set_start_value(x::GenericVariableRef{T}, v::Number) where {T}
+    set_start_value(x, convert(T, v))
+    return
+end
 
 """
-    value(v::VariableRef; result = 1)
+    value(v::GenericVariableRef; result = 1)
 
 Return the value of variable `v` associated with result index `result` of the
 most-recent returned by the solver.
@@ -1076,47 +1155,52 @@ Use [`has_values`](@ref) to check if a result exists before asking for values.
 
 See also: [`result_count`](@ref).
 """
-function value(v::VariableRef; result::Int = 1)::Float64
+function value(v::GenericVariableRef{T}; result::Int = 1)::T where {T}
     return MOI.get(owner_model(v), MOI.VariablePrimal(result), v)
 end
 
 """
-    value(var_value::Function, v::VariableRef)
+    value(var_value::Function, v::GenericVariableRef)
 
 Evaluate the value of the variable `v` as `var_value(v)`.
 """
-function value(var_value::Function, v::VariableRef)
+function value(var_value::Function, v::GenericVariableRef)
     return var_value(v)
 end
 
 """
-    has_values(model::Model; result::Int = 1)
+    has_values(model::GenericModel; result::Int = 1)
 
 Return `true` if the solver has a primal solution in result index `result`
 available to query, otherwise return `false`.
 
 See also [`value`](@ref) and [`result_count`](@ref).
 """
-function has_values(model::Model; result::Int = 1)
+function has_values(model::GenericModel; result::Int = 1)
     return primal_status(model; result = result) != MOI.NO_SOLUTION
 end
 
 """
-    add_variable(m::Model, v::AbstractVariable, name::String="")
+    add_variable(m::GenericModel, v::AbstractVariable, name::String="")
 
 Add a variable `v` to `Model m` and sets its name.
 """
 function add_variable end
 
-function add_variable(model::Model, v::ScalarVariable, name::String = "")
+function add_variable(model::GenericModel, v::ScalarVariable, name::String = "")
     model.is_model_dirty = true
     return _moi_add_variable(backend(model), model, v, name)
 end
 
-function _moi_add_variable(moi_backend, model, v::ScalarVariable, name::String)
+function _moi_add_variable(
+    moi_backend,
+    model::GenericModel{T},
+    v::ScalarVariable,
+    name::String,
+) where {T}
     index = MOI.add_variable(moi_backend)
-    var_ref = VariableRef(model, index)
-    _moi_constrain_variable(moi_backend, index, v.info)
+    var_ref = GenericVariableRef(model, index)
+    _moi_constrain_variable(moi_backend, index, v.info, T)
     if !isempty(name) &&
        MOI.supports(moi_backend, MOI.VariableName(), MOI.VariableIndex)
         set_name(var_ref, name)
@@ -1124,28 +1208,33 @@ function _moi_add_variable(moi_backend, model, v::ScalarVariable, name::String)
     return var_ref
 end
 
-function _moi_constrain_variable(moi_backend::MOI.ModelLike, index, info)
+function _moi_constrain_variable(
+    moi_backend::MOI.ModelLike,
+    index,
+    info,
+    ::Type{T},
+) where {T}
     # We don't call the _moi* versions (e.g., _moi_set_lower_bound) because they
     # have extra checks that are not necessary for newly created variables.
     if info.has_lb
         _moi_add_constraint(
             moi_backend,
             index,
-            MOI.GreaterThan{Float64}(info.lower_bound),
+            MOI.GreaterThan{T}(info.lower_bound),
         )
     end
     if info.has_ub
         _moi_add_constraint(
             moi_backend,
             index,
-            MOI.LessThan{Float64}(info.upper_bound),
+            MOI.LessThan{T}(info.upper_bound),
         )
     end
     if info.has_fix
         _moi_add_constraint(
             moi_backend,
             index,
-            MOI.EqualTo{Float64}(info.fixed_value),
+            MOI.EqualTo{T}(info.fixed_value),
         )
     end
     if info.binary
@@ -1159,7 +1248,7 @@ function _moi_constrain_variable(moi_backend::MOI.ModelLike, index, info)
             moi_backend,
             MOI.VariablePrimalStart(),
             index,
-            convert(Float64, info.start),
+            convert(T, info.start),
         )
     end
 end
@@ -1172,7 +1261,7 @@ Variable `scalar_variables` constrained to belong to `set`.
 Adding this variable can be understood as doing:
 ```julia
 function JuMP.add_variable(
-    model::Model,
+    model::GenericModel,
     variable::VariableConstrainedOnCreation,
     names,
 )
@@ -1195,21 +1284,22 @@ struct VariableConstrainedOnCreation{
 end
 
 function add_variable(
-    model::Model,
+    model::GenericModel{T},
     variable::VariableConstrainedOnCreation,
     name::String,
-)
+) where {T}
     var_index = _moi_add_constrained_variable(
         backend(model),
         variable.scalar_variable,
         variable.set,
         name,
+        T,
     )
-    return VariableRef(model, var_index)
+    return GenericVariableRef(model, var_index)
 end
 
 function add_variable(
-    model::Model,
+    model::GenericModel,
     variables::AbstractArray{<:VariableConstrainedOnCreation},
     names::AbstractArray{<:String},
 )
@@ -1217,7 +1307,7 @@ function add_variable(
 end
 
 function add_variable(
-    model::Model,
+    model::GenericModel,
     variables::AbstractArray{<:VariableConstrainedOnCreation},
     name::String,
 )
@@ -1229,9 +1319,10 @@ function _moi_add_constrained_variable(
     scalar_variable::ScalarVariable,
     set::MOI.AbstractScalarSet,
     name::String,
-)
+    ::Type{T},
+) where {T}
     var_index, con_index = MOI.add_constrained_variable(moi_backend, set)
-    _moi_constrain_variable(moi_backend, var_index, scalar_variable.info)
+    _moi_constrain_variable(moi_backend, var_index, scalar_variable.info, T)
     if !isempty(name)
         MOI.set(moi_backend, MOI.VariableName(), var_index, name)
     end
@@ -1245,7 +1336,7 @@ Vector of variables `scalar_variables` constrained to belong to `set`.
 Adding this variable can be thought as doing:
 ```julia
 function JuMP.add_variable(
-    model::Model,
+    model::GenericModel,
     variable::VariablesConstrainedOnCreation,
     names,
 )
@@ -1287,17 +1378,19 @@ function _vectorize_names(name::String, ::Any)
 end
 
 function add_variable(
-    model::Model,
+    model::GenericModel{T},
     variable::VariablesConstrainedOnCreation,
     names,
-)
+) where {T}
     var_indices = _moi_add_constrained_variables(
         backend(model),
         variable.scalar_variables,
         variable.set,
         _vectorize_names(names, variable.shape),
+        T,
     )
-    var_refs = [VariableRef(model, var_index) for var_index in var_indices]
+    var_refs =
+        [GenericVariableRef{T}(model, var_index) for var_index in var_indices]
     return reshape_vector(var_refs, variable.shape)
 end
 
@@ -1306,14 +1399,15 @@ function _moi_add_constrained_variables(
     scalar_variables::Vector{<:ScalarVariable},
     set::MOI.AbstractVectorSet,
     names::Union{Vector{String},Nothing},
-)
+    ::Type{T},
+) where {T}
     if set isa MOI.Reals
         var_indices = MOI.add_variables(moi_backend, MOI.dimension(set))
     else
         var_indices, con_index = MOI.add_constrained_variables(moi_backend, set)
     end
     for (index, variable) in zip(var_indices, scalar_variables)
-        _moi_constrain_variable(moi_backend, index, variable.info)
+        _moi_constrain_variable(moi_backend, index, variable.info, T)
     end
     if names !== nothing
         for (var_index, name) in zip(var_indices, names)
@@ -1426,7 +1520,11 @@ _is_binary(v::ScalarVariable) = v.info.binary
 
 _is_integer(v::ScalarVariable) = v.info.integer
 
-function add_variable(model::Model, v::ComplexVariable, name::String = "")
+function add_variable(
+    model::GenericModel,
+    v::ComplexVariable,
+    name::String = "",
+)
     model.is_model_dirty = true
     var = ScalarVariable(v.info)
     real_part = add_variable(model, _real(var), _real(name))
@@ -1448,7 +1546,7 @@ function build_variable(
 end
 
 function add_variable(
-    model::Model,
+    model::GenericModel,
     variables::AbstractArray{<:ComplexVariable},
     name::Union{<:AbstractArray{String},String} = "",
 )
@@ -1456,7 +1554,7 @@ function add_variable(
 end
 
 """
-    reduced_cost(x::VariableRef)::Float64
+    reduced_cost(x::GenericVariableRef{T})::T where {T}
 
 Return the reduced cost associated with variable `x`.
 
@@ -1465,7 +1563,7 @@ Equivalent to querying the shadow price of the active variable bound
 
 See also: [`shadow_price`](@ref).
 """
-function reduced_cost(x::VariableRef)::Float64
+function reduced_cost(x::GenericVariableRef{T})::T where {T}
     model = owner_model(x)
     if !has_duals(model)
         error(
@@ -1473,7 +1571,7 @@ function reduced_cost(x::VariableRef)::Float64
             " not have duals available.",
         )
     end
-    sign = objective_sense(model) == MIN_SENSE ? 1.0 : -1.0
+    sign = objective_sense(model) == MIN_SENSE ? one(T) : -one(T)
     if is_fixed(x)
         return sign * dual(FixRef(x))
     end
@@ -1488,7 +1586,7 @@ function reduced_cost(x::VariableRef)::Float64
 end
 
 """
-    all_variables(model::Model)::Vector{VariableRef}
+    all_variables(model::GenericModel{T})::Vector{GenericVariableRef{T}} where {T}
 
 Returns a list of all variables currently in the model. The variables are
 ordered by creation time.
@@ -1508,13 +1606,15 @@ julia> all_variables(model)
  y
 ```
 """
-function all_variables(model::Model)
+function all_variables(model::GenericModel{T}) where {T}
     all_indices =
         MOI.get(model, MOI.ListOfVariableIndices())::Vector{MOI.VariableIndex}
-    return VariableRef[VariableRef(model, idx) for idx in all_indices]
+    return GenericVariableRef{T}[
+        GenericVariableRef(model, idx) for idx in all_indices
+    ]
 end
 
-function dual(vref::VariableRef)
+function dual(::GenericVariableRef)
     return error(
         "To query the dual variables associated with a variable bound, first " *
         "obtain a constraint reference using one of `UpperBoundRef`, `LowerBoundRef`, " *
@@ -1533,7 +1633,7 @@ end
 value(::_MA.Zero) = 0.0
 value(x::Number) = x
 
-function _info_from_variable(v::VariableRef)
+function _info_from_variable(v::GenericVariableRef)
     has_lb = has_lower_bound(v)
     lb = has_lb ? lower_bound(v) : -Inf
     has_ub = has_upper_bound(v)
@@ -1566,7 +1666,7 @@ function _info_from_variable(v::VariableRef)
 end
 
 """
-    relax_integrality(model::Model)
+    relax_integrality(model::GenericModel)
 
 Modifies `model` to "relax" all binary and integrality constraints on
 variables. Specifically,
@@ -1615,10 +1715,12 @@ Subject to
  x binary
 ```
 """
-relax_integrality(model::Model) = _relax_or_fix_integrality(nothing, model)
+function relax_integrality(model::GenericModel)
+    return _relax_or_fix_integrality(nothing, model)
+end
 
 """
-    fix_discrete_variables([var_value::Function = value,] model::Model)
+    fix_discrete_variables([var_value::Function = value,] model::GenericModel)
 
 Modifies `model` to convert all binary and integer variables to continuous
 variables with fixed bounds of `var_value(x)`.
@@ -1666,23 +1768,25 @@ Subject to
  x binary
 ```
 """
-function fix_discrete_variables(var_value::Function, model::Model)
+function fix_discrete_variables(var_value::Function, model::GenericModel)
     return _relax_or_fix_integrality(var_value, model)
 end
 
-fix_discrete_variables(model::Model) = fix_discrete_variables(value, model)
+function fix_discrete_variables(model::GenericModel)
+    return fix_discrete_variables(value, model)
+end
 
 function _relax_or_fix_integrality(
     var_value::Union{Nothing,Function},
-    model::Model,
-)
-    if num_constraints(model, VariableRef, MOI.Semicontinuous{Float64}) > 0
+    model::GenericModel{T},
+) where {T}
+    if num_constraints(model, VariableRef, MOI.Semicontinuous{T}) > 0
         error(
             "Support for relaxing semicontinuous constraints is not " *
             "yet implemented.",
         )
     end
-    if num_constraints(model, VariableRef, MOI.Semiinteger{Float64}) > 0
+    if num_constraints(model, VariableRef, MOI.Semiinteger{T}) > 0
         error(
             "Support for relaxing semi-integer constraints is not " *
             "yet implemented.",
@@ -1704,8 +1808,8 @@ function _relax_or_fix_integrality(
         elseif info.binary
             unset_binary(v)
             if !info.has_fix
-                set_lower_bound(v, max(0.0, info.lower_bound))
-                set_upper_bound(v, min(1.0, info.upper_bound))
+                set_lower_bound(v, max(zero(T), info.lower_bound))
+                set_upper_bound(v, min(one(T), info.upper_bound))
             elseif info.fixed_value < 0 || info.fixed_value > 1
                 error(
                     "The model has no valid relaxation: binary variable " *
@@ -1800,7 +1904,7 @@ for sym in (:(<=), :(>=), :(<), :(>))
        ```
     """
     @eval begin
-        Base.$(sym)(::VariableRef, ::Number) = error($(msg))
-        Base.$(sym)(::Number, ::VariableRef) = error($(msg))
+        Base.$(sym)(::GenericVariableRef, ::Number) = error($(msg))
+        Base.$(sym)(::Number, ::GenericVariableRef) = error($(msg))
     end
 end

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -8,8 +8,9 @@
 
 Returns number of variables in `model`.
 """
-num_variables(model::GenericModel)::Int64 =
-    MOI.get(model, MOI.NumberOfVariables())
+function num_variables(model::GenericModel)::Int64
+    return MOI.get(model, MOI.NumberOfVariables())
+end
 
 """
     AbstractVariable
@@ -239,6 +240,7 @@ end
 const VariableRef = GenericVariableRef{Float64}
 
 value_type(::Type{GenericVariableRef{T}}) where {T} = T
+
 function variable_ref_type(
     ::Union{GenericModel{T},Type{GenericModel{T}}},
 ) where {T}
@@ -298,9 +300,11 @@ function check_belongs_to_model(v::AbstractVariableRef, model::AbstractModel)
 end
 
 Base.iszero(::GenericVariableRef) = false
+
 function Base.copy(v::GenericVariableRef{T}) where {T}
     return GenericVariableRef{T}(v.model, v.index)
 end
+
 Base.broadcastable(v::GenericVariableRef) = Ref(v)
 
 Base.zero(v::AbstractVariableRef) = zero(typeof(v))
@@ -333,6 +337,7 @@ function coefficient(
         return zero(T)
     end
 end
+
 function coefficient(
     ::GenericVariableRef{T},
     ::GenericVariableRef{T},
@@ -443,10 +448,6 @@ index(v::GenericVariableRef) = v.index
 function GenericVariableRef{T}(model::GenericModel{T}) where {T}
     index = MOI.add_variable(backend(model))
     return GenericVariableRef{T}(model, index)
-end
-
-function GenericVariableRef(model::GenericModel{T}) where {T}
-    return GenericVariableRef{T}(model)
 end
 
 """
@@ -1137,11 +1138,6 @@ function set_start_value(
         variable,
         _convert_if_something(T, value),
     )
-    return
-end
-
-function set_start_value(x::GenericVariableRef{T}, v::Number) where {T}
-    set_start_value(x, convert(T, v))
     return
 end
 

--- a/test/Containers/test_tables.jl
+++ b/test/Containers/test_tables.jl
@@ -85,7 +85,7 @@ function JuMP.build_variable(::Function, info::VariableInfo, _::_Mock)
     return _MockVariable(ScalarVariable(info))
 end
 
-function JuMP.add_variable(model::Model, x::_MockVariable, name::String)
+function JuMP.add_variable(model::GenericModel, x::_MockVariable, name::String)
     variable = add_variable(model, x.var, name)
     return _MockVariableRef(variable)
 end

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -67,6 +67,7 @@ struct MyVariableRef <: JuMP.AbstractVariableRef
     idx::Int
 end
 
+JuMP.variable_ref_type(::Union{MyModel,Type{MyModel}}) = MyVariableRef
 Base.copy(v::MyVariableRef) = v
 
 function Base.:(==)(v::MyVariableRef, w::MyVariableRef)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,18 @@ end
 
 Kokako.run_tests(MODULES_TO_TEST)
 
+# `Float32` is cheaper to test than `BigFloat` and is enough
+# for the purpose of testing that the types don't get promoted to `Float64`
+Kokako.run_tests(
+    MODULES_TO_TEST,
+    JuMP.GenericModel{Float32},
+    JuMP.GenericVariableRef{Float32};
+    test_prefix = "test_extension_",
+    include_names = Dict(
+        "test_mutable_arithmetics.jl" => ["test_extension_promote_operation"],
+    ),
+)
+
 Kokako.run_tests(
     MODULES_TO_TEST,
     JuMPExtension.MyModel,

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -32,19 +32,20 @@ function test_extension_VariableIndex_constraints(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     m = ModelType()
     @variable(m, x)
     # x <= 10.0 doesn't translate to a SingleVariable constraint because
     # the LHS is first subtracted to form x - 10.0 <= 0.
-    @constraint(m, cref, x in MOI.LessThan(10.0))
+    @constraint(m, cref, x in MOI.LessThan(10))
     c = constraint_object(cref)
     @test c.func == x
-    @test c.set == MOI.LessThan(10.0)
+    @test c.set == MOI.LessThan(T(10))
     @variable(m, y[1:2])
-    @constraint(m, cref2[i = 1:2], y[i] in MOI.LessThan(float(i)))
+    @constraint(m, cref2[i = 1:2], y[i] in MOI.LessThan(i))
     c = constraint_object(cref2[1])
     @test c.func == y[1]
-    @test c.set == MOI.LessThan(1.0)
+    @test c.set == MOI.LessThan(T(1))
     return
 end
 
@@ -83,27 +84,29 @@ function test_extension_AffExpr_scalar_constraints(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    AffExprType = JuMP.GenericAffExpr{value_type(ModelType),VariableRefType}
     model = ModelType()
+    T = value_type(ModelType)
     @variable(model, x)
     cref = @constraint(model, 2x <= 10)
     @test "" == @inferred name(cref)
     set_name(cref, "c")
-    _test_constraint_name_util(cref, "c", AffExpr, MOI.LessThan{Float64})
+    _test_constraint_name_util(cref, "c", AffExprType, MOI.LessThan{Float64})
     c = constraint_object(cref)
     @test isequal_canonical(c.func, 2x)
-    @test c.set == MOI.LessThan(10.0)
+    @test c.set == MOI.LessThan(T(10))
     cref = @constraint(model, 3x + 1 ≥ 10)
     c = constraint_object(cref)
     @test isequal_canonical(c.func, 3x)
-    @test c.set == MOI.GreaterThan(9.0)
+    @test c.set == MOI.GreaterThan(T(9))
     cref = @constraint(model, 1 == -x)
     c = constraint_object(cref)
-    @test isequal_canonical(c.func, 1.0x)
-    @test c.set == MOI.EqualTo(-1.0)
+    @test isequal_canonical(c.func, one(T) * x)
+    @test c.set == MOI.EqualTo(-one(T))
     cref = @constraint(model, 2 == 1)
     c = constraint_object(cref)
-    @test isequal_canonical(c.func, zero(AffExpr))
-    @test c.set == MOI.EqualTo(-1.0)
+    @test isequal_canonical(c.func, zero(AffExprType))
+    @test c.set == MOI.EqualTo(-one(T))
     return
 end
 
@@ -111,6 +114,7 @@ function test_extension_AffExpr_vectorized_constraints(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     model = ModelType()
     @variable(model, x)
     err = ErrorException(
@@ -119,16 +123,16 @@ function test_extension_AffExpr_vectorized_constraints(
         "sides of the constraint must have the same dimension.",
     )
     @test_throws_strip err @constraint(model, [x, 2x] in MOI.EqualTo(1.0))
-    T = typeof([x, 2x])
+    VT = typeof([x, 2x])
     err = ErrorException(
-        "Operation `sub_mul` between `$T` and `$Int` is not " *
+        "Operation `sub_mul` between `$VT` and `$Int` is not " *
         "allowed. This most often happens when you write a constraint like " *
         "`x >= y` where `x` is an array and `y` is a constant. Use the " *
         "broadcast syntax `x .- y >= 0` instead.",
     )
     @test_throws err @constraint(model, [x, 2x] == 1)
     err = ErrorException(
-        "Operation `sub_mul` between `$Int` and `$T` is not " *
+        "Operation `sub_mul` between `$Int` and `$VT` is not " *
         "allowed. This most often happens when you write a constraint like " *
         "`x >= y` where `x` is a constant and `y` is an array. Use the " *
         "broadcast syntax `x .- y >= 0` instead.",
@@ -140,10 +144,10 @@ function test_extension_AffExpr_vectorized_constraints(
     end
     cref = @constraint(model, [x, 2x] .== [1 - x, 3])
     c = constraint_object.(cref)
-    @test isequal_canonical(c[1].func, 2.0x)
-    @test c[1].set == MOI.EqualTo(1.0)
-    @test isequal_canonical(c[2].func, 2.0x)
-    @test c[2].set == MOI.EqualTo(3.0)
+    @test isequal_canonical(c[1].func, 2x)
+    @test c[1].set == MOI.EqualTo(T(1))
+    @test isequal_canonical(c[2].func, 2x)
+    @test c[2].set == MOI.EqualTo(T(3))
     return
 end
 
@@ -151,6 +155,7 @@ function test_extension_AffExpr_vectorized_interval_constraints(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     model = ModelType()
     @variable(model, x[1:2])
     err = ErrorException(
@@ -158,12 +163,12 @@ function test_extension_AffExpr_vectorized_interval_constraints(
         "scalar constraint. Did you mean to use the dot comparison " *
         "operators `l .<= f(x) .<= u` instead?",
     )
-    b = [5.0, 6.0]
+    b = T[5, 6]
     @test_throws_strip err @constraint(model, b <= x <= b)
     cref = @constraint(model, b .<= x .<= b)
     c = constraint_object.(cref)
     for i in 1:2
-        @test isequal_canonical(c[i].func, 1.0 * x[i])
+        @test isequal_canonical(c[i].func, 1 * x[i])
         @test c[i].set == MOI.Interval(b[i], b[i])
     end
     return
@@ -173,11 +178,12 @@ function test_extension_AffExpr_vector_constraints(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    AffExprType = JuMP.GenericAffExpr{value_type(ModelType),VariableRefType}
     model = ModelType()
     cref = @constraint(model, [1, 2] in MOI.Zeros(2))
     c = constraint_object(cref)
-    @test isequal_canonical(c.func[1], zero(AffExpr) + 1)
-    @test isequal_canonical(c.func[2], zero(AffExpr) + 2)
+    @test isequal_canonical(c.func[1], zero(AffExprType) + 1)
+    @test isequal_canonical(c.func[2], zero(AffExprType) + 2)
     @test c.set == MOI.Zeros(2)
     @test c.shape isa VectorShape
     @test_throws DimensionMismatch @constraint(model, [1, 2] in MOI.Zeros(3))
@@ -222,19 +228,22 @@ function test_extension_two_sided_constraints(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
+    AffExprType = JuMP.GenericAffExpr{T,VariableRefType}
     m = ModelType()
     @variable(m, x)
     @variable(m, y)
-    @constraint(m, cref, 1.0 <= x + y + 1.0 <= 2.0)
-    _test_constraint_name_util(cref, "cref", AffExpr, MOI.Interval{Float64})
+    @constraint(m, cref, 1 <= x + y + 1 <= 2)
+    _test_constraint_name_util(cref, "cref", AffExprType, MOI.Interval{T})
     c = constraint_object(cref)
     @test isequal_canonical(c.func, x + y)
-    @test c.set == MOI.Interval(0.0, 1.0)
-    cref = @constraint(m, 2x - y + 2.0 ∈ MOI.Interval(-1.0, 1.0))
+    @test c.set ==
+          MOI.Interval(zero(value_type(ModelType)), one(value_type(ModelType)))
+    cref = @constraint(m, 2x - y + T(2) ∈ MOI.Interval(-one(T), one(T)))
     @test "" == @inferred name(cref)
     c = constraint_object(cref)
     @test isequal_canonical(c.func, 2x - y)
-    @test c.set == MOI.Interval(-3.0, -1.0)
+    @test c.set == MOI.Interval(-3one(T), -one(T))
     return
 end
 
@@ -242,18 +251,19 @@ function test_extension_broadcasted_constraint_eq(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     m = ModelType()
     @variable(m, x[1:2])
-    A = [1.0 2.0; 3.0 4.0]
-    b = [4.0, 5.0]
+    A = T[1 2; 3 4]
+    b = T[4, 5]
     cref = @constraint(m, A * x .== b)
     @test (2,) == @inferred size(cref)
     c1 = constraint_object(cref[1])
     @test isequal_canonical(c1.func, x[1] + 2x[2])
-    @test c1.set == MOI.EqualTo(4.0)
+    @test c1.set == MOI.EqualTo(T(4))
     c2 = constraint_object(cref[2])
     @test isequal_canonical(c2.func, 3x[1] + 4x[2])
-    @test c2.set == MOI.EqualTo(5.0)
+    @test c2.set == MOI.EqualTo(T(5))
     return
 end
 
@@ -261,9 +271,10 @@ function test_extension_broadcasted_constraint_leq(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     m = ModelType()
     @variable(m, x[1:2, 1:2])
-    UB = [1.0 2.0; 3.0 4.0]
+    UB = T[1 2; 3 4]
     cref = @constraint(m, x .+ 1 .<= UB)
     @test (2, 2) == @inferred size(cref)
     for i in 1:2
@@ -280,11 +291,12 @@ function test_extension_broadcasted_two_sided_constraint(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     m = ModelType()
     @variable(m, x[1:2])
     @variable(m, y[1:2])
-    l = [1.0, 2.0]
-    u = [3.0, 4.0]
+    l = T[1, 2]
+    u = T[3, 4]
     cref = @constraint(m, l .<= x + y .+ 1 .<= u)
     @test (2,) == @inferred size(cref)
     for i in 1:2
@@ -318,6 +330,7 @@ function test_extension_quadexpr_constraints(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     model = ModelType()
     @variable(model, x)
     @variable(model, y)
@@ -325,12 +338,12 @@ function test_extension_quadexpr_constraints(
     cref = @constraint(model, x^2 + x <= 1)
     c = constraint_object(cref)
     @test isequal_canonical(c.func, x^2 + x)
-    @test c.set == MOI.LessThan(1.0)
+    @test c.set == MOI.LessThan(one(T))
 
-    cref = @constraint(model, y * x - 1.0 == 0.0)
+    cref = @constraint(model, y * x - 1 == 0)
     c = constraint_object(cref)
     @test isequal_canonical(c.func, x * y)
-    @test c.set == MOI.EqualTo(1.0)
+    @test c.set == MOI.EqualTo(one(T))
 
     cref = @constraint(
         model,
@@ -362,6 +375,7 @@ function test_extension_indicator_constraint(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     model = ModelType()
     @variable(model, a, Bin)
     @variable(model, b, Bin)
@@ -374,7 +388,7 @@ function test_extension_indicator_constraint(
     ]
         c = constraint_object(cref)
         @test c.func == [a, x + 2y]
-        @test c.set == MOI.Indicator{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(1.0))
+        @test c.set == MOI.Indicator{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(one(T)))
     end
     for cref in [
         @constraint(model, !b => {2x + y <= 1})
@@ -385,7 +399,7 @@ function test_extension_indicator_constraint(
     ]
         c = constraint_object(cref)
         @test c.func == [b, 2x + y]
-        @test c.set == MOI.Indicator{MOI.ACTIVATE_ON_ZERO}(MOI.LessThan(1.0))
+        @test c.set == MOI.Indicator{MOI.ACTIVATE_ON_ZERO}(MOI.LessThan(one(T)))
     end
     err = ErrorException(
         "In `@constraint(model, !(a, b) => {x <= 1})`: Invalid binary variable expression `!(a, b)` for indicator constraint.",
@@ -414,6 +428,8 @@ function test_extension_SDP_constraint(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
+    AffExprType = JuMP.GenericAffExpr{T,VariableRefType}
     m = ModelType()
     @variable(m, x)
     @variable(m, y)
@@ -434,7 +450,7 @@ function test_extension_SDP_constraint(
     _test_constraint_name_util(
         sym_ref,
         "sym_ref",
-        Vector{AffExpr},
+        Vector{AffExprType},
         MOI.PositiveSemidefiniteConeTriangle,
     )
     c = constraint_object(sym_ref)
@@ -448,7 +464,7 @@ function test_extension_SDP_constraint(
     _test_constraint_name_util(
         cref,
         "cref",
-        Vector{AffExpr},
+        Vector{AffExprType},
         MOI.PositiveSemidefiniteConeSquare,
     )
     c = constraint_object(cref)
@@ -464,7 +480,7 @@ function test_extension_SDP_constraint(
         _test_constraint_name_util(
             iref[i],
             "iref[$i]",
-            Vector{AffExpr},
+            Vector{AffExprType},
             MOI.PositiveSemidefiniteConeSquare,
         )
         c = constraint_object(iref[i])
@@ -478,7 +494,7 @@ function test_extension_SDP_constraint(
 
     @constraint(m, con_d, 0 <= LinearAlgebra.Diagonal([x, y]), PSDCone())
     c = constraint_object(con_d)
-    @test c.func isa Vector{GenericAffExpr{Float64,VariableRefType}}
+    @test c.func isa Vector{AffExprType}
     @test isequal_canonical(c.func[1], 1x)
     @test iszero(c.func[2])
     @test iszero(c.func[3])
@@ -492,7 +508,7 @@ function test_extension_SDP_constraint(
         PSDCone()
     )
     c = constraint_object(con_d_sym)
-    @test c.func isa Vector{GenericAffExpr{Float64,VariableRefType}}
+    @test c.func isa Vector{AffExprType}
     @test isequal_canonical(c.func[1], 1x)
     @test iszero(c.func[2])
     @test isequal_canonical(c.func[3], 1y)
@@ -505,7 +521,7 @@ function test_extension_SDP_constraint(
         PSDCone()
     )
     c = constraint_object(con_td)
-    @test c.func isa Vector{GenericAffExpr{Float64,VariableRefType}}
+    @test c.func isa Vector{AffExprType}
     @test isequal_canonical(c.func[1], 1x)
     @test isequal_canonical(c.func[2], 1z)
     @test isequal_canonical(c.func[3], 1w)
@@ -520,7 +536,7 @@ function test_extension_SDP_constraint(
         PSDCone(),
     )
     c = constraint_object(con_td_sym)
-    @test c.func isa Vector{GenericAffExpr{Float64,VariableRefType}}
+    @test c.func isa Vector{AffExprType}
     @test isequal_canonical(c.func[1], 1x)
     @test isequal_canonical(c.func[2], 1w)
     @test isequal_canonical(c.func[3], 1y)
@@ -533,7 +549,7 @@ function test_extension_SDP_constraint(
         PSDCone()
     )
     c = constraint_object(con_ut)
-    @test c.func isa Vector{GenericAffExpr{Float64,VariableRefType}}
+    @test c.func isa Vector{AffExprType}
     @test isequal_canonical(c.func[1], 1x)
     @test iszero(c.func[2])
     @test isequal_canonical(c.func[3], 1y)
@@ -547,7 +563,7 @@ function test_extension_SDP_constraint(
         PSDCone()
     )
     c = constraint_object(con_lt)
-    @test c.func isa Vector{GenericAffExpr{Float64,VariableRefType}}
+    @test c.func isa Vector{AffExprType}
     @test isequal_canonical(c.func[1], 1x)
     @test isequal_canonical(c.func[2], 1z)
     @test iszero(c.func[3])
@@ -560,17 +576,18 @@ function test_extension_SDP_errors(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    AffExprType = JuMP.GenericAffExpr{value_type(ModelType),VariableRefType}
     model = ModelType()
     @variable(model, x)
     @variable(model, y)
     @variable(model, z)
     @variable(model, w)
-    aff_str = "$(GenericAffExpr{Float64,VariableRefType})"
+    aff_str = "$AffExprType"
     err = ErrorException(
         "In `@constraint(model, [x 1; 1 -y] >= [1 x; x -2], PSDCone(), unknown_kw = 1)`:" *
         " Unrecognized constraint building format. Tried to invoke " *
         "`build_constraint(error, $(aff_str)[x - " *
-        "1 -x + 1; -x + 1 -y + 2], $(MOI.GreaterThan(0.0)), $(PSDCone()); unknown_kw = 1)`, but no " *
+        "1 -x + 1; -x + 1 -y + 2], $(MOI.GreaterThan(false)), $(PSDCone()); unknown_kw = 1)`, but no " *
         "such method exists. This is due to specifying an unrecognized " *
         "function, constraint set, and/or extra positional/keyword " *
         "arguments.\n\nIf you're trying to create a JuMP extension, you " *
@@ -694,6 +711,7 @@ function test_extension_nonsensical_SDP_constraint(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     m = ModelType()
     @test_throws_strip(
         ErrorException(
@@ -705,7 +723,7 @@ function test_extension_nonsensical_SDP_constraint(
     @test_throws MethodError @variable(m, notone[1:5, 2:6], PSD)
     @test_throws MethodError @variable(m, oneD[1:5], PSD)
     @test_throws MethodError @variable(m, threeD[1:5, 1:5, 1:5], PSD)
-    Y = [1.0 2.0; 2.1 3.0]
+    Y = T[1 2; 21//10 3]
     function _ErrorException(m)
         return ErrorException(
             "In `$m`: Non-symmetric bounds, integrality or starting values " *
@@ -1155,12 +1173,13 @@ function test_extension_abstractarray_vector_constraint(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     model = ModelType()
     @variable(model, x[1:2, 1:2])
     c = @constraint(model, view(x, 1:4) in SOS1())
     obj = constraint_object(c)
     @test obj.func == x[1:4]
-    @test obj.set == MOI.SOS1([1.0, 2.0, 3.0, 4.0])
+    @test obj.set == MOI.SOS1(T[1, 2, 3, 4])
     return
 end
 
@@ -1168,13 +1187,14 @@ function test_extension_constraint_inference(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     model = ModelType()
     @variable(model, x)
     foo(model, x) = @constraint(model, 2x <= 1)
     c = @inferred foo(model, x)
     obj = constraint_object(c)
     @test obj.func == 2x
-    @test obj.set == MOI.LessThan(1.0)
+    @test obj.set == MOI.LessThan(one(T))
     return
 end
 
@@ -1469,10 +1489,13 @@ function test_extension_HermitianPSDCone_errors(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    AffExprType =
+        JuMP.GenericAffExpr{Complex{value_type(ModelType)},VariableRefType}
     model = ModelType()
+    T = value_type(ModelType)
     @variable(model, x)
     @variable(model, y)
-    aff_str = "$(GenericAffExpr{ComplexF64,VariableRefType})"
+    aff_str = "$AffExprType"
     err = ErrorException(
         "In `@constraint(model, H in HermitianPSDCone(), unknown_kw = 1)`:" *
         " Unrecognized constraint building format. Tried to invoke " *
@@ -1597,6 +1620,9 @@ function test_semiinteger()
 end
 
 function test_symmetric_vectorize_allocations()
+    if VERSION < v"1.8"
+        return
+    end
     model = Model()
     @variable(model, x[1:2])
     C = SparseArrays.sparse([0 1; 0 0])

--- a/test/test_expr.jl
+++ b/test/test_expr.jl
@@ -195,8 +195,9 @@ function test_extension_linear_terms_empty_AffExpr(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     k = 0
-    aff = zero(GenericAffExpr{Float64,VariableRefType})
+    aff = zero(GenericAffExpr{T,VariableRefType})
     @test length(linear_terms(aff)) == 0
     for (coeff, var) in linear_terms(aff)
         k += 1
@@ -233,14 +234,15 @@ function test_extension_coefficient_QuadExpr_VariableRefType(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     m = ModelType()
     x = @variable(m, x)
     y = @variable(m, y)
     z = @variable(m, z)
-    quad = @expression(m, 6.0 * x^2 + 5.0 * x * y + 2.0 * y + 3.0 * x)
-    @test coefficient(quad, x) == 3.0
-    @test coefficient(quad, y) == 2.0
-    @test coefficient(quad, z) == 0.0
+    quad = @expression(m, T(6) * x^2 + T(5) * x * y + T(2) * y + T(3) * x)
+    @test coefficient(quad, x) == T(3)
+    @test coefficient(quad, y) == T(2)
+    @test coefficient(quad, z) == T(0)
     return
 end
 
@@ -248,15 +250,16 @@ function test_extension_coefficient_QuadExpr_VariableRefType_VariableRefType(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     m = ModelType()
     x = @variable(m, x)
     y = @variable(m, y)
     z = @variable(m, z)
-    quad = @expression(m, 6.0 * x^2 + 5.0 * x * y + 2.0 * y + 3.0 * x)
-    @test coefficient(quad, x, y) == 5.0
-    @test coefficient(quad, x, x) == 6.0
+    quad = @expression(m, T(6) * x^2 + T(5) * x * y + T(2) * y + T(3) * x)
+    @test coefficient(quad, x, y) == T(5)
+    @test coefficient(quad, x, x) == T(6)
     @test coefficient(quad, x, y) == coefficient(quad, y, x)
-    @test coefficient(quad, z, z) == 0.0
+    @test coefficient(quad, z, z) == T(0)
     return
 end
 
@@ -264,31 +267,32 @@ function test_extension_MA_add_mul(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     model = ModelType()
     @variable(model, x)
     @variable(model, y)
     # MA.add_mul!!(ex::Number, c::Number, x::GenericAffExpr)
-    aff = MA.add_mul!!(1.0, 2.0, GenericAffExpr(1.0, :a => 1.0))
-    @test isequal_canonical(aff, GenericAffExpr(3.0, :a => 2.0))
+    aff = MA.add_mul!!(1, 2, GenericAffExpr(T(1), x => T(1)))
+    @test isequal_canonical(aff, GenericAffExpr(T(3), x => T(2)))
     # MA.add_mul!!(ex::Number, c::Number, x::GenericQuadExpr) with c == 0
-    QuadExprType = GenericQuadExpr{Float64,VariableRefType}
-    quad = MA.add_mul!!(2.0, 0.0, QuadExprType())
-    @test isequal_canonical(quad, convert(QuadExprType, 2.0))
+    QuadExprType = GenericQuadExpr{T,VariableRefType}
+    quad = MA.add_mul!!(2, 0, QuadExprType())
+    @test isequal_canonical(quad, convert(QuadExprType, 2))
     # MA.add_mul!!(ex::Number, c::VariableRef, x::VariableRef)"
-    @test_expression_with_string MA.add_mul(5.0, x, y) "x*y + 5"
-    @test_expression_with_string MA.add_mul!!(5.0, x, y) "x*y + 5"
+    @test_expression_with_string MA.add_mul(5, x, y) "x*y + 5"
+    @test_expression_with_string MA.add_mul!!(5, x, y) "x*y + 5"
     # MA.add_mul!!(ex::Number, c::T, x::T) where T<:GenericAffExpr" begin
-    @test_expression_with_string MA.add_mul(1.0, 2x, x + 1) "2 x² + 2 x + 1"
-    @test_expression_with_string MA.add_mul!!(1.0, 2x, x + 1) "2 x² + 2 x + 1"
+    @test_expression_with_string MA.add_mul(1, 2x, x + 1) "2 x² + 2 x + 1"
+    @test_expression_with_string MA.add_mul!!(1, 2x, x + 1) "2 x² + 2 x + 1"
     # MA.add_mul!!(ex::Number, c::GenericAffExpr{C,V}, x::V) where {C,V}" begin
-    @test_expression_with_string MA.add_mul(1.0, 2x, x) "2 x² + 1"
-    @test_expression_with_string MA.add_mul!!(1.0, 2x, x) "2 x² + 1"
+    @test_expression_with_string MA.add_mul(1, 2x, x) "2 x² + 1"
+    @test_expression_with_string MA.add_mul!!(1, 2x, x) "2 x² + 1"
     # MA.add_mul!!(ex::Number, c::GenericQuadExpr, x::Number)" begin
-    @test_expression_with_string MA.add_mul(0.0, x^2, 1.0) "x²"
-    @test_expression_with_string MA.add_mul!!(0.0, x^2, 1.0) "x²"
+    @test_expression_with_string MA.add_mul(0, x^2, 1) "x²"
+    @test_expression_with_string MA.add_mul!!(0, x^2, 1) "x²"
     # MA.add_mul!!(ex::Number, c::GenericQuadExpr, x::Number) with c == 0" begin
-    @test_expression_with_string MA.add_mul(0.0, x^2, 0.0) "0"
-    @test_expression_with_string MA.add_mul!!(0.0, x^2, 0.0) "0"
+    @test_expression_with_string MA.add_mul(0, x^2, 0) "0"
+    @test_expression_with_string MA.add_mul!!(0, x^2, 0) "0"
     # MA.add_mul!!(aff::AffExpr,c::VariableRef,x::AffExpr)" begin
     @test_expression_with_string MA.add_mul(2x, x, x + 1) "x² + 3 x"
     @test_expression_with_string MA.add_mul!!(2x, x, x + 1) "x² + 3 x"

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -1506,16 +1506,16 @@ end
 
 function test_MA_Zero_objective()
     model = Model()
-    @test @objective(model, Min, sum(i for i in 1:0)) === false
+    @test @objective(model, Min, sum(i for i in 1:0)) === 0.0
     return
 end
 
 function test_MA_Zero_expression()
     model = Model()
-    @test @expression(model, sum(i for i in 1:0)) === false
+    @test @expression(model, sum(i for i in 1:0)) === 0.0
     @expression(model, expr[j = 1:2], sum(i for i in j:0))
-    @test expr == [false, false]
-    @test expr isa Vector{Bool}
+    @test expr == [0.0, 0.0]
+    @test expr isa Vector{Float64}
     return
 end
 

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -30,12 +30,16 @@ function JuMP.build_variable(
     return NewVariable(info)
 end
 
-function JuMP.add_variable(model::Model, v::NewVariable, name::String = "")
+function JuMP.add_variable(
+    model::GenericModel,
+    v::NewVariable,
+    name::String = "",
+)
     return add_variable(model, ScalarVariable(v.info), name * "_normal_add")
 end
 
 function JuMP.add_variable(
-    model::Model,
+    model::GenericModel,
     v::VariablesConstrainedOnCreation{
         MOI.SecondOrderCone,
         VectorShape,
@@ -103,7 +107,11 @@ end
 
 const MyVariableTuple{S,T,U,V} = Tuple{VariableInfo{S,T,U,V},Int,Int}
 
-function JuMP.add_variable(model::Model, v::MyVariableTuple, name::String = "")
+function JuMP.add_variable(
+    model::GenericModel,
+    v::MyVariableTuple,
+    name::String = "",
+)
     model.ext[:names][v] = name
     return v
 end
@@ -346,53 +354,56 @@ function test_extension_check_constraint_basics(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
+    AffExprType = GenericAffExpr{T,VariableRefType}
     m = ModelType()
     @variable(m, w)
     @variable(m, x)
     @variable(m, y)
     @variable(m, z)
-    t = 10.0
-    cref = @constraint(m, 3x - y == 3.3(w + 2z) + 5)
+    t = T(10)
+    α = T(33) / T(10)
+    cref = @constraint(m, 3x - y == α * (w + 2z) + 5)
     c = constraint_object(cref)
-    @test isequal_canonical(c.func, 3 * x - y - 3.3 * w - 6.6 * z)
-    @test c.set == MOI.EqualTo(5.0)
-    cref = @constraint(m, 3x - y == (w + 2z) * 3.3 + 5)
+    @test isequal_canonical(c.func, 3 * x - y - α * w - 2α * z)
+    @test c.set == MOI.EqualTo(T(5))
+    cref = @constraint(m, 3x - y == (w + 2z) * α + 5)
     c = constraint_object(cref)
-    @test isequal_canonical(c.func, 3 * x - y - 3.3 * w - 6.6 * z)
-    @test c.set == MOI.EqualTo(5.0)
+    @test isequal_canonical(c.func, 3 * x - y - α * w - 2α * z)
+    @test c.set == MOI.EqualTo(T(5))
     cref = @constraint(m, (x + y) / 2 == 1)
     c = constraint_object(cref)
-    @test isequal_canonical(c.func, 0.5 * x + 0.5 * y)
-    @test c.set == MOI.EqualTo(1.0)
+    @test isequal_canonical(c.func, T(inv(2)) * x + T(inv(2)) * y)
+    @test c.set == MOI.EqualTo(T(1))
     cref = @constraint(m, -1 <= x - y <= t)
     c = constraint_object(cref)
     @test isequal_canonical(c.func, x - y)
-    @test c.set == MOI.Interval(-1.0, t)
+    @test c.set == MOI.Interval(-T(1), t)
     cref = @constraint(m, -1 <= x + 1 <= 1)
     c = constraint_object(cref)
     @test isequal_canonical(c.func, 1x)
-    @test c.set == MOI.Interval(-2.0, 0.0)
+    @test c.set == MOI.Interval(-T(2), T(0))
     cref = @constraint(m, -1 <= x <= 1)
     c = constraint_object(cref)
-    @test c.func isa GenericAffExpr
+    @test c.func isa AffExprType
     @test isequal_canonical(c.func, 1x)
-    @test c.set == MOI.Interval(-1.0, 1.0)
-    cref = @constraint(m, -1 <= x <= sum(0.5 for i in 1:2))
+    @test c.set == MOI.Interval(-T(1), T(1))
+    cref = @constraint(m, -1 <= x <= sum(T(inv(2)) for i in 1:2))
     c = constraint_object(cref)
-    @test c.func isa GenericAffExpr
+    @test c.func isa AffExprType
     @test isequal_canonical(c.func, 1x)
-    @test c.set == MOI.Interval(-1.0, 1.0)
+    @test c.set == MOI.Interval(-T(1), T(1))
     cref = @constraint(m, 1 >= x >= 0)
     c = constraint_object(cref)
-    @test c.func isa GenericAffExpr
+    @test c.func isa AffExprType
     @test isequal_canonical(c.func, 1x)
-    @test c.set == MOI.Interval(0.0, 1.0)
+    @test c.set == MOI.Interval(T(0), T(1))
     @test_throws ErrorException @constraint(m, x <= t <= y)
     @test_throws ErrorException @constraint(m, 0 <= Dict() <= 1)
     @test_macro_throws ErrorException @constraint(1 <= x <= 2, foo = :bar)
     @test isequal_canonical(
-        @expression(m, 3x - y - 3.3(w + 2z) + 5),
-        3 * x - y - 3.3 * w - 6.6 * z + 5,
+        @expression(m, 3x - y - α * (w + 2z) + 5),
+        3 * x - y - α * w - T(66) / T(10) * z + 5,
     )
     @test isequal_canonical(
         @expression(m, quad, (w + 3) * (2x + 1) + 10),
@@ -400,8 +411,8 @@ function test_extension_check_constraint_basics(
     )
     cref = @constraint(m, 3 + 5 * 7 <= 0)
     c = constraint_object(cref)
-    @test isequal_canonical(c.func, zero(AffExpr))
-    @test c.set == MOI.LessThan(-38.0)
+    @test isequal_canonical(c.func, zero(AffExprType))
+    @test c.set == MOI.LessThan(-T(38))
     return
 end
 
@@ -409,27 +420,28 @@ function test_extension_Unicode_comparison_operators(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     model = ModelType()
     @variable(model, x)
     @variable(model, y)
-    t = 10.0
+    t = T(10)
     cref = @constraint(model, (x + y) / 2 ≥ 1)
     c = constraint_object(cref)
-    @test isequal_canonical(c.func, 0.5 * x + 0.5 * y)
-    @test c.set == MOI.GreaterThan(1.0)
+    @test isequal_canonical(c.func, inv(T(2)) * x + inv(T(2)) * y)
+    @test c.set == MOI.GreaterThan(T(1))
     cref = @constraint(model, (x + y) / 2 ≤ 1)
     c = constraint_object(cref)
-    @test isequal_canonical(c.func, 0.5 * x + 0.5 * y)
-    @test c.set == MOI.LessThan(1.0)
+    @test isequal_canonical(c.func, inv(T(2)) * x + inv(T(2)) * y)
+    @test c.set == MOI.LessThan(T(1))
     cref = @constraint(model, -1 ≤ x - y ≤ t)
     c = constraint_object(cref)
     @test isequal_canonical(c.func, x - y)
-    @test c.set == MOI.Interval(-1.0, t)
+    @test c.set == MOI.Interval(-T(1), t)
     cref = @constraint(model, 1 ≥ x ≥ 0)
     c = constraint_object(cref)
     @test c.func isa GenericAffExpr
     @test isequal_canonical(c.func, 1 * x)
-    @test c.set == MOI.Interval(0.0, 1.0)
+    @test c.set == MOI.Interval(T(0), T(1))
     return
 end
 
@@ -458,12 +470,13 @@ function test_extension_build_constraint_scalar_inequality(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     model = ModelType()
     @variable(model, x)
     con = @build_constraint(3x == 1)
     @test con isa ScalarConstraint
     @test isequal_canonical(con.func, 3x)
-    @test con.set == MOI.EqualTo(1.0)
+    @test con.set == MOI.EqualTo(T(1))
     return
 end
 
@@ -484,20 +497,21 @@ function test_extension_build_constraint_SOS1(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     model = ModelType()
     @variable(model, x[1:3])
     con = @build_constraint(x in SOS1())
-    con2 = @build_constraint(x in SOS1([4.0, 6.0, 1.0]))
+    con2 = @build_constraint(x in SOS1(T[4, 6, 1]))
     @test con isa VectorConstraint
     @test con.func == x
-    @test con.set == MOI.SOS1([1.0, 2.0, 3.0])
+    @test con.set == MOI.SOS1(T[1, 2, 3])
     @test_throws(
         ErrorException("Weight vector in SOS1 is not of length 3."),
-        @build_constraint(x in SOS1([1.0]))
+        @build_constraint(x in SOS1(T[1]))
     )
     @test con2 isa VectorConstraint
     @test con2.func == x
-    @test con2.set == MOI.SOS1([4.0, 6.0, 1.0])
+    @test con2.set == MOI.SOS1(T[4, 6, 1])
     return
 end
 
@@ -505,20 +519,21 @@ function test_extension_build_constraint_SOS2(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     model = ModelType()
     @variable(model, x[1:3])
     con = @build_constraint(x in SOS2())
-    con2 = @build_constraint(x in SOS2([4.0, 6.0, 1.0]))
+    con2 = @build_constraint(x in SOS2(T[4, 6, 1]))
     @test con isa VectorConstraint
     @test con.func == x
-    @test con.set == MOI.SOS2([1.0, 2.0, 3.0])
+    @test con.set == MOI.SOS2(T[1, 2, 3])
     @test_throws(
         ErrorException("Weight vector in SOS2 is not of length 3."),
-        @build_constraint(x in SOS2([1.0]))
+        @build_constraint(x in SOS2(T[1]))
     )
     @test con2 isa VectorConstraint
     @test con2.func == x
-    @test con2.set == MOI.SOS2([4.0, 6.0, 1.0])
+    @test con2.set == MOI.SOS2(T[4, 6, 1])
     return
 end
 
@@ -526,15 +541,16 @@ function test_extension_build_constraint_broadcast(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     model = ModelType()
     @variable(model, x[1:2])
-    ub = [1.0, 2.0]
+    ub = T[1, 2]
     con = @build_constraint(x .<= ub)
     @test con isa Vector{<:ScalarConstraint}
     @test isequal_canonical(con[1].func, 1.0x[1])
     @test isequal_canonical(con[2].func, 1.0x[2])
-    @test con[1].set == MOI.LessThan(1.0)
-    @test con[2].set == MOI.LessThan(2.0)
+    @test con[1].set == MOI.LessThan(T(1))
+    @test con[2].set == MOI.LessThan(T(2))
     return
 end
 
@@ -1490,16 +1506,16 @@ end
 
 function test_MA_Zero_objective()
     model = Model()
-    @test @objective(model, Min, sum(i for i in 1:0)) === 0.0
+    @test @objective(model, Min, sum(i for i in 1:0)) === false
     return
 end
 
 function test_MA_Zero_expression()
     model = Model()
-    @test @expression(model, sum(i for i in 1:0)) === 0.0
+    @test @expression(model, sum(i for i in 1:0)) === false
     @expression(model, expr[j = 1:2], sum(i for i in j:0))
-    @test expr == [0.0, 0.0]
-    @test expr isa Vector{Float64}
+    @test expr == [false, false]
+    @test expr isa Vector{Bool}
     return
 end
 

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -549,7 +549,7 @@ function test_set_retrieve_time_limit()
 end
 
 struct DummyExtensionData
-    model::Model
+    model::GenericModel
 end
 function JuMP.copy_extension_data(
     data::DummyExtensionData,

--- a/test/test_objective.jl
+++ b/test/test_objective.jl
@@ -92,29 +92,24 @@ function test_extension_objective_affine(
     ModelType = Model,
     VariableType = VariableRef,
 )
+    T = value_type(ModelType)
     model = ModelType()
     @variable(model, x)
     @objective(model, Min, 2x)
     @test MIN_SENSE == @inferred objective_sense(model)
-    @test objective_function_type(model) == GenericAffExpr{Float64,VariableType}
+    @test objective_function_type(model) == GenericAffExpr{T,VariableType}
     @test isequal_canonical(objective_function(model), 2x)
     @test isequal_canonical(
         2x,
-        @inferred objective_function(
-            model,
-            GenericAffExpr{Float64,VariableType},
-        )
+        @inferred objective_function(model, GenericAffExpr{T,VariableType})
     )
     @objective(model, Max, x + 3x + 1)
     @test MAX_SENSE == @inferred objective_sense(model)
-    @test objective_function_type(model) == GenericAffExpr{Float64,VariableType}
+    @test objective_function_type(model) == GenericAffExpr{T,VariableType}
     @test isequal_canonical(objective_function(model), 4x + 1)
     @test isequal_canonical(
         4x + 1,
-        @inferred objective_function(
-            model,
-            GenericAffExpr{Float64,VariableType},
-        )
+        @inferred objective_function(model, GenericAffExpr{T,VariableType})
     )
     return
 end
@@ -123,23 +118,20 @@ function test_extension_objective_quadratic(
     ModelType = Model,
     VariableType = VariableRef,
 )
+    T = value_type(ModelType)
     model = ModelType()
     @variable(model, x)
     @objective(model, Min, x^2 + 2x)
     @test MIN_SENSE == @inferred objective_sense(model)
-    @test objective_function_type(model) ==
-          GenericQuadExpr{Float64,VariableType}
+    @test objective_function_type(model) == GenericQuadExpr{T,VariableType}
     @test isequal_canonical(objective_function(model), x^2 + 2x)
     @test isequal_canonical(
         x^2 + 2x,
-        @inferred objective_function(
-            model,
-            GenericQuadExpr{Float64,VariableType},
-        )
+        @inferred objective_function(model, GenericQuadExpr{T,VariableType})
     )
     @test_throws InexactError objective_function(
         model,
-        GenericAffExpr{Float64,VariableType},
+        GenericAffExpr{T,VariableType},
     )
     return
 end
@@ -158,6 +150,7 @@ function test_extension_objective_sense_as_binnding(
     ModelType = Model,
     VariableType = VariableRef,
 )
+    T = value_type(ModelType)
     model = ModelType()
     @variable(model, x)
     sense = MIN_SENSE
@@ -165,10 +158,7 @@ function test_extension_objective_sense_as_binnding(
     @test MIN_SENSE == @inferred objective_sense(model)
     @test isequal_canonical(
         2x,
-        @inferred objective_function(
-            model,
-            GenericAffExpr{Float64,VariableType},
-        )
+        @inferred objective_function(model, GenericAffExpr{T,VariableType})
     )
     sense = :Min
     @test_throws ErrorException @objective(model, sense, 2x)

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -98,7 +98,7 @@ struct CustomIndex
 end
 
 function JuMP.add_constraint(
-    model::Model,
+    model::GenericModel,
     constraint::CustomConstraint,
     name::String,
 )
@@ -398,7 +398,7 @@ function test_extension_printing_variable_ref(
     io_test(MIME("text/latex"), x, "x2")
     set_name(x, "")
     @test name(x) == ""
-    if x isa VariableRef
+    if x isa GenericVariableRef
         io_test(MIME("text/plain"), x, "_[1]")
         io_test(MIME("text/latex"), x, "{\\_}_{1}")
     else

--- a/test/test_variable.jl
+++ b/test/test_variable.jl
@@ -51,14 +51,15 @@ function test_extension_variable_no_bound(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     model = ModelType()
     @variable(model, nobounds)
     @test !has_lower_bound(nobounds)
     @test !has_upper_bound(nobounds)
     @test !is_fixed(nobounds)
     _test_variable_name_util(nobounds, "nobounds")
-    @test zero(nobounds) isa GenericAffExpr{Float64,VariableRefType}
-    @test one(nobounds) isa GenericAffExpr{Float64,VariableRefType}
+    @test zero(nobounds) isa GenericAffExpr{T,VariableRefType}
+    @test one(nobounds) isa GenericAffExpr{T,VariableRefType}
     return
 end
 
@@ -431,17 +432,18 @@ function test_extension_variable_macro_return_type(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     model = ModelType()
-    @variable(model, x[1:3, 1:4, 1:2], start = 0.0)
+    @variable(model, x[1:3, 1:4, 1:2], start = T(0))
     @test typeof(x) == Array{VariableRefType,3}
-    @test typeof(start_value.(x)) == Array{Float64,3}
-    @variable(model, y[1:0], start = 0.0)
+    @test typeof(start_value.(x)) == Array{T,3}
+    @variable(model, y[1:0], start = T(0))
     @test typeof(y) == Vector{VariableRefType}
     # No type to infer for an empty collection.
-    @test typeof(start_value.(y)) == Vector{Union{Nothing,Float64}}
-    @variable(model, z[1:4], start = 0.0)
+    @test typeof(start_value.(y)) == Vector{Union{Nothing,T}}
+    @variable(model, z[1:4], start = T(0))
     @test typeof(z) == Vector{VariableRefType}
-    @test typeof(start_value.(z)) == Vector{Float64}
+    @test typeof(start_value.(z)) == Vector{T}
     return
 end
 
@@ -449,12 +451,13 @@ function test_extension_variable_start_value_on_empty(
     ModelType = Model,
     VariableRefType = VariableRef,
 )
+    T = value_type(ModelType)
     model = ModelType()
     @variable(model, x[1:4, 1:0, 1:3], start = 0)  # Array{VariableRef}
     @variable(model, y[1:4, 2:1, 1:3], start = 0)  # DenseAxisArray
     @variable(model, z[1:4, Set(), 1:3], start = 0)  # SparseAxisArray
 
-    @test start_value.(x) == Array{Float64}(undef, 4, 0, 3)
+    @test start_value.(x) == Array{T}(undef, 4, 0, 3)
     # TODO: Decide what to do here. I don't know if we still need to test this
     #       given broadcast syntax.
     # @test typeof(start_value(y)) <: DenseAxisArray{Float64}


### PR DESCRIPTION
A first approach could be to change `Model` into `Model{T}` with `Model() = Model{Float64}()` and `VariableRef` into `VariableRef{T}` with `VariableRef() = VariableRef{Float64}()`.
However, this would be breaking with respect to performance. Users having a `Model` or `VariableRef` as a field would not have a concrete field anymore.
Moreover, even if it is nonbreaking, users only caring about `Float64` will have non-concrete fields when using `Model` or `VariableRef` even if these types seem concrete from the name.

For these reasons, this PR is considering a different approach.
We define `GenericModel{T}` and `const Model = GenericModel{Float64}` and `GenericVariableRef{T}` with `const VariableRef = GenericVariableRef{Float64}`.
We now have a few advantages:

* This is non-breaking
* When the users use `GenericModel` and `GenericVariableRef` as a `struct` field, it's clear from the name that it is not concrete
* It is consistent with `AffExpr`/`GenericAffExpr` and `QuadExpr`/`GenericQuadExpr`

This PR also adds the `value_type` function to the JuMP API. This function gives the return type of the `JuMP.value` function on variables of the JuMP model. It can be called on a variable or a model. Calling it on an affine or quadratic may be confusing since the coefficient of the expression might be different from the `value_type` of the variables or even the return type of `value` on the expression. It is therefore not defined for affine and quadratic expressions.

- [x] Make current tests pass
- [x] Add tests
- [x] Add docs

Note that incorporates the changes of

- [x] https://github.com/jump-dev/JuMP.jl/pull/3332

because otherwise, I would have had to complicate the tests because of this:
```julia
julia> string(Float32(1) * im)
"0.0f0 + 1.0f0im"
```

Here if how it looks like
```julia
julia> model = GenericModel{Rational{BigInt}}(CDDLib.Optimizer{Rational{BigInt}})
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: EMPTY_OPTIMIZER
Solver name: CDD

julia> @variable(model, 0 <= x[1:2])
2-element Vector{GenericVariableRef{Rational{BigInt}}}:
 x[1]
 x[2]

julia> @constraint(model, c1, 2x[1] + x[2] <= 1)
c1 : 2//1 x[1] + x[2] ≤ 1//1

julia> @constraint(model, c2, x[1] + 3x[2] <= 2)
c2 : x[1] + 3//1 x[2] ≤ 2//1

julia> @objective(model, Max, sum(x))
x[1] + x[2]

julia> optimize!(model)

julia> solution_summary(model)
* Solver : CDD

* Status
  Result count       : 1
  Termination status : OPTIMAL
  Message from the solver:
  "Optimal"

* Candidate solution (result #1)
  Primal status      : FEASIBLE_POINT
  Dual status        : NO_SOLUTION
  Objective value    : 4//5

* Work counters


julia> value.(x)
2-element Vector{Rational{BigInt}}:
 1//5
 3//5

julia> value(c1)
1//1

julia> value(c2)
2//1
```

Closes https://github.com/jump-dev/JuMP.jl/issues/2025