### PR TITLE
Fix docstring of Model not appearing in docs

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -77,11 +77,6 @@ An abstract type that should be subtyped for users creating JuMP extensions.
 """
 abstract type AbstractModel end
 
-"""
-    Model
-
-A mathematical model of an optimization problem.
-"""
 mutable struct Model <: AbstractModel
     # In MANUAL and AUTOMATIC modes, CachingOptimizer.
     # In DIRECT mode, will hold an AbstractOptimizer.


### PR DESCRIPTION
x-ref https://discourse.julialang.org/t/add-bridges/93478/2

Upstream issue is https://github.com/JuliaDocs/Documenter.jl/issues/396. Easiest just to remove the docstring on the struct.

- [x] Check preview before merging