### PR TITLE
Add more precompile statements to improve TTFX of Ipopt

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -847,12 +847,12 @@ SnoopPrecompile.@precompile_all_calls begin
                 x8[i = 1:3; isodd(i)], (start = i)
             end)
             @expressions(model, begin
-                a, x1 + x2
-                b, x1^2 + x2
+                a, -1 + x1 + x2
+                b, 1 + x1^2 + x2
             end)
             @constraints(model, begin
                 c1, a >= 0
-                c2[i=2:3, j=["a"]], a <= i
+                c2[i = 2:3, j = ["a"]], a <= i
                 c3, a == 0
                 c4, 0 <= a <= 1
                 c5, b >= 0

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -837,7 +837,7 @@ SnoopPrecompile.@precompile_all_calls begin
                 ),
             )
             @variables(model, begin
-                x1
+                x1 >= 0
                 0 <= x2 <= 1
                 x3 == 2
                 x4, Bin
@@ -852,7 +852,7 @@ SnoopPrecompile.@precompile_all_calls begin
             end)
             @constraints(model, begin
                 c1, a >= 0
-                c2, a <= 0
+                c2[i=2:3, j=["a"]], a <= i
                 c3, a == 0
                 c4, 0 <= a <= 1
                 c5, b >= 0
@@ -866,24 +866,33 @@ SnoopPrecompile.@precompile_all_calls begin
             @objective(model, Min, x1)
             @objective(model, Max, a)
             @objective(model, Min, b)
-            @NLconstraint(model, sin(x1) + sin(a) + sin(b) <= 1)
+            @NLconstraint(model, c9, 1 * sin(x1) + 2.0 * sin(a) + sin(b) <= 1)
             @NLparameter(model, p == 2)
             @NLexpression(model, expr, x1^p)
-            @NLobjective(model, Min, expr)
+            @NLobjective(model, Min, 1 + expr)
             optimize!(model)
             # This block could sit in MOI, but it's a public API at the JuMP
             # level, so it can go here.
+            #
+            # We evaluate with a `view` because it's a common type for solvers
+            # like Ipopt to use.
             d = NLPEvaluator(model)
+            MOI.features_available(d)
             MOI.initialize(d, [:Grad, :Jac, :Hess])
             g = zeros(num_nonlinear_constraints(model))
+            v_g = view(g, 1:length(g))
             x = zeros(num_variables(model))
             MOI.eval_objective(d, x)
             MOI.eval_constraint(d, g, x)
+            MOI.eval_constraint(d, v_g, x)
             MOI.eval_objective_gradient(d, g, x)
             J = zeros(length(MOI.jacobian_structure(d)))
             MOI.eval_constraint_jacobian(d, J, x)
+            v_J = view(J, 1:length(J))
+            MOI.eval_constraint_jacobian(d, v_J, x)
             H = zeros(length(MOI.hessian_lagrangian_structure(d)))
-            MOI.eval_hessian_lagrangian(d, H, x, 1.0, g)
+            v_H = view(H, 1:length(H))
+            MOI.eval_hessian_lagrangian(d, v_H, x, 1.0, v_g)
         end
     end
 end


### PR DESCRIPTION
With the changes in https://github.com/jump-dev/Ipopt.jl/pull/348, Ipopt is now down to the 1 second mark:

```julia
julia> @time using JuMP, Ipopt
  7.814919 seconds (10.48 M allocations: 679.759 MiB, 3.36% gc time, 0.28% compilation time)

julia> @time @eval begin
         let
           model = Model(Ipopt.Optimizer)
           @variable(model, x >= 0)
           @variable(model, 0 <= y <= 3)
           @NLobjective(model, Min, (12x + 20y)^2)
           @constraint(model, c1, 6x + 8y >= 1)
           @constraint(model, c2, (7x + 12y)^2 <= 120)
           optimize!(model)
         end
       end;

******************************************************************************
This program contains Ipopt, a library for large-scale nonlinear optimization.
 Ipopt is released as open source code under the Eclipse Public License (EPL).
         For more information visit https://github.com/coin-or/Ipopt
******************************************************************************

This is Ipopt version 3.14.4, running with linear solver MUMPS 5.5.1.

Number of nonzeros in equality constraint Jacobian...:        0
Number of nonzeros in inequality constraint Jacobian.:        6
Number of nonzeros in Lagrangian Hessian.............:        6

Total number of variables............................:        2
                     variables with only lower bounds:        1
                variables with lower and upper bounds:        1
                     variables with only upper bounds:        0
Total number of equality constraints.................:        0
Total number of inequality constraints...............:        2
        inequality constraints with only lower bounds:        1
   inequality constraints with lower and upper bounds:        0
        inequality constraints with only upper bounds:        1

iter    objective    inf_pr   inf_du lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls
   0  1.0239980e-01 8.60e-01 1.67e+00  -1.0 0.00e+00    -  0.00e+00 0.00e+00   0
   1  4.4898677e+00 0.00e+00 1.77e+01  -1.0 4.00e-01    -  1.97e-01 1.00e+00H  1
   2  4.3086284e+00 0.00e+00 3.73e+00  -1.0 4.77e-01    -  9.87e-01 1.45e-01f  2
   3  4.1790216e+00 0.00e+00 4.71e-03  -1.0 4.59e-02    -  1.00e+00 1.00e+00f  1
   4  4.0122780e+00 0.00e+00 5.08e-03  -2.5 6.10e-02    -  9.95e-01 1.00e+00f  1
   5  4.0003207e+00 0.00e+00 1.02e-06  -3.8 3.83e-03    -  1.00e+00 1.00e+00h  1
   6  4.0000035e+00 0.00e+00 1.49e-09  -5.7 1.12e-04    -  1.00e+00 1.00e+00h  1
   7  3.9999998e+00 0.00e+00 2.17e-13  -8.6 1.35e-06    -  1.00e+00 1.00e+00h  1

Number of Iterations....: 7

                                   (scaled)                 (unscaled)
Objective...............:   3.9999997650149046e+00    3.9999997650149046e+00
Dual infeasibility......:   2.1734307877695728e-13    2.1734307877695728e-13
Constraint violation....:   0.0000000000000000e+00    0.0000000000000000e+00
Variable bound violation:   9.8432153005599301e-09    9.8432153005599301e-09
Complementarity.........:   2.5085551206500019e-09    2.5085551206500019e-09
Overall NLP error.......:   2.5085551206500019e-09    2.5085551206500019e-09


Number of objective function evaluations             = 12
Number of objective gradient evaluations             = 8
Number of equality constraint evaluations            = 0
Number of inequality constraint evaluations          = 12
Number of equality constraint Jacobian evaluations   = 0
Number of inequality constraint Jacobian evaluations = 8
Number of Lagrangian Hessian evaluations             = 7
Total seconds in IPOPT                               = 0.006

EXIT: Optimal Solution Found.
  1.029464 seconds (700.34 k allocations: 47.196 MiB, 4.15% gc time, 98.43% compilation time)
```

The flame graph brings up an interesting point:

![image](https://user-images.githubusercontent.com/8177701/214208399-d704ce72-d572-48b3-8524-48992b78c8e5.png)

The middle tower is trying to compile `_moi_add_constraint(::Ipopt.Optimizer, ::VariableIndex, ::ZeroOne)` (even though it won't be called):

https://github.com/jump-dev/JuMP.jl/blob/ac5c1450d5900c711db727b173d9a9b7d9fa68f3/src/variables.jl#L1137-L1142

And my attempts to add it to `SnoopPrecompile.@precompile_all_calls` with a try-catch were unsuccessful. 

@timholy is there a trick to precompiling functions which throw errors?