### PR TITLE
Bridge based parameters

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -755,6 +755,7 @@ include("operators.jl")
 include("sd.jl")
 include("sets.jl")
 include("solution_summary.jl")
+include("parameters.jl")
 
 # print.jl must come last, because it uses types defined in earlier files.
 include("print.jl")

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -1,0 +1,97 @@
+struct ParametricTerm{T}
+    var::MOI.VariableIndex
+    coeff::T
+    param::MOI.VariableIndex
+end
+
+struct FixParametricVariablesBridge{T} <: MOI.Bridges.Constraint.AbstractBridge
+    aff_constr::MOI.ConstraintIndex
+    parametric_terms::Vector{ParametricTerm{T}}
+end
+
+function MOI.Bridges.Constraint.concrete_bridge_type(
+    ::Type{<:FixParametricVariablesBridge}, 
+    F::Type{<:MOI.ScalarQuadraticFunction},
+    S::Type{<:MOI.AbstractScalarSet},
+)
+    return FixParametricVariablesBridge{Float64}
+end
+
+function MOI.supports_constraint(
+    ::Type{<:FixParametricVariablesBridge},
+	::Type{<:MOI.ScalarQuadraticFunction},
+	::Type{<:MOI.AbstractScalarSet},
+)
+	return true
+end
+
+function MOI.Bridges.added_constrained_variable_types(::Type{<:FixParametricVariablesBridge}) 
+	return Tuple{DataType}[]    # todo
+end
+
+function MOI.Bridges.added_constraint_types(::Type{<:FixParametricVariablesBridge})
+	return []                   # todo
+end
+
+MOI.Bridges.needs_final_touch(::FixParametricVariablesBridge) = true
+
+function MOI.Bridges.final_touch(
+    bridge::FixParametricVariablesBridge{T},
+    model::MOI.ModelLike,
+) where {T}
+    for _t in bridge.touches
+        coeff = _t.coeff
+        fix_constr = MOI.ConstraintIndex{MOI.VariableIndex,MOI.EqualTo{Float64}}(_t.param.value)
+        curr_param_val = MOI.get(model, MOI.ConstraintSet(), fix_constr).value
+        attached_var = _t.var
+        
+        MOI.modify(
+            model,
+            bridge.aff_constr,
+            MOI.ScalarCoefficientChange(attached_var, convert(T, coeff * curr_param_val)),
+        )
+    end
+    # todo: do we need to set the model to "dirty"?
+end
+
+function MOI.Bridges.Constraint.bridge_constraint(
+    ::Type{<:FixParametricVariablesBridge}, 
+    m::MOI.ModelLike, 
+    f::MOI.ScalarQuadraticFunction, 
+    s::MOI.AbstractScalarSet,       # todo: Union(LT, GT, EQ)
+)
+    affine_terms = f.affine_terms
+    constant = f.constant
+
+    parametric_terms = []
+    for term in f.quadratic_terms
+        coeff = term.coefficient
+
+        c1 = MOI.ConstraintIndex{MOI.VariableIndex,MOI.EqualTo{Float64}}(term.variable_1.value)
+        if MOI.is_valid(m, c1)
+            push!(parametric_terms, Touch(term.variable_2, coeff, term.variable_1))
+            coeff *= MOI.get(m, MOI.ConstraintSet(), c1).value
+            push!(affine_terms, MOI.ScalarAffineTerm(coeff, term.variable_2))
+            continue
+        end
+
+        c2 = MOI.ConstraintIndex{MOI.VariableIndex,MOI.EqualTo{Float64}}(term.variable_2.value)
+        if MOI.is_valid(m, c2)
+            push!(parametric_terms, Touch(term.variable_1, coeff, term.variable_2))
+            coeff *= MOI.get(m, MOI.ConstraintSet(), c2).value
+            push!(affine_terms, MOI.ScalarAffineTerm(coeff, term.variable_1))
+            continue
+        end
+        
+        @error "nope"
+    end
+
+    f = MOI.ScalarAffineFunction(affine_terms, constant)
+    aff_constr = MOI.add_constraint(m, f, s)
+
+    return FixParametricVariablesBridge{Float64}(aff_constr, parametric_terms)
+end
+
+function wrap_model!(model)
+    add_bridge(model, FixParametricVariablesBridge)
+end


### PR DESCRIPTION
# Idea
_Preface: This PR is not meant as an actual PR, but more as starting point for the discussion of a possible implementation for (partial, not generally viable) parameters in (MI)LP models - mostly since @odow encouraged me to open this even for a prototype. However, after the first benchmarks I am not sure if this idea is worth extensive consideration (also because it's not a general solution)._

The main idea originated while skimming through [this rework in PowerSimulations.jl](https://github.com/NREL-SIIP/PowerSimulations.jl/commit/8345963de2effcade1d4944c49a24068896e9a44#diff-17d6eaec9a0898dbd4527d1de3f5382d72ab85426bf1148633d048d9eb810a74R3): using fixed variables as parameters. While (from now on I'm only thinking about LPs) this works easily as long as the parameters are part of `b` (thought as in some constraints like `Ax <= b`), because the solver just eliminates them during presolve. However, as soon as they are part of `Ax`, they actually create an expression `param * var`, and since both of them are actually `JuMP.VariableRef` this will entail the creation of a `QuadExpr` (instead of an `AffExpr`).

After [asking about "multiplicative parameters"](https://discourse.julialang.org/t/jump-multiplicative-parameters-for-lp/94192/3), the idea (see [here](https://discourse.julialang.org/t/moi-re-evaluate-custom-bridge-direct-model-bridging/94219) for the first steps) was that - since solvers like `HiGHS` actually do not support quadratic terms in the constraints - adding a MathOptInterface bridge that converts `MOI.ScalarQuadraticFunction` into `MOI.ScalarAffineFunction` could

1. take the initial constraint,
2. find all quadratic terms in the underlying function,
3. lookup the values of all fixed variables that are involved,
4. replace the constraint by one containing an affine function were all fixed variables are replaced by their values

Therefore the usage of a "ParameterRef" would then entail:
1. creating a variable and fixing it to some value
2. using it like a constant (the "variable" will be replaced by its value before being passed to the solver)
3. calling `set_value(param, val) = fix(param, val; force=true)` automatically takes care of updating the parameter's value

---

> Remark: While [odow suggested](https://discourse.julialang.org/t/moi-re-evaluate-custom-bridge-direct-model-bridging/94219/8) to open the PR in MOI, I felt like this is too much of a special use case to fit there, and a few thoughts (see notes) made me think that it would fit the context of JuMP better. Apologies if that's not the case - feel free to continue any discussion over at MOI instead!

# Initial prototype

I have added the `parameters.jl` file, that implements:

- a basic bridge that (partially) takes care of the initial conversion
- the necessary `final_touch(...)` to take care of actual changes in parameter values

A simple test model is available [in this gist](https://gist.github.com/sstroemer/d759caf0a4ab35d4d3fee0202f23c204). It implements a basic concept of something generating (`gen`) a commodity (here: heat) that can be stored (`charge`/`discharge`) into `state` (with some losses due to efficiency), while making sure that a given demand is met. All that for each timestep. The parameters are: the `demand` (RHS / constant), the `cost` (coefficient in the objective function) of generation, and the conversion efficiency `cop` (coefficient in the constraints). Those are randomized.

While simple, this is a pretty "hard" example, since 50% of all constraints contain a multiplicative parameter that needs to be adjusted.

# First benchmarks

An initial performance test compares the timing for the steps: build, solve, update, re-solve. This is done for a standard model that is rebuilt from scratch each time, a parametric model, as well as a standard model where coefficients are adjusted manually. Timings (**all values given in milliseconds**) obtained from BenchmarkTools are listed below. All values correspond to **median** results. Re-optimize actually creates a new (random) set of parameters, therefore the solve times for the _w/o param_ can vary compared to the first solve.

The model contains 4 different variables per timestep, as well as 2 different constraints per timestep. Including upper and lower bounds for the variable this results (for a total of `T` timesteps) in:
- `4*T variables`
- `2*T equality constraints`
- `8*T inequality constraints/variable bounds` (`4*T` upper + `4*T` lower bounds)

Remark: The build step for _w/o param_ and _manually_ is the same. The _update_ step is identical to _build_ for _w/o param_ (it just re-creates the whole model).

I did not compare against ParametricOptInterface or ParameterJuMP, since the results do not seem that interesting/impressive at a first glance. Could be that I'm missing something important / did something completely wrong... but, while I think it could be okay to lose some performance in the "first" iteration (no real reason to do parametric models if not for iterative solves), the performance gain seems to quickly go down with larger model sizes (something that I do not understand right now; does not seem to be GC or memory / allocation related).

Percentages in the following tables are "change compared to the baseline defined by the standard model", given separately for the first (build + optimize) as well as for all subsequent iterations (update + re-optimize). _(pass only, no opt.)_ is the time it takes to pass the model to the solver (only measured after an update) - see notes at the end.

## T = 100
|      | **build** | **optimize** | **update** | **re-optimize** | _(pass only, no opt.)_ | **total first iteration** | **total per subsequent iteration** |
|:--------------:|:---------:|:------------:|:----------:|:---------------:|:--------:|:--------------------:|:--------------------:|
| **w/o param**  | 0.34      | 2.26         | 0.34       | 2.39            | 2.27     | 2.6 (+0%)            | 2.73 (+0%)           |
| **with param** | 0.93      | 2.91         | 0.26       | 0.53            | 0.52     | 3.84 (+48%)          | 0.79 (-71%)          |
| **manually**   | 0.34      | 2.26         | 0.23       | 0.55            | 0.51     | 2.6 (+0%)            | 0.78 (-71%)          |


## T = 1000
|        | **build** | **optimize** | **update** | **re-optimize** | _(pass only, no opt.)_ | **total first iteration** | **total per subsequent iteration** |
|:--------------:|:---------:|:------------:|:----------:|:---------------:|:-------------------:|:--------------------:|:--------------------:|
| **w/o param**  | 1.7       | 23.25        | 1.7        | 23.1            | 20.2                | 24.95 (+0%)          | 24.8 (+0%)           |
| **with param** | 2.86      | 29.46        | 3.29       | 4.9             | 1.76                | 32.32 (+30%)         | 8.19 (-67%)          |
| **manually**   | 1.7       | 23.25        | 2.91       | 4.78            | 1.85                | 24.95 (+0%)          | 7.69 (-69%)          |

## T = 10000
|       | **build** | **optimize** | **update** | **re-optimize** | _(pass only, no opt.)_ | **total first iteration** | **total per subsequent iteration** |
|:--------------:|:---------:|:------------:|:----------:|:---------------:|:-------------------:|:--------------------:|:--------------------:|
| **w/o param**  | 15.46     | 291.81       | 15.46      | 287.93          | 125.56              | 307.27 (+0%)         | 303.39 (+0%)         |
| **with param** | 24.44     | 347.56       | 100.2      | 78.76           | 19.93               | 372 (+21%)           | 178.96 (-41%)        |
| **manually**   | 15.46     | 291.81       | 97         | 73.63           | 19.67               | 307.27 (+0%)         | 170.63 (-44%)        |


# Notes

This is just a collection of notes/thoughts:
- There are most likey mistakes and things that could be done better/faster...
- I am pretty sure, that the "re-optimize" is not an obvious comparison: Some of the speed up could come from the "previous" solution being available as starting point (=> `HiGHS` completely skips presolve and needs a lot less iterations). But: 
    - We actually need to trigger the `optimize!(...)`, because that is what triggers the `final_touch(...)`, which could otherwise "mask away" a lot of necessary effort. This can be circumvented by setting the solver time limit to something really small. See the _(pass only, no opt.)_ column.
    - In practice that increased "solve performance" could actually be relevant - e.g. for model predictive control cases, the subsequent problems can be similar enough to benefit from this.
    - This is most likely only relevant for "smaller" problems, that are efficiently solved using simplex (IPM does not necessarily benefit from a starting solution; but maybe the presolve could be - partially - skipped?)
- We could easily implement a `@parameter` macro similar to `@variable`, with one additional feature: if the `JuMP.Model` would be wrapped into a `JuMP.ParametricModel` that has a field `enable_parameters` (or something like this), `@parameter` could check this flag. If it is enable, it constructs the parameter as fixed variable, if not it just returns the (initial) value. This way, a model could be converted from parametric (for repeated solves, accepting some performance loss for the first build+solve) to non-parametric without any relevant loss of performance (returning the value immediately stops the creation of `QuadExpr`s).
- This is currently only viable for `JuMP.Model` and does not support `JuMP.direct_model`. While this should be (as far as I understood) not too much work, performance could be vastly different to the current tests (especially for the comparison against the use of `set_normalized_coefficient(...)`).
- This currently does not solve the problem of multiplicative parameters in the objective function (since quadratic objectives are actually supported by many solvers). Furthermore it fails with any solver that supports quadratic terms in the constraints. Is there a way to "force" the application of a specific bridge onto a constraint/objective?
- Parameters in the RHS (so e.g. bounds) are not affected by this (since they actually end up in the affine terms of the `QuadExpr` anyways).
- `MOI.Bridges.added_constrained_variable_types(...)` and `MOI.Bridges.added_constraint_types(...)` are currently not correctly implemented.
- The current implementation clashes with the `relax_with_penalty!(...)` functionality. I'm not sure why (didn't dig into it)?


Please feel free to criticize, fix, change, ... !