### PR TITLE
Add set_start_values to simplify setting all starting values in a model

### DIFF
--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -781,7 +781,8 @@ julia> dual_start_value(con)
 
 !!! tip
     To simplify setting start values for all variables and constraints in a
-    model, see [`set_start_values`](@ref). The [Primal and dual warm-starts](@ref) also gives a detailed description of how to iterate over constraints
+    model, see [`set_start_values`](@ref). The [Primal and dual warm-starts](@ref)
+    tutorial also gives a detailed description of how to iterate over constraints
     in the model to set custom start values.
 
 ## Constraint containers

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -780,8 +780,9 @@ julia> dual_start_value(con)
 ```
 
 !!! tip
-    For more information, check out the [Primal and dual warm-starts](@ref)
-    tutorial.
+    To simplify setting start values for all variables and constraints in a
+    model, see [`set_start_values`](@ref). The [Primal and dual warm-starts](@ref) also gives a detailed description of how to iterate over constraints
+    in the model to set custom start values.
 
 ## Constraint containers
 

--- a/docs/src/manual/variables.md
+++ b/docs/src/manual/variables.md
@@ -636,6 +636,7 @@ julia> start_value.(z)
     x_solution = value.(x)
     set_start_value.(x, x_solution)
     ```
+    Alternatively, use [`set_start_values`](@ref).
 
 ## [Delete a variable](@id delete_a_variable)
 

--- a/docs/src/reference/models.md
+++ b/docs/src/reference/models.md
@@ -48,6 +48,7 @@ unset_silent
 set_time_limit_sec
 unset_time_limit_sec
 time_limit_sec
+set_start_values
 get_optimizer_attribute
 set_optimizer_attribute
 set_optimizer_attributes

--- a/docs/src/tutorials/conic/start_values.jl
+++ b/docs/src/tutorials/conic/start_values.jl
@@ -18,6 +18,9 @@
 # be a starting point for which you can modify if you want to do something
 # similar in your own code.
 
+# !!! warning
+#     This tutorial does not set start values for nonlinear models.
+
 # This tutorial uses the following packages:
 
 using JuMP
@@ -77,3 +80,10 @@ optimize!(model)
 
 # Now the optimization terminates after 0 iterations because our starting point
 # is already optimal.
+
+# Note that some solvers do not support setting some parts of the starting
+# solution, for example, they may support only `set_start_value` for variables.
+# If you encounter an `UnsupportedSupported` attribute error for
+# [`MOI.VariablePrimalStart`](@ref), [`MOI.ConstraintPrimalStart`](@ref), or
+# [`MOI.ConstraintDualStart`](@ref), comment out the corresponding part of the
+# `set_optimal_start_values` function.

--- a/docs/src/tutorials/conic/start_values.jl
+++ b/docs/src/tutorials/conic/start_values.jl
@@ -9,6 +9,10 @@
 # solution. This can improve performance, particularly if you are repeatedly
 # solving a sequence of related problems.
 
