### PR TITLE
Add SnoopPrecompile workload

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,12 +9,14 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 MutableArithmetics = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 MathOptInterface = "1.11"
 MutableArithmetics = "1"
 OrderedCollections = "1"
+SnoopPrecompile = "1"
 julia = "1.6"
 
 [extras]

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -807,6 +807,24 @@ for sym in names(@__MODULE__; all = true)
     @eval export $sym
 end
 
+using SnoopPrecompile
+
+@precompile_all_calls begin
+    # Because lots of the work is done by macros, and macros are expanded
+    # at lowering time, not much of this would get precompiled without `@eval`
+    @eval begin
+        let
+            model = Model(() -> MOI.Utilities.MockOptimizer(MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())))
+            @variable(model, x >= 0)
+            @variable(model, 0 <= y <= 3)
+            @objective(model, Min, 12x + 20y)
+            @constraint(model, c1, 6x + 8y >= 100)
+            @constraint(model, c2, 7x + 12y >= 120)
+            optimize!(model)
+        end
+    end
+end
+
 include("precompile.jl")
 _precompile_()
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -814,7 +814,13 @@ using SnoopPrecompile
     # at lowering time, not much of this would get precompiled without `@eval`
     @eval begin
         let
-            model = Model(() -> MOI.Utilities.MockOptimizer(MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())))
+            model = Model(
+                () -> MOI.Utilities.MockOptimizer(
+                    MOI.Utilities.UniversalFallback(
+                        MOI.Utilities.Model{Float64}(),
+                    ),
+                ),
+            )
             @variable(model, x >= 0)
             @variable(model, 0 <= y <= 3)
             @objective(model, Min, 12x + 20y)


### PR DESCRIPTION
On my machine, this cuts the TTFX of a simple workload (using the
GLPK solver, which is not used here) from about 8.5s to about 3s.

The improvement was measured on Julia `master`; there may be some (much smaller) improvement for Julia 1.8 as well, but I haven't tested. The workload is the one in #3192, identical to the one in the `@precompile_all_calls` block except using GLPK as the solver.