### PR TITLE
Improve error message when unsupported operators are used in NL macros

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -459,7 +459,12 @@ end
 # nonlinear function fallbacks for JuMP built-in types
 ###############################################################################
 
-const _OP_HINT = "Are you trying to build a nonlinear problem? Make sure you use @NLconstraint/@NLobjective."
+const _OP_HINT =
+    "Are you trying to build a nonlinear problem? Make sure you use " *
+    "@NLconstraint/@NLobjective. If you are using an `@NL` macro and you " *
+    "encountered this error message, it is because you are attempting to use " *
+    "another unsupported function which calls this method internally."
+
 for f in MOI.Nonlinear.DEFAULT_UNIVARIATE_OPERATORS
     if f in (:+, :-, :abs) || !isdefined(Base, f)
         continue


### PR DESCRIPTION
Closes #3235

Not sure what the best approach is here. Ideally, this would be fixed by the move to `MOI.ScalarNonlinearFunction`.