+# !!! tip
+#     See [`set_start_values`](@ref) for a generic implementation of this
+#     function that was added to JuMP after this tutorial was written.
+
 # In this tutorial, we demonstrate how to write a function that sets the primal
 # and dual starts as the optimal solution stored in a model. It is intended to
 # be a starting point for which you can modify if you want to do something

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -1061,7 +1061,15 @@ function set_start_values(
     constraint_primal = Dict{ConstraintRef,Float64}()
     constraint_dual = Dict{ConstraintRef,Float64}()
     for (F, S) in list_of_constraint_types(model)
-        _get_start_values(model, F, S, constraint_primal, constraint_dual)
+        _get_start_values(
+            model,
+            F,
+            S,
+            constraint_primal,
+            constraint_primal_start,
+            constraint_dual,
+            constraint_dual_start,
+        )
     end
     if nonlinear_dual_start !== nothing && num_nonlinear_constraints(model) > 0
         if MOI.supports(backend(model), MOI.NLPBlockDualStart())
@@ -1086,7 +1094,9 @@ function _get_start_values(
     ::Type{F},
     ::Type{S},
     constraint_primal,
+    constraint_primal_start::Union{Nothing,Function},
     constraint_dual,
+    constraint_dual_start::Union{Nothing,Function},
 ) where {F,S}
     moi_model = backend(model)
     CI = MOI.ConstraintIndex{moi_function_type(F),S}

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -1088,6 +1088,7 @@ function _get_start_values(
     constraint_primal,
     constraint_dual,
 ) where {F,S}
+    moi_model = backend(model)
     CI = MOI.ConstraintIndex{moi_function_type(F),S}
     support_constraint_primal =
         MOI.supports(moi_model, MOI.ConstraintPrimalStart(), CI)

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -980,3 +980,127 @@ function optimizer_index(x::Union{VariableRef,ConstraintRef{Model}})
     end
     return _moi_optimizer_index(backend(model), index(x))
 end
+
+"""
+    set_start_values(
+        model::Model;
+        variable_primal_start::Union{Nothing,Function} = value,
+        constraint_primal_start::Union{Nothing,Function} = value,
+        constraint_dual_start::Union{Nothing,Function} = dual,
+        nonlinear_dual_start::Union{Nothing,Function} = nonlinear_dual_start_value,
+    )
+
+Set the primal and dual starting values in `model` using the functions provided.
+
+If any keyword argument is `nothing`, the corresponding start value is skipped.
+
+If the optimizer does not support setting the starting value, the value will be
+skipped.
+
+## `variable_primal_start`
+
+This function controls the primal starting solution for the variables. It is
+equivalent to calling [`set_start_value`](@ref) for each variable, or setting
+the [`MOI.VariablePrimalStart`](@ref) attribute.
+
+If it is a function, it must have the form `variable_primal_start(x::VariableRef)`
+that maps each variable `x` to the starting primal value.
+
+The default is [`value`](@ref).
+
+## `constraint_primal_start`
+
+This function controls the primal starting solution for the constraints. It is
+equivalent to calling [`set_start_value`](@ref) for each constraint, or setting
+the [`MOI.ConstraintPrimalStart`](@ref) attribute.
+
+If it is a function, it must have the form `constraint_primal_start(ci::ConstraintRef)`
+that maps each constraint `ci` to the starting primal value.
+
+The default is [`value`](@ref).
+
+## `constraint_dual_start`
+
+This function controls the dual starting solution for the constraints. It is
+equivalent to calling [`set_dual_start_value`](@ref) for each constraint, or
+setting the [`MOI.ConstraintDualStart`](@ref) attribute.
+
+If it is a function, it must have the form `constraint_dual_start(ci::ConstraintRef)`
+that maps each constraint `ci` to the starting dual value.
+
+The default is [`dual`](@ref).
+
+## `nonlinear_dual_start`
+
+This function controls the dual starting solution for the nonlinear constraints
+It is equivalent to calling [`set_nonlinear_dual_start_value`](@ref).
+
+If it is a function, it must have the form `nonlinear_dual_start(model::Model)`
+that returns a vector corresponding to the dual start of the constraints.
+
+The default is [`nonlinear_dual_start_value`](@ref).
+"""
+function set_start_values(
+    model::Model;
+    variable_primal_start::Union{Nothing,Function} = value,
+    constraint_primal_start::Union{Nothing,Function} = value,
+    constraint_dual_start::Union{Nothing,Function} = dual,
+    nonlinear_dual_start::Union{Nothing,Function} = nonlinear_dual_start_value,
+)
+    ## Store a mapping of the variable primal solution
+    variable_primal = Dict()
+    support_variable_primal = MOI.supports(
+        backend(model),
+        MOI.VariablePrimalStart(),
+        MOI.VariableIndex,
+    )
+    if support_variable_primal && variable_primal_start !== nothing
+        for x in all_variables(model)
+            variable_primal[x] = variable_primal_start(x)
+        end
+    end
+    # In the following, we loop through every constraint and store a mapping
+    # from the constraint index to a tuple containing the primal and dual
+    # solutions.
+    constraint_primal, constraint_dual = Dict(), Dict()
+    for (F, S) in list_of_constraint_types(model)
+        # We add a try-catch here because some constraint types might not
+        # support getting the primal or dual solution.
+        CI = MOI.ConstraintIndex{moi_function_type(F),S}
+        support_constraint_primal = MOI.supports(
+            backend(model),
+            MOI.ConstraintPrimalStart(),
+            CI,
+        )
+        support_constraint_dual = MOI.supports(
+            backend(model),
+            MOI.ConstraintDualStart(),
+            CI,
+        )
+        for ci in all_constraints(model, F, S)
+            if support_constraint_primal && constraint_primal_start !== nothing
+                constraint_primal[ci] = constraint_primal_start(ci)
+            end
+            if support_constraint_dual && constraint_dual_start !== nothing
+                constraint_dual[ci] = constraint_dual_start(ci)
+            end
+        end
+    end
+    if nonlinear_dual_start !== nothing && num_nonlinear_constraints(model) > 0
+        if MOI.supports(backend(model), MOI.NLPBlockDualStart())
+            nlp_dual_start = nonlinear_dual_start(model)
+            set_nonlinear_dual_start_value(model, nlp_dual_start)
+        end
+    end
+    ## Now we can loop through our cached solutions and set the starting values.
+    for (x, primal_start) in variable_primal
+        set_start_value(x, primal_start)
+    end
+    for (ci, primal_start) in constraint_primal
+        set_start_value(ci, primal_start)
+    end
+    for (ci, dual_start) in constraint_dual
+        set_dual_start_value(ci, dual_start)
+    end
+    return
+end


### PR DESCRIPTION
x-ref: https://github.com/jump-dev/JuMP.jl/issues/2348#issuecomment-1442189960

This is a fairly common request. And "copy this large function from the docs but change it" isn't a great answer to have.

Needs:

 - [x] docs
 - [x] tests