### PR TITLE
Improve precompilation with nospecialize and some more SnoopPrecompile

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -170,7 +170,7 @@ env = Gurobi.Env()
 model = Model(() -> Gurobi.Optimizer(env); add_bridges = false)
 ```
 """
-function Model(optimizer_factory; add_bridges::Bool = true)
+function Model((@nospecialize optimizer_factory); add_bridges::Bool = true)
     model = Model()
     set_optimizer(model, optimizer_factory; add_bridges = add_bridges)
     return model
@@ -826,6 +826,9 @@ using SnoopPrecompile
             @objective(model, Min, 12x + 20y)
             @constraint(model, c1, 6x + 8y >= 100)
             @constraint(model, c2, 7x + 12y >= 120)
+            @constraint(model, [x, y, x] in SecondOrderCone())
+            @constraint(model, [1.0 * x y; y x] >= 0, PSDCone())
+            @constraint(model, 1.0 * x ⟂ y)
             optimize!(model)
         end
     end

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -827,7 +827,7 @@ using SnoopPrecompile
             @constraint(model, c1, 6x + 8y >= 100)
             @constraint(model, c2, 7x + 12y >= 120)
             @constraint(model, [x, y, x] in SecondOrderCone())
-            @constraint(model, [1.0 * x y; y x] >= 0, PSDCone())
+            @constraint(model, [1.0*x y; y x] >= 0, PSDCone())
             @constraint(model, 1.0 * x ⟂ y)
             optimize!(model)
         end

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -397,7 +397,7 @@ set_optimizer(model, HiGHS.Optimizer; add_bridges = false)
 """
 function set_optimizer(
     model::Model,
-    optimizer_constructor;
+    (@nospecialize optimizer_constructor);
     add_bridges::Bool = true,
 )
     error_if_direct_mode(model, :set_optimizer)


### PR DESCRIPTION
x-ref https://github.com/jump-dev/JuMP.jl/issues/3192

```julia
julia> @time @eval begin
           let
               model = Model(HiGHS.Optimizer)
               @variable(model, x >= 0)
               @variable(model, 0 <= y <= 3)
               @objective(model, Min, 12x + 20y)
               @constraint(model, c1, 6x + 8y >= 100)
               @constraint(model, c2, 7x + 12y >= 120)
               optimize!(model)
           end
       end;
Running HiGHS 1.4.0 [date: 1970-01-01, git hash: bcf6c0b22]
Copyright (c) 2022 ERGO-Code under MIT licence terms
Presolving model
2 rows, 2 cols, 4 nonzeros
2 rows, 2 cols, 4 nonzeros
Presolve : Reductions: rows 2(-0); columns 2(-0); elements 4(-0) - Not reduced
Problem not reduced by presolve: solving the LP
Using EKK dual simplex solver - serial
  Iteration        Objective     Infeasibilities num(sum)
          0     0.0000000000e+00 Pr: 2(220) 0s
          2     2.0500000000e+02 Pr: 0(0) 0s
Model   status      : Optimal
Simplex   iterations: 2
Objective value     :  2.0500000000e+02
HiGHS run time      :          0.00
  0.639640 seconds (436.39 k allocations: 29.309 MiB, 98.57% compilation time)
```