### PR TITLE
Add --> syntax support for indicator constraints

### DIFF
--- a/src/indicator.jl
+++ b/src/indicator.jl
@@ -15,9 +15,11 @@ function _build_indicator_constraint(
     set = MOI.Indicator{A}(moi_set(constraint))
     return VectorConstraint([variable, jump_function(constraint)], set)
 end
+
 function _indicator_variable_set(::Function, variable::Symbol)
     return variable, MOI.Indicator{MOI.ACTIVATE_ON_ONE}
 end
+
 function _indicator_variable_set(_error::Function, expr::Expr)
     if expr.args[1] == :¬ || expr.args[1] == :!
         if length(expr.args) != 2
@@ -30,6 +32,12 @@ function _indicator_variable_set(_error::Function, expr::Expr)
         return expr, MOI.Indicator{MOI.ACTIVATE_ON_ONE}
     end
 end
+
+function parse_constraint_head(_error::Function, ::Val{:(-->)}, lhs, rhs)
+    code, call = parse_constraint_call(_error, false, Val(:(=>)), lhs, rhs)
+    return false, code, call
+end
+
 function parse_constraint_call(
     _error::Function,
     vectorized::Bool,

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -350,17 +350,19 @@ function test_extension_indicator_constraint(
     @variable(model, y)
     for cref in [
         @constraint(model, a => {x + 2y <= 1}),
-        @constraint(model, a ⇒ {x + 2y ≤ 1})
+        @constraint(model, a ⇒ {x + 2y ≤ 1}),
+        @constraint(model, a --> {x + 2y ≤ 1}),
     ]
         c = constraint_object(cref)
         @test c.func == [a, x + 2y]
         @test c.set == MOI.Indicator{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(1.0))
     end
     for cref in [
-        @constraint(model, !b => {2x + y <= 1})
-        @constraint(model, ¬b ⇒ {2x + y ≤ 1})
+        @constraint(model, !b => {2x + y <= 1}),
+        @constraint(model, ¬b ⇒ {2x + y ≤ 1}),
+        @constraint(model, ¬b --> {2x + y ≤ 1}),
         # This returns a vector of constraints that is concatenated.
-        @constraint(model, ![b, b] .=> {[2x + y, 2x + y] .≤ 1})
+        @constraint(model, ![b, b] .=> {[2x + y, 2x + y] .≤ 1}),
     ]
         c = constraint_object(cref)
         @test c.func == [b, 2x + y]

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -349,20 +349,20 @@ function test_extension_indicator_constraint(
     @variable(model, x)
     @variable(model, y)
     for cref in [
-        @constraint(model, a => {x + 2y <= 1}),
-        @constraint(model, a ⇒ {x + 2y ≤ 1}),
-        @constraint(model, a --> {x + 2y ≤ 1}),
+        @constraint(model, a => {x + 2y <= 1})
+        @constraint(model, a ⇒ {x + 2y ≤ 1})
+        @constraint(model, a --> {x + 2y ≤ 1})
     ]
         c = constraint_object(cref)
         @test c.func == [a, x + 2y]
         @test c.set == MOI.Indicator{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(1.0))
     end
     for cref in [
-        @constraint(model, !b => {2x + y <= 1}),
-        @constraint(model, ¬b ⇒ {2x + y ≤ 1}),
-        @constraint(model, ¬b --> {2x + y ≤ 1}),
+        @constraint(model, !b => {2x + y <= 1})
+        @constraint(model, ¬b ⇒ {2x + y ≤ 1})
+        @constraint(model, ¬b --> {2x + y ≤ 1})
         # This returns a vector of constraints that is concatenated.
-        @constraint(model, ![b, b] .=> {[2x + y, 2x + y] .≤ 1}),
+        @constraint(model, ![b, b] .=> {[2x + y, 2x + y] .≤ 1})
     ]
         c = constraint_object(cref)
         @test c.func == [b, 2x + y]


### PR DESCRIPTION
x-ref: https://github.com/jump-dev/JuMP.jl/pull/3206#issuecomment-1409594524

I've left the default printing as `z => { ... }`, but if we merge #3206 then there's an argument that we should switch the printing and documentation to `-->` instead of `=>` (leaving `=>` as supported so it is non-breaking).

cc @chriscoey 