### PR TITLE
Support inequality syntax for HermitianPSDCone

### DIFF
--- a/docs/src/manual/complex.md
+++ b/docs/src/manual/complex.md
@@ -275,8 +275,3 @@ julia> @constraint(model, H in HermitianPSDCone())
 [x[1]           (0.0 + 1.0im);
  (0.0 - 1.0im)  (-1.0 - 0.0im) x[2]] ∈ HermitianPSDCone()
 ```
-
-!!! note
-    The matrix `H` in `H in HermitianPSDCone()` must be a `LinearAlgebra.Hermitian`
-    matrix type. A `build_constraint` error will be thrown if the matrix is
-    a different matrix type.

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -580,3 +580,47 @@ function build_constraint(
         shape,
     )
 end
+
+function build_constraint(
+    _error::Function,
+    Q::AbstractMatrix{<:AbstractJuMPScalar},
+    set::HermitianPSDCone,
+) where {V}
+    if !LinearAlgebra.ishermitian(Q)
+        _error("the matrix is not Hermitian.")
+    end
+    return build_constraint(_error, LinearAlgebra.Hermitian(Q), set)
+end
+
+function build_constraint(
+    _error::Function,
+    Q::AbstractMatrix{<:AbstractJuMPScalar},
+    set::Union{MOI.GreaterThan,MOI.LessThan},
+    extra::HermitianPSDCone,
+) where {V}
+    if !LinearAlgebra.ishermitian(Q)
+        _error("the matrix is not Hermitian.")
+    end
+    return build_constraint(_error, LinearAlgebra.Hermitian(Q), set, extra)
+end
+
+function build_constraint(
+    _error::Function,
+    f::LinearAlgebra.Hermitian{V,<:AbstractMatrix{V}},
+    s::MOI.GreaterThan,
+    extra::HermitianPSDCone,
+) where {V<:AbstractJuMPScalar}
+    @assert iszero(s.lower)
+    return build_constraint(_error, f, extra)
+end
+
+function build_constraint(
+    _error::Function,
+    f::LinearAlgebra.Hermitian{V,<:AbstractMatrix{V}},
+    s::MOI.LessThan,
+    extra::HermitianPSDCone,
+) where {V<:AbstractJuMPScalar}
+    @assert iszero(s.upper)
+    new_f = _MA.operate!!(*, -1, f)
+    return build_constraint(_error, new_f, extra)
+end

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -585,7 +585,7 @@ function build_constraint(
     _error::Function,
     Q::AbstractMatrix{<:AbstractJuMPScalar},
     set::HermitianPSDCone,
-) where {V}
+)
     if !LinearAlgebra.ishermitian(Q)
         _error("the matrix is not Hermitian.")
     end
@@ -597,7 +597,7 @@ function build_constraint(
     Q::AbstractMatrix{<:AbstractJuMPScalar},
     set::Union{MOI.GreaterThan,MOI.LessThan},
     extra::HermitianPSDCone,
-) where {V}
+)
     if !LinearAlgebra.ishermitian(Q)
         _error("the matrix is not Hermitian.")
     end

--- a/test/test_complex.jl
+++ b/test/test_complex.jl
@@ -283,6 +283,9 @@ function test_complex_hermitian_constraint_nonhermitian_syntax()
         ),
         @constraint(model, x in HermitianPSDCone()),
     )
+    H = [x[1, 1] x[1, 2]; x[1, 2] x[2, 2]]
+    @constraint(model, c, H in HermitianPSDCone())
+    @test constraint_object(c).func == [x[1, 1], x[1, 2], x[2, 2], 0]
     return
 end
 

--- a/test/test_complex.jl
+++ b/test/test_complex.jl
@@ -311,7 +311,7 @@ function test_complex_hermitian_constraint_lessthan_inequality_syntax()
     @constraint(model, c, 0 <= H, HermitianPSDCone())
     @test constraint_object(c).func == [x[1, 1], x[1, 2], x[2, 2], 0.0]
     @test function_string(MIME("text/plain"), constraint_object(c)) ==
-        "[x[1,1]  x[1,2];\n x[1,2]  x[2,2]]"
+          "[x[1,1]  x[1,2];\n x[1,2]  x[2,2]]"
     @test_throws_strip(
         ErrorException(
             "In `@constraint(model, 0 <= x, HermitianPSDCone())`: the matrix " *


### PR DESCRIPTION
This also adds support for general matrix types for which `LinearAlgebra.ishermitian(X) == true`, and it throws a nicer error if not.