### PR TITLE
Backport dot product fix with complex numbers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuMP"
 uuid = "4076af6c-e467-56ae-b986-b466b2749572"
 repo = "https://github.com/jump-dev/JuMP.jl.git"
-version = "1.8.1"
+version = "1.8.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ embedded in [Julia](https://julialang.org/). You can find out more about us by
 visiting [jump.dev](https://jump.dev).
 
 
-**Latest Release**: [![version](https://juliahub.com/docs/JuMP/DmXqY/1.8.1/version.svg)](https://juliahub.com/ui/Packages/JuMP/DmXqY/1.8.1) (`release-1.0` branch):
+**Latest Release**: [![version](https://juliahub.com/docs/JuMP/DmXqY/1.8.1/version.svg)](https://juliahub.com/ui/Packages/JuMP/DmXqY/1.8.2) (`release-1.0` branch):
   * Installation via the Julia package manager:
     * `import Pkg; Pkg.add("JuMP")`
   * Get help:

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,16 @@ CurrentModule = JuMP
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version 1.8.2 (February 27, 2023)
+
+### Fixed
+
+ - Fixed dot product between complex JuMP expression and number (#3244)
+
+### Other
+
+ - Polish simple SDP examples (#3232)
+
 ## Version 1.8.1 (February 23, 2023)
 
 ### Fixed

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -398,9 +398,9 @@ end
 # Base Julia's generic fallback vecdot, aka dot, requires that dot, aka LinearAlgebra.dot, be defined
 # for scalars, so instead of defining them one-by-one, we will
 # fallback to the multiplication operator
-LinearAlgebra.dot(lhs::_JuMPTypes, rhs::_JuMPTypes) = lhs * rhs
-LinearAlgebra.dot(lhs::_JuMPTypes, rhs::_Constant) = lhs * rhs
-LinearAlgebra.dot(lhs::_Constant, rhs::_JuMPTypes) = lhs * rhs
+LinearAlgebra.dot(lhs::_JuMPTypes, rhs::_JuMPTypes) = conj(lhs) * rhs
+LinearAlgebra.dot(lhs::_JuMPTypes, rhs::_Constant) = conj(lhs) * rhs
+LinearAlgebra.dot(lhs::_Constant, rhs::_JuMPTypes) = conj(lhs) * rhs
 
 function Base.promote_rule(V::Type{<:AbstractVariableRef}, R::Type{<:Number})
     return GenericAffExpr{_float_type(R),V}

--- a/test/test_complex.jl
+++ b/test/test_complex.jl
@@ -19,6 +19,11 @@ import SparseArrays
 
 const MA = MutableArithmetics
 
+function _test_dot(a, b)
+    @test LinearAlgebra.dot(a, b) == conj(a) * b
+    @test LinearAlgebra.dot(b, a) == conj(b) * a
+end
+
 function test_complex_aff_expr()
     model = Model()
     @variable(model, x)
@@ -28,6 +33,8 @@ function test_complex_aff_expr()
     @test 1im + x == 1im + (1 + 0im) * x
     @test 1im - x == -(1 + 0im)x + 1im
     @test 1im - 1 * x == -1 * x + 1im
+    _test_dot(4 - 5im, y)
+    _test_dot((3 - 7im) * x + 2 - im, y)
     return
 end
 


### PR DESCRIPTION
We cannot make a patch release with the master branch because of https://github.com/jump-dev/JuMP.jl/pull/3219 so let's do a patch release on the release-1.8 branch.