### PR TITLE
"Native" support for parametric (LP/MILP) models

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -739,6 +739,7 @@ include("quad_expr.jl")
 include("nlp.jl")
 include("macros.jl")
 include("optimizer_interface.jl")
+include("parameters.jl")    # todo: this needs to come after `optimizer_interface.jl` since it uses `optimize!` - should that be moved to the lower block?
 
 # These includes are self-contained and can go in any order, except that
 # operators.jl must come after mutable_arithmetics.jl

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -273,7 +273,7 @@ end
 function _set_value(parameter::VariableRef, value::Float64; fix::Bool = true)
     # todo: this could be done only once if this is called by broadcasting
     model = owner_model(parameter)
-    if !haskey(model.ext[:__parameters].parameter, parameter)
+    if !haskey(model.ext[:__parameters].parameters, parameter)
         error("Can not set value on a non-parameter.")
     end
 

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -1,7 +1,6 @@
 import SparseArrays
 import LinearAlgebra
 import OrderedCollections
-using JuMP
 
 
 """

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -1,0 +1,367 @@
+import SparseArrays
+import LinearAlgebra
+import OrderedCollections
+
+
+"""
+    AffineVariableUpdate
+
+An affine calculation of a variable's coefficient in a constraint.
+"""
+struct AffineVariableUpdate
+    # This keeps the constant term.
+    constant::Float64
+    # This keeps the multiplicative factors for each param in the linear term.
+    params::SparseArrays.SparseVector{Float64, UInt64}
+end
+
+"""
+    AffineUpdateLink
+
+A single update to a given `constraint`, calculating the coefficient of `variable`
+following the affine update calculation represented by `update`
+"""
+struct AffineUpdateLink
+    constraint::ConstraintRef
+    variable::VariableRef
+    update::AffineVariableUpdate
+end
+
+"""
+    ParametricConstraint
+
+Parametric constraint type, that allows using parameters (in the form of VariableRef)
+inside the constraints body. Keeps the affine expression, the set, as well as the
+temporal (not bound to a ConstraintRef) `AffineVariableUpdate`s.
+"""
+struct ParametricConstraint{S} <: AbstractConstraint
+    f::AffExpr
+    s::S
+    temporal_update_links::Dict{VariableRef, AffineVariableUpdate}
+end
+
+"""
+    ParameterData
+
+Representation of the data associated with a parameter (its `value`). Keeps
+the incremental `index` to efficiently construct the affine update calculation.
+"""
+mutable struct ParameterData
+    index::UInt64
+    value::Float64
+end
+
+"""
+    JuMP.build_constraint(..., ::GenericAffExpr, ..., ...)
+
+Wrapper that enables constructing a parametric constraint that does not contain
+any parameters (therefore constructing an AffExpr instead of a QuadExpr).
+"""
+function JuMP.build_constraint(
+    _error::Function,
+    f::GenericAffExpr,
+    set::MOI.AbstractScalarSet,
+    ::Type{ParametricConstraint};
+)
+    return JuMP.build_constraint(_error, f, set)
+end
+
+"""
+    JuMP.build_constraint(..., ::GenericQuadExpr, ..., ...)
+
+Convert the constructed QuadExpr into an AffExpr and prepare proper
+updates to later calculate the coefficient of a given `VariableRef`
+inside the constraint based on all parameter values.
+"""
+function JuMP.build_constraint(
+    _error::Function,
+    f::JuMP.GenericQuadExpr,
+    set::MOI.AbstractScalarSet,
+    ::Type{ParametricConstraint};
+)
+    affine = f.aff
+    terms = f.terms
+
+    model = nothing # todo: extract the model somehow so that it doesn't default to `nothing`
+    n_param = 0  
+
+    # We expect as many updates as there are quadratic terms.
+    updates = Dict{VariableRef, AffineVariableUpdate}()
+    sizehint!(updates, length(terms))
+
+    for (vars, coeff) in terms
+        if isnothing(model)
+            model = owner_model(vars.a)
+            n_param = length(model.ext[:__parameters])
+        end
+
+        # Look up ParameterData for both involved variables.
+        v_a = get(model.ext[:__parameters], vars.a, nothing)
+        v_b = get(model.ext[:__parameters], vars.b, nothing)
+
+        if v_a !== nothing
+            if !haskey(updates, vars.b)
+                # Construct a AffineVariableUpdate, based on the constant
+                # (the affine term of the variabel) and a zeroed sparse vector.
+                updates[vars.b] = AffineVariableUpdate(get(affine.terms, vars.b, 0.0), SparseArrays.spzeros(n_param))
+            end
+            
+            # Add the coefficient of the quadratic term to the entry of
+            # the sparse vector corresponding to the correct parameter.
+            # Basically, for `2.0 * p * x`, this remembers the mapping
+            #   x -> p -> 2.0
+            # later telling us that the coefficient of `x` can be
+            # calculated as:
+            #   constant + 2.0 * `p`
+            updates[vars.b].params[v_a.index] += coeff
+        elseif v_b !== nothing
+            if !haskey(updates, vars.a)
+                updates[vars.a] = AffineVariableUpdate(get(affine.terms, vars.a, 0.0), SparseArrays.spzeros(n_param))
+            end
+
+            updates[vars.a].params[v_b.index] += coeff
+        else
+            # Both involved variables are "free" and not a parameter.
+            _error("At least one parameter is not properly registered.")
+        end
+    end
+
+    # The affine function may contain a constant term, move it to the set.
+    new_set = typeof(set)(MOI.constant(set) - affine.constant)
+    affine.constant = 0
+
+    return ParametricConstraint(affine, new_set, updates)
+end
+
+"""
+    JuMP.add_constraint(::Model, ::ParametricConstraint, ::String)
+
+Add the given parametric constraint `con` to the model. After adding it,
+this inserts the (previously only temporal) update links into the model.
+"""
+function JuMP.add_constraint(
+    model::Model,
+    con::ParametricConstraint,
+    name::String,
+)
+    # todo: handle the name
+    
+    constr = add_constraint(
+        model,
+        ScalarConstraint(con.f, con.s)
+    )
+
+    # Add all update links, now bound to the constructed constraint.
+    for (k, v) in con.temporal_update_links
+        push!(model.ext[:__links], AffineUpdateLink(constr, k, v))
+    end
+
+    return constr
+end
+
+"""
+    _mmdot(x, y)
+
+Compute the dot product of `x` and `y`, allowing for mismatches in the dimension.
+The missing entries of the shorter vector are assumed to be zero.
+"""
+function _mmdot(x, y)
+    lx = length(x)
+    ly = length(y)
+
+    if lx == ly
+        return LinearAlgebra.dot(x, y)
+    elseif lx < ly
+        return LinearAlgebra.dot(x, @view(y[1:lx]))
+    else
+        return LinearAlgebra.dot(@view(x[1:ly]), y)
+    end
+end
+
+"""
+    _eval_var_coeff(update::AffineVariableUpdate, param_values::Vector{Float64})
+
+Evaluate the affine update calculation given by `update` on the current
+global state of all parameters (as defined by `param_values`)
+"""
+function _eval_var_coeff(update::AffineVariableUpdate, param_values::Vector{Float64})
+    return update.constant + _mmdot(update.params, param_values)
+end
+
+"""
+    _finalize_parameters(model::JuMP.Model)
+
+Finalize all parameter values by updating the coefficients of each variable
+that is subject to a registered `AffineVariableUpdate` in a `ParametricConstraint`.
+"""
+function _finalize_parameters(model::JuMP.Model)
+    # Collect the values of all parameters into a vector. Since
+    # `model.ext[:__parameters]` is an `OrderedDict`, this unambiguous.
+    param_values = collect(it[2].value for it in model.ext[:__parameters])
+
+    # Update all coefficients.
+    @inbounds @simd for ul in model.ext[:__links]
+        # todo: somehow this results in less allocations but more time (be = backend(model) previously):
+        # MOI.modify(
+        #     be, ul.constraint,
+        #     MOI.ScalarCoefficientChange(ul.variable, eval_var_coeff(model, ul.update))
+        # )
+        set_normalized_coefficient(ul.constraint, ul.variable, _eval_var_coeff(ul.update, param_values))
+    end
+    # model.is_model_dirty = true       # this is used if MOI.modify(...) is used
+
+    return optimize!(model; ignore_optimize_hook = true)
+end
+
+"""
+    enable_parameters!(model::JuMP.Model)
+
+Enable parameters for `model` by registering the necessary optimize hook,
+as well as creating the intermediate storages that are used by parameters.
+"""
+function enable_parameters!(model::JuMP.Model)
+    haskey(model, :__parameters) && return nothing
+
+    set_optimize_hook(model, _finalize_parameters)
+
+    # todo: these could be part of `Model` (like `set_string_names_on_creation`)
+    model.ext[:__parameters] = OrderedCollections.OrderedDict{VariableRef, ParameterData}()
+    model.ext[:__links] = Vector{AffineUpdateLink}()
+
+    return nothing
+end
+
+function _set_value(parameter::VariableRef, value::Float64; fix::Bool=true)
+    # todo: this could be done only once if this is called by broadcasting
+    model = owner_model(parameter)
+    if !haskey(model.ext[:__parameters], parameter)
+        error("nope!")
+    end
+
+    # Change the value of the parameter.
+    model.ext[:__parameters][parameter].value = value
+
+    # If we need fixing, update the constraint.
+    fix && JuMP.fix(parameter, value; force=true)
+
+    # todo: modify the objective function here to fix all parameter values
+    return nothing
+end
+
+"""
+    set_value(parameter::VariableRef, value::Float64; fix::Bool=true)
+
+Set the value of `parameter` to `value`. If `fix` is `true`, this also
+inserts a MOI.EqualTo, that fixes the value of the corresponding `VariableRef`.
+Fixing decreases performance and is only necessary for parameters that are not
+only used as multiplicative parameters (e.g. on the RHS of a constraint).
+"""
+JuMP.set_value(parameter::VariableRef, value::Float64; fix::Bool=true) = _set_value(parameter, value; fix=fix)
+
+"""
+    @pexpression(...)
+
+Construct a parametric expression.
+
+Example usage:
+
+    model = JuMP.Model(HiGHS.Optimizer)
+    enable_parameters!(model)
+
+    @variable(model, x)
+    @parameter(model, p)
+
+    @pexpression(model, e, x + 10)
+    add_to_expression!(e, p * x)
+"""
+macro pexpression(args...)
+    # todo: only to the wrapping if it is an AffExpr
+    # todo: handle the case were the only arg is a VariableRef
+    return esc(:($JuMP.QuadExpr.($JuMP.@expression($(args...)))))
+end
+
+"""
+    @pconstraint(...)
+
+Construct a parametric constraint.
+
+Using this macro for a constraint makes sure that all involved
+parameters are tracked accordingly and automatically update the constraint
+as soon as `optimize!(...)` is called. Using this for a constraint that does
+not contain any parameters does not involve a performance loss (since it
+then just defaults to the standard `build_constraint(...)`); therefore it
+can (mostly) be used liberally.
+
+Before a call to `optimize!(...)`, this constraint does not represent
+the correct left-hand-side expression. To force an update, `_finalize_parameters(model)`
+can be used. This is not recommended!
+
+Example usage:
+
+    model = JuMP.Model(HiGHS.Optimizer)
+    enable_parameters!(model)
+
+    @variable(model, x)
+    @parameter(model, p)
+
+    @pconstraint(model, p * x >= 0)
+"""
+macro pconstraint(args...)
+    return esc(:($JuMP.@constraint($(args...), ParametricConstraint)))
+end
+
+"""
+    @parameter(model, ..., value; fix=true)
+
+Construct a parameter (can be named and vectorized like a variable) and
+set its initial `value`. If `fix` is `true`, this will create an additional
+MOI.EqualTo constraint, that fixes the value of the corresponding `VariableRef`.
+Fixing decreases performance and is only necessary for parameters that are not
+only used as multiplicative parameters (e.g. on the RHS of a constraint).
+"""
+macro parameter(args...)
+    # todo: this is performing worse than the manual code, improve this!
+    _error(str...) = JuMP._macro_error(:parameter, args, __source__, str...)
+
+    args = JuMP._reorder_parameters(args)
+    flat_args, kw_args, _ = JuMP.Containers._extract_kw_args(args)
+    kw_args = Dict(kw.args[1] => kw.args[2] for kw in kw_args)
+
+    if !(length(flat_args) in [2, 3])
+        _error("Wrong number of arguments. Did you miss the initial parameter value?")
+    end
+    # todo: properly catch misconfigurations of arguments
+    # if !(flat_args[end] isa Number) and !(flat_args[end] isa Vector)
+    #     _error("Wrong arguments. Did you miss the initial parameter value?")
+    # end
+    _vector_scalar_get(_scalar::Number, ::Int64) = _scalar
+    _vector_scalar_get(_vector::Vector{T} where T<:Number, i::Int64) = _vector[i]
+
+    # todo: fix this mess
+    if get(kw_args, :fix, true)
+        return esc(quote
+            _var = $JuMP.@variable($(flat_args[1:(end-1)]...))
+            if _var isa Vector
+                for i in eachindex(_var)
+                    $(flat_args[1]).ext[:__parameters][_var[i]] = ParameterData(UInt64(length($(flat_args[1]).ext[:__parameters]) + 1), $_vector_scalar_get($(flat_args[end]), i))
+                end
+            else
+                $(flat_args[1]).ext[:__parameters][_var] = ParameterData(UInt64(length($(flat_args[1]).ext[:__parameters]) + 1), $(flat_args[end]))
+                $JuMP.fix(_var, $(flat_args[end]); force=true)
+            end
+            _var
+        end)
+    else
+        return esc(quote
+            _var = $JuMP.@variable($(flat_args[1:(end-1)]...))
+            if _var isa Vector
+                for i in eachindex(_var)
+                    $(flat_args[1]).ext[:__parameters][_var[i]] = ParameterData(UInt64(length($(flat_args[1]).ext[:__parameters]) + 1), $_vector_scalar_get($(flat_args[end]), i))
+                end
+            else
+                $(flat_args[1]).ext[:__parameters][_var] = ParameterData(UInt64(length($(flat_args[1]).ext[:__parameters]) + 1), $(flat_args[end]))
+            end
+            _var
+        end)
+    end
+end


### PR DESCRIPTION
# Idea

This PR is based on the initial idea and discussion over at jump-dev/MathOptInterface.jl#2092. In contrast however, it builds up a pretty similar approach based mostly on JuMP functionality. It also does not rely on a bridge, and supports multiplicative parameters in the objective functions (and to some degree duals of the parameters).

_Preface: there are a lot of rough edges, this is just a first proof-of-concept_

This spends some additional time during model building to setup the proper data structure, but on parameter updates / new iterations it is almost as fast as possible (there is a single `LinearAlgebra.dot` call overhead - and that should be pretty fast for `SparseVector`s)!

# Rough outline

## Example 1
Create a model and enable parameters for it:
```julia
import HiGHS
using JuMP

model = JuMP.Model(HiGHS.Optimizer)
enable_parameters!(model)
```
We can now add parameters like variables, and bind them to initial values:

```julia
@variable(model, x[1:3] >= 0)

@parameter(model, p[1:2], [1.0, 1.0])
@parameter(model, c[1:3], [1.0, 1.5, 3.0])
@parameter(model, q, 5.0)
```

We can construct a paramteric constraint using
```julia
@pconstraint(model, constr, (p[1] + p[2]) * x[1] + 2*p[2]*x[2] + 2*x[1] + x[3] >= q)
```

You'll notice that this constraint actually reads `2 x[1] + x[3] - q ≥ 0.0` currently. This is due to the fact, that multiplicative parameters are only substituted before calling the solver (so they are currently considered to be 0 from the constraint's point of view).

We can also define an objective using parameters:
```julia
@objective(model, ParametricMin, sum((4.0 - i) * c[i] * x[i] for i in 1:3))
```

And now we just call
```julia
optimize!(model)
```

Let's look at the constraint now
```julia
constr
```
results in `4 x[1] + x[3] - q + 2 x[2] ≥ 0.0`

and the objective
```julia
objective_function(model)
```
results in `3 x[3] + 3 x[2] + 3 x[1]`.

We can also query
```julia
reduced_cost(q)     # => 0.75
```
but that needs to be handled with care since it only works for parameters that **do not** occur in a multiplicative way.

Updating a parameter is as simple as
```julia
set_value(p[2], 0.0)
```
which again does not affect the constraints immediately, but only as soon as we actually call `optimize!(...)`. It is therefore pretty fast.

---

## Example 2

Using expressions works like we would expect - except for the fact that my constraint macro is ... lacking. But that can be fixed. See spoiler
for full example:

<details>

```julia
model = JuMP.Model(HiGHS.Optimizer)
enable_parameters!(model)

@variable(model, x[1:3] >= 0)
@parameter(model, p[1:2], [1.0, 1.0]; fix=false)
@parameter(model, q, 5.0)

# todo "model[:e1] is bound to the AffExpr
e1 = @pexpression(model, [i=1:2], x[i] + 1)

add_to_expression!(e1[1], x[2]*p[1])
add_to_expression!(e1[2], x[3]*p[2])

e2 = @pexpression(model, q + 5)

@pconstraint(model, c[i=1:2], e1[i] + e2 >= 10)

@objective(model, Min, sum(x))

optimize!(model)
print(c[1])

set_value(p[1], 5.0; fix=false)

optimize!(model)
print(c[1])
```

</details>

# Benchmark

I am using - similar to the MOI PR - a comparison against doing it manually. See code in the spoiler:

<details>

```julia
import HiGHS
import Gurobi
using JuMP



function build_and_pass_bm(N::Int64, opt)
    @info "Build model"
    @time begin
        model = direct_model(opt)
        set_silent(model)
        set_string_names_on_creation(model, false)

        @variable(model, x[1:N])
        @constraint(model, c[i=1:N], 1.5 * x[i] >= 1)
        # @constraint(model, b[i=1:N], x[i] >= (mod(i, 2) == 0 ? 5 : 0))
        @objective(model, Min, sum(x))
    end
    @info "First optimize"
    @time optimize!(model)
    @info "Update"
    @time begin 
        set_normalized_coefficient.(c, x, (2.0 * 1.5) .* ones(N))
    end
    @info "Re-optimize"
    @time optimize!(model)
    @info "Total"
    return model
end

function build_and_pass(N::Int64, opt)
    @info "Build model"
    @time begin
        model = direct_model(opt)
        set_silent(model)
        set_string_names_on_creation(model, false)
        enable_parameters!(model)

        @variable(model, x[1:N])
        # @parameter(model, p[1:N], ones(N); fix=false)  # <-- performance is bad
        @variable(model, p[1:N])
        for i in 1:N
            model.ext[:__parameters].parameters[p[i]] = ParameterData(UInt64(i), 1.0)
        end

        @pconstraint(model, c[i=1:N], 1.5 * p[i] * x[i] >= 1)
        # @constraint(model, b[i=1:N], x[i] >= (mod(i, 2) == 0 ? 5 : 0))
        @objective(model, Min, sum(x))
    end
    @info "First optimize"
    @time optimize!(model)
    @info "Update"
    @time begin 
        set_value.(p, 2.0 .* ones(N); fix=false)
    end
    @info "Re-optimize"
    @time optimize!(model)
    @info "Total"
    return model
end

@time build_and_pass(1, Gurobi.Optimizer());
@time build_and_pass_bm(1, Gurobi.Optimizer());

GC.gc()
@time _m = build_and_pass(50_000, Gurobi.Optimizer());
GC.gc()
@time _m = build_and_pass_bm(50_000, Gurobi.Optimizer());
```

</details>

## Results

The best possible (manual) timings are:
```julia
[ Info: Build model
  0.074890 seconds (1.15 M allocations: 80.642 MiB)
[ Info: First optimize
  0.034082 seconds (34 allocations: 1.047 KiB)
[ Info: Update
  0.008517 seconds (100.01 k allocations: 2.671 MiB)
[ Info: Re-optimize
  0.012197 seconds (21 allocations: 656 bytes)
[ Info: Total
  0.172960 seconds (1.25 M allocations: 83.346 MiB)
```

The timings of the parametric model are:
```julia
[ Info: Build model
  0.224829 seconds (3.50 M allocations: 255.444 MiB, 22.86% gc time)
[ Info: First optimize
  0.075105 seconds (499.53 k allocations: 20.211 MiB)
[ Info: Update
  0.009579 seconds (300.02 k allocations: 8.011 MiB)
[ Info: Re-optimize
  0.052549 seconds (549.52 k allocations: 21.737 MiB)
[ Info: Total
  0.387364 seconds (4.85 M allocations: 305.430 MiB, 13.27% gc time)
```

## Notes
- This is currently slower on the build step than the MOI approach (but actually a faster once we consider the first solve too), but faster on subsequent updates and reoptimizes
- For a model with only parametric constraints (so every single one needs to be updated), the update and re-optimize is already faster than fully rebuilding and optimizing. In reality, there will be constraints that are not parametric, and building the model will require "external" data handling (e.g. for constructing the constraints based on some configuration) that will make "not re-building" a lot faster.
- I am using `Gurobi` for this at the moment, since `HiGHS` struggles with cases with "more" variables,
(see also [this comment by odow](https://github.com/jump-dev/MathOptInterface.jl/pull/2092#issuecomment-1424927590)).
- The build time for the "first iteration" is bad... However, this enables something that can not be reasonably done manually: constructing a constraint out of multiple expressions and then modifying a parameter (in the manual case, we would not easily know what the correct variable coefficient is based on an update to only a specific parameter).

# Open points
- benchmark against ParameterJuMP / POI (see [this comment by joaquimg](https://github.com/jump-dev/MathOptInterface.jl/pull/2092#issuecomment-1427319385))
- my macros are a total mess; the `@parameter` macro is a lot slower than doing what I thought it does manually so this is completely wrong; the expression/constraint macro need to properly bind their results in the calling scope
- I have "hacked" into the objective creation - there is most likely a better way to do this in the end



credits and history: [discourse](https://discourse.julialang.org/t/late-evaluation-of-expression-as-anymous-function/94516) (I've tried bulding expressions, building functions, using `DynamicExpressions.jl`, ...)

cc because maybe interested: @fleimgruber