### PR TITLE
Add remove_bridge, print_active_bridges, and document

### DIFF
--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -493,12 +493,12 @@ By default [`Model`](@ref) will create a `CachingOptimizer` in `AUTOMATIC` mode.
 
 ### LazyBridgeOptimizer
 
-The second layer that JuMP applies automatically is a `LazyBridgeOptimizer`. A
-`LazyBridgeOptimizer` is an MOI layer that attempts to transform the problem
-from the formulation provided by the user into an equivalent problem supported
-by the solver. This may involve adding new variables and constraints to the
-optimizer. The transformations are selected from a set of known recipes called
-_bridges_.
+The second layer that JuMP applies automatically is a [`MOI.Bridges.LazyBridgeOptimizer`](@ref).
+A [`MOI.Bridges.LazyBridgeOptimizer`](@ref) is an MOI layer that attempts to
+transform the problem from the formulation provided by the user into an
+equivalent problem supported by the solver. This may involve adding new
+variables and constraints to the optimizer. The transformations are selected
+from a set of known recipes called _bridges_.
 
 A common example of a bridge is one that splits an interval constraint like
 `@constraint(model, 1 <= x + y <= 2)` into two constraints,
@@ -522,6 +522,11 @@ with model cache MOIU.UniversalFallback{MOIU.Model{Float64}}
   fallback for MOIU.Model{Float64}
 with optimizer A HiGHS model with 0 columns and 0 rows.
 ```
+
+Bridges can be added and removed from a [`MOI.Bridges.LazyBridgeOptimizer`](@ref)
+using [`add_bridge`](@ref) and [`remove_bridge`](@ref). Use
+[`print_active_bridges`](@ref) to see which bridges are used to reformulate the
+model. Read the [Ellipsoid approximation](@ref) tutorial for more details.
 
 ### Unsafe backend
 

--- a/docs/src/reference/models.md
+++ b/docs/src/reference/models.md
@@ -82,7 +82,10 @@ MOIU.attach_optimizer(::JuMP.Model)
 ## Bridge tools
 
 ```@docs
+add_bridge
+remove_bridge
 bridge_constraints
+print_active_bridges
 print_bridge_graph
 ```
 

--- a/docs/src/tutorials/conic/ellipse_approx.jl
+++ b/docs/src/tutorials/conic/ellipse_approx.jl
@@ -28,7 +28,7 @@
 # ```math
 # E(D, c) = \{ x : (x - c)^\top D ( x - c) \leq 1 \},
 # ```
-# contains ``\mathcal{S}`` and and has the smallest possible volume.
+# contains ``\mathcal{S}`` and has the smallest possible volume.
 
 # The optimal ``D`` and ``c`` are given by the optimization problem:
 # ```math

--- a/docs/src/tutorials/conic/ellipse_approx.jl
+++ b/docs/src/tutorials/conic/ellipse_approx.jl
@@ -7,8 +7,8 @@
 
 # This tutorial considers the problem of computing _extremal ellipsoids_:
 # finding ellipsoids that best approximate a given set. As an extension, we show
-# how to use JuMP to inspect the bridges were used, and how to explore
-# alternate formulations.
+# how to use JuMP to inspect the bridges that were used, and how to explore
+# alternative formulations.
 
 # The model comes from Section 4.9 "Applications VII: Extremal Ellipsoids"
 # of the book *Lectures on Modern Convex Optimization* by
@@ -114,14 +114,14 @@ m, n = size(S)
     model,
     [i in 1:m],
     (S[i, :]' * Z * S[i, :]) - (2 * S[i, :]' * z) + s <= 1,
-)
+);
 
 # We cannot directly represent the objective ``(\det(Z))^{\frac{1}{n}}``, so we introduce
 # the conic reformulation:
 
 @variable(model, t)
 @constraint(model, [t; vec(Z)] in MOI.RootDetConeSquare(n))
-@objective(model, Max, t)
+@objective(model, Max, t);
 
 # Now, solve the program:
 
@@ -174,10 +174,10 @@ print_active_bridges(model)
 # This says that SCS does not support a `MOI.VariableIndex` objective function,
 # and that JuMP used a [`MOI.Bridges.Objective.FunctionizeBridge`](@ref) to
 # convert it into a `MOI.ScalarAffineFunction{Float64}` objective function.
-# We can leave JuMP to do the reformulation, or we can rewrite out model to
+# We can leave JuMP to do the reformulation, or we can rewrite our model to
 # have an objective function that SCS natively supports:
 
-@objective(model, Max, 1.0 * t + 0.0)
+@objective(model, Max, 1.0 * t + 0.0);
 
 # Re-printing the active bridges:
 
@@ -194,7 +194,7 @@ print_active_bridges(model)
 #  * Replacing the [`MOI.ScalarAffineFunction`](@ref) in [`MOI.GreaterThan`](@ref)
 #    constraints with [`MOI.VectorAffineFunction`](@ref) in [`MOI.Nonnegatives`](@ref)
 #
-#  * Replacing the [`MOI.RootDetConeSquare`](@ref) constriant with
+#  * Replacing the [`MOI.RootDetConeSquare`](@ref) constraint with
 #    [`MOI.RootDetConeTriangle`](@ref).
 
 # Note that we still need to bridge [`MOI.PositiveSemidefiniteConeTriangle`](@ref)
@@ -226,10 +226,10 @@ solve_time_1 = solve_time(model)
 print_active_bridges(model)
 
 # The last bullet shows how JuMP reformulated the [`MOI.RootDetConeTriangle`](@ref)
-# constraint by adding a mixed of [`MOI.PositiveSemidefiniteConeTriangle`](@ref)
+# constraint by adding a mix of [`MOI.PositiveSemidefiniteConeTriangle`](@ref)
 # and [`MOI.GeometricMeanCone`](@ref) constraints. Because SCS doesn't natively
 # support the [`MOI.GeometricMeanCone`](@ref), these were further bridged using
-# a [`MOI.Bridges.Constraint.GeoMeanToPowerBridge`](@ref) bridge in series of
+# a [`MOI.Bridges.Constraint.GeoMeanToPowerBridge`](@ref) bridge to a series of
 # [`MOI.PowerCone`](@ref) constraints. However, there are many other ways that
 # a [`MOI.GeometricMeanCone`](@ref) can be reformulated into something that SCS
 # supports. Let's see what happens if we use [`remove_bridge`](@ref) to remove

--- a/docs/src/tutorials/conic/ellipse_approx.jl
+++ b/docs/src/tutorials/conic/ellipse_approx.jl
@@ -222,10 +222,8 @@ set_silent(model)
     s
     nth_root_det_Z
 end)
-@expressions(model, begin
-    f_nonneg, [1 - (S[i, :]' * Z * S[i, :]) + (2 * S[i, :]' * z) - s for i in 1:m]
-    f_root, vcat(nth_root_det_Z, [Z[i, j] for i in 1:n for j in i:n])
-end);
+f_nonneg = [1 - (S[i, :]' * Z * S[i, :]) + (2 * S[i, :]' * z) - s for i in 1:m]
+f_root = vcat(nth_root_det_Z, [Z[i, j] for i in 1:n for j in i:n])
 @constraints(model, begin
     Z >= 0, PSDCone()
     LinearAlgebra.Symmetric([s z'; z Z]) >= 0, PSDCone()

--- a/docs/src/tutorials/conic/ellipse_approx.jl
+++ b/docs/src/tutorials/conic/ellipse_approx.jl
@@ -107,7 +107,7 @@ m, n = size(S)
 @constraint(
     model,
     [i in 1:m],
-    (S[i, :]' * Z * S[i, :]) - (2 * S[i, :]' * z) + s <= 1,
+    S[i, :]' * Z * S[i, :] - 2 * S[i, :]' * z + s <= 1,
 )
 @constraint(model, [t; vec(Z)] in MOI.RootDetConeSquare(n))
 @objective(model, Max, t)
@@ -205,14 +205,14 @@ set_silent(model)
 @constraint(model, Z >= 0, PSDCone())
 ## The former [s z'; z Z] >= 0, PSDCone()
 @constraint(model, LinearAlgebra.Symmetric([s z'; z Z]) >= 0, PSDCone())
-## The former constraint (S[i, :]' * Z * S[i, :]) - (2 * S[i, :]' * z) + s <= 1
-f = [1 - (S[i, :]' * Z * S[i, :]) + (2 * S[i, :]' * z) - s for i in 1:m]
+## The former constraint S[i, :]' * Z * S[i, :] - 2 * S[i, :]' * z + s <= 1
+f = [1 - S[i, :]' * Z * S[i, :] + 2 * S[i, :]' * z - s for i in 1:m]
 @constraint(model, f in MOI.Nonnegatives(m))
 ## The former constraint [t; vec(Z)] in MOI.RootDetConeSquare(n)
 Z_upper = [Z[i, j] for j in 1:n for i in 1:j]
-@constraint(model, 1 * vcat(t, Z_upper) .+ 0.0 in MOI.RootDetConeTriangle(n))
+@constraint(model, 1 * vcat(t, Z_upper) .+ 0 in MOI.RootDetConeTriangle(n))
 ## The former @objective(model, Max, t)
-@objective(model, Max, 1.0 * t + 0.0)
+@objective(model, Max, 1 * t + 0)
 optimize!(model)
 Test.@test isapprox(D, value.(Z); atol = 1e-6)  #src
 solve_time_1 = solve_time(model)

--- a/docs/src/tutorials/conic/ellipse_approx.jl
+++ b/docs/src/tutorials/conic/ellipse_approx.jl
@@ -259,4 +259,5 @@ print_active_bridges(model)
 
 # In general though, the performance of a particular reformulation is problem-
 # and solver-specific. Therefore, JuMP chooses to minimize the number of bridges in
-# the default reformulation.
+# the default reformulation, leaving you to explore alternative formulations
+# using the tools and techniques shown in this tutorial.

--- a/docs/src/tutorials/conic/ellipse_approx.jl
+++ b/docs/src/tutorials/conic/ellipse_approx.jl
@@ -112,7 +112,8 @@ m, n = size(S)
 @constraint(model, LinearAlgebra.Symmetric([s z'; z Z]) >= 0, PSDCone())
 @constraint(
     model,
-    [i in 1:m], (S[i, :]' * Z * S[i, :]) - (2 * S[i, :]' * z) + s <= 1,
+    [i in 1:m],
+    (S[i, :]' * Z * S[i, :]) - (2 * S[i, :]' * z) + s <= 1,
 )
 
 # We cannot directly represent the objective ``(\det(Z))^{\frac{1}{n}}``, so we introduce
@@ -209,11 +210,12 @@ set_silent(model)
     t
 end)
 f_nonneg = [1 - (S[i, :]' * Z * S[i, :]) + (2 * S[i, :]' * z) - s for i in 1:m]
+f_root = vcat(t, [Z[i, j] for j in 1:n for i in 1:j])
 @constraints(model, begin
     Z >= 0, PSDCone()
     LinearAlgebra.Symmetric([s z'; z Z]) >= 0, PSDCone()
     f_nonneg in MOI.Nonnegatives(m)
-    vcat(t, [Z[i, j] for i in 1:n for j in i:n]) in MOI.RootDetConeTriangle(n)
+    f_root in MOI.RootDetConeTriangle(n)
 end);
 @objective(model, Max, 1.0 * t + 0.0)
 optimize!(model)

--- a/docs/src/tutorials/conic/ellipse_approx.jl
+++ b/docs/src/tutorials/conic/ellipse_approx.jl
@@ -36,7 +36,7 @@
 # \max        \quad & t                                                                    \\
 # \text{s.t.} \quad & Z \succeq 0 \\
 #                   & \begin{bmatrix} s & z^\top \\ z & Z \\ \end{bmatrix} \succeq 0 \\
-#                   & x_i^\top Z x_i - 2x_i^\top z + s \leq 0    & \quad i=1, \ldots, m \\
+#                   & x_i^\top Z x_i - 2x_i^\top z + s \leq 1    & \quad i=1, \ldots, m \\
 #                   & t \ge \sqrt[n]{\det(Z)},
 # \end{aligned}
 # ```

--- a/docs/src/tutorials/conic/ellipse_approx.jl
+++ b/docs/src/tutorials/conic/ellipse_approx.jl
@@ -18,7 +18,7 @@
 
 # ## Problem formulation
 
-# Suppose that we are given a set ``S`` consisting of ``m`` points in
+# Suppose that we are given a set ``\mathcal{S}`` consisting of ``m`` points in
 # ``n``-dimensional space:
 # ```math
 # \mathcal{S} = \{ x_1, \ldots, x_m \} \subset \mathbb{R}^n
@@ -258,5 +258,5 @@ print_active_bridges(model)
 # model, the [`MOI.SecondOrderCone`](@ref) formulation is more efficient.
 
 # In general though, the performance of a particular reformulation is problem-
-# and solver-specific. Therefore, JuMP chooses to minimize number of bridges in
+# and solver-specific. Therefore, JuMP chooses to minimize the number of bridges in
 # the default reformulation.

--- a/docs/src/tutorials/conic/ellipse_approx.jl
+++ b/docs/src/tutorials/conic/ellipse_approx.jl
@@ -18,36 +18,29 @@
 
 # ## Problem formulation
 
-# Suppose that we are given a set ``S`` consisting of ``m`` points in ``n``-dimensional space:
+# Suppose that we are given a set ``S`` consisting of ``m`` points in
+# ``n``-dimensional space:
 # ```math
 # \mathcal{S} = \{ x_1, \ldots, x_m \} \subset \mathbb{R}^n
 # ```
 # Our goal is to determine an optimal vector ``c \in  \mathbb{R}^n`` and
-# an optimal ``n \times n`` real symmetric matrix ``D`` such that the ellipse
+# an optimal ``n \times n`` real symmetric matrix ``D`` such that the ellipse:
 # ```math
 # E(D, c) = \{ x : (x - c)^\top D ( x - c) \leq 1 \},
 # ```
-# contains ``\mathcal{S}`` and such that this ellipse has
-# the smallest possible volume.
+# contains ``\mathcal{S}`` and and has the smallest possible volume.
 
-# The optimal ``D`` and ``c`` are given by the convex semidefinite program
+# The optimal ``D`` and ``c`` are given by the optimization problem:
 # ```math
 # \begin{aligned}
-# \text{maximize }   && \quad (\det(Z))^{\frac{1}{n}}  & \\
-# \text{subject to } && \quad Z \; & \succeq \; 0 & \text{ (PSD) }, & \\
-# && \quad\begin{bmatrix}
-#     s  &  z^\top   \\
-#     z  &  Z        \\
-# \end{bmatrix}
-#  \; & \succeq \; 0 & \text{ (PSD) }, & \\
-# && x_i^\top Z x_i - 2x_i^\top z + s \; & \leq \; 0 &  i=1, \ldots, m &
+# \max        \quad & t                                                                    \\
+# \text{s.t.} \quad & Z                                                    \; & \succeq \; 0 \\
+#                   & \begin{bmatrix} s & z^\top \\ z & Z \\ \end{bmatrix} \; & \succeq \; 0 \\
+#                   & x_i^\top Z x_i - 2x_i^\top z + s                     \; & \leq \; 0    &  i=1, \ldots, m \\
+#                   & t \\ge \sqrt[n]\det(Z),
 # \end{aligned}
 # ```
-# with matrix variable ``Z``, vector variable ``z`` and real variables ``t, s``.
-# The optimal solution ``(t_*, Z_*, z_*, s_*)`` gives the optimal ellipse data as
-# ```math
-# D = Z_*, \quad c = Z_*^{-1} z_*.
-# ```
+# The optimal ellipse is given by ``D = Z_*`` and ``c = Z_*^{-1} z_*``.
 
 # ## Required packages
 
@@ -65,10 +58,10 @@ import Test  #src
 # We first need to generate some points to work with.
 
 function generate_point_cloud(
-    m;       # number of 2-dimensional points
-    a = 10,  # scaling in x direction
-    b = 2,   # scaling in y direction
-    rho = deg2rad(30),  # rotation of points around origin
+    m;            # number of 2-dimensional points
+    a = 10,       # scaling in x direction
+    b = 2,        # scaling in y direction
+    rho = π / 6,  # rotation of points around origin
     random_seed = 1,
 )
     rng = Random.MersenneTwister(random_seed)
@@ -97,8 +90,8 @@ plot = Plots.scatter(
 
 # ## JuMP formulation
 
-# Now let's build the JuMP model. We'll be able to compute
-# ``D`` and ``c`` after the solve.
+# Now let's build and the JuMP model. We'll compute ``D`` and ``c`` after the
+# solve.
 
 model = Model(SCS.Optimizer)
 ## We need to use a tighter tolerance for this example, otherwise the bounding
@@ -109,22 +102,15 @@ m, n = size(S)
 @variable(model, z[1:n])
 @variable(model, Z[1:n, 1:n], PSD)
 @variable(model, s)
-@constraint(model, LinearAlgebra.Symmetric([s z'; z Z]) >= 0, PSDCone())
+@variable(model, t)
+@constraint(model, [s z'; z Z] >= 0, PSDCone())
 @constraint(
     model,
     [i in 1:m],
     (S[i, :]' * Z * S[i, :]) - (2 * S[i, :]' * z) + s <= 1,
-);
-
-# We cannot directly represent the objective ``(\det(Z))^{\frac{1}{n}}``, so we introduce
-# the conic reformulation:
-
-@variable(model, t)
+)
 @constraint(model, [t; vec(Z)] in MOI.RootDetConeSquare(n))
-@objective(model, Max, t);
-
-# Now, solve the program:
-
+@objective(model, Max, t)
 optimize!(model)
 Test.@test termination_status(model) == OPTIMAL    #src
 Test.@test primal_status(model) == FEASIBLE_POINT  #src
@@ -136,6 +122,9 @@ solution_summary(model)
 # ``D`` and ``c``:
 
 D = value.(Z)
+
+#-
+
 c = D \ value.(z)
 
 # Finally, overlaying the solution in the plot we see the minimal volume approximating
@@ -146,13 +135,8 @@ Test.@test isapprox(c, [-3.24802, -1.842825]; atol = 1e-2)                    #s
 
 P = sqrt(D)
 q = -P * c
-
-Plots.plot!(
-    plot,
-    [tuple(P \ [cos(θ) - q[1], sin(θ) - q[2]]...) for θ in 0:0.05:(2pi+0.05)];
-    c = :crimson,
-    label = nothing,
-)
+data = [tuple(P \ [cos(θ) - q[1], sin(θ) - q[2]]...) for θ in 0:0.05:(2pi+0.05)]
+Plots.plot!(plot, data; c = :crimson, label = nothing)
 
 # ## Alternative formulations
 
@@ -174,6 +158,7 @@ print_active_bridges(model)
 # This says that SCS does not support a `MOI.VariableIndex` objective function,
 # and that JuMP used a [`MOI.Bridges.Objective.FunctionizeBridge`](@ref) to
 # convert it into a `MOI.ScalarAffineFunction{Float64}` objective function.
+
 # We can leave JuMP to do the reformulation, or we can rewrite our model to
 # have an objective function that SCS natively supports:
 
@@ -183,18 +168,27 @@ print_active_bridges(model)
 
 print_active_bridges(model)
 
-# we get `* Supported objective: MOI.ScalarAffineFunction{Float64}`. We can
-# manually implement some other reformulations to change our model to something
-# that SCS more closely supports by:
+# we get `* Supported objective: MOI.ScalarAffineFunction{Float64}`.
+
+# We can manually implement some other reformulations to change our model to
+# something that SCS more closely supports by:
 #
 #  * Replacing the [`MOI.VectorOfVariables`](@ref) in [`MOI.PositiveSemidefiniteConeTriangle`](@ref)
-#    constraint `Z[1:n, 1:n], PSD` with the [`MOI.VectorAffineFunction`](@ref)
-#    in [`MOI.PositiveSemidefiniteConeTriangle`](@ref) `Z >= 0, PSDCone()`.
+#    constraint `@variable(model, Z[1:n, 1:n], PSD)` with the
+#    [`MOI.VectorAffineFunction`](@ref) in [`MOI.PositiveSemidefiniteConeTriangle`](@ref)
+#    `@constraint(model, Z >= 0, PSDCone())`.
+#
+#  * Replacing the [`MOI.VectorOfVariables`](@ref) in [`MOI.PositiveSemidefiniteConeSquare`](@ref)
+#    constraint `[s z'; z Z] >= 0, PSDCone()` with the
+#    [`MOI.VectorAffineFunction`](@ref) in [`MOI.PositiveSemidefiniteConeTriangle`](@ref)
+#    `@constraint(model, LinearAlgebra.Symmetric([s z'; z Z]) >= 0, PSDCone())`.
 #
 #  * Replacing the [`MOI.ScalarAffineFunction`](@ref) in [`MOI.GreaterThan`](@ref)
-#    constraints with [`MOI.VectorAffineFunction`](@ref) in [`MOI.Nonnegatives`](@ref)
+#    constraints with the vectorized equivalent of
+#   [`MOI.VectorAffineFunction`](@ref) in [`MOI.Nonnegatives`](@ref)
 #
-#  * Replacing the [`MOI.RootDetConeSquare`](@ref) constraint with
+#  * Replacing the [`MOI.VectorOfVariables`](@ref) in [`MOI.RootDetConeSquare`](@ref)
+#    constraint with [`MOI.VectorAffineFunction`](@ref) in
 #    [`MOI.RootDetConeTriangle`](@ref).
 
 # Note that we still need to bridge [`MOI.PositiveSemidefiniteConeTriangle`](@ref)
@@ -203,20 +197,21 @@ print_active_bridges(model)
 model = Model(SCS.Optimizer)
 set_attribute(model, "eps_rel", 1e-6)
 set_silent(model)
-@variables(model, begin
-    z[1:n]
-    Z[1:n, 1:n], Symmetric
-    s
-    t
-end)
-f_nonneg = [1 - (S[i, :]' * Z * S[i, :]) + (2 * S[i, :]' * z) - s for i in 1:m]
-f_root = vcat(t, [Z[i, j] for j in 1:n for i in 1:j])
-@constraints(model, begin
-    Z >= 0, PSDCone()
-    LinearAlgebra.Symmetric([s z'; z Z]) >= 0, PSDCone()
-    f_nonneg in MOI.Nonnegatives(m)
-    f_root in MOI.RootDetConeTriangle(n)
-end);
+@variable(model, z[1:n])
+@variable(model, s)
+@variable(model, t)
+## The former @variable(model, Z[1:n, 1:n], PSD)
+@variable(model, Z[1:n, 1:n], Symmetric)
+@constraint(model, Z >= 0, PSDCone())
+## The former [s z'; z Z] >= 0, PSDCone()
+@constraint(model, LinearAlgebra.Symmetric([s z'; z Z]) >= 0, PSDCone())
+## The former constraint (S[i, :]' * Z * S[i, :]) - (2 * S[i, :]' * z) + s <= 1
+f = [1 - (S[i, :]' * Z * S[i, :]) + (2 * S[i, :]' * z) - s for i in 1:m]
+@constraint(model, f in MOI.Nonnegatives(m))
+## The former constraint [t; vec(Z)] in MOI.RootDetConeSquare(n)
+Z_upper = [Z[i, j] for j in 1:n for i in 1:j]
+@constraint(model, 1 * vcat(t, Z_upper) .+ 0.0 in MOI.RootDetConeTriangle(n))
+## The former @objective(model, Max, t)
 @objective(model, Max, 1.0 * t + 0.0)
 optimize!(model)
 solve_time_1 = solve_time(model)
@@ -227,13 +222,16 @@ print_active_bridges(model)
 
 # The last bullet shows how JuMP reformulated the [`MOI.RootDetConeTriangle`](@ref)
 # constraint by adding a mix of [`MOI.PositiveSemidefiniteConeTriangle`](@ref)
-# and [`MOI.GeometricMeanCone`](@ref) constraints. Because SCS doesn't natively
-# support the [`MOI.GeometricMeanCone`](@ref), these were further bridged using
-# a [`MOI.Bridges.Constraint.GeoMeanToPowerBridge`](@ref) bridge to a series of
-# [`MOI.PowerCone`](@ref) constraints. However, there are many other ways that
-# a [`MOI.GeometricMeanCone`](@ref) can be reformulated into something that SCS
-# supports. Let's see what happens if we use [`remove_bridge`](@ref) to remove
-# the [`MOI.Bridges.Constraint.GeoMeanToPowerBridge`](@ref):
+# and [`MOI.GeometricMeanCone`](@ref) constraints.
+
+# Because SCS doesn't natively support the [`MOI.GeometricMeanCone`](@ref),
+# these constraintns were further bridged using a [`MOI.Bridges.Constraint.GeoMeanToPowerBridge`](@ref)
+# to a series of [`MOI.PowerCone`](@ref) constraints.
+
+# However, there are many other ways that a [`MOI.GeometricMeanCone`](@ref) can
+# be reformulated into something that SCS supports. Let's see what happens if we
+# use [`remove_bridge`](@ref) to remove the
+# [`MOI.Bridges.Constraint.GeoMeanToPowerBridge`](@ref):
 
 remove_bridge(model, MOI.Bridges.Constraint.GeoMeanToPowerBridge)
 optimize!(model)
@@ -252,8 +250,10 @@ print_active_bridges(model)
 
 # This time, JuMP used a [`MOI.Bridges.Constraint.GeoMeanBridge`](@ref) to
 # reformulate the constraint into a set of [`MOI.RotatedSecondOrderCone`](@ref)
-# constraints, that were further reformulated into a set of supported
-# [`MOI.SecondOrderCone`](@ref) constraints. It seems that for this particular
+# constraints, which were further reformulated into a set of supported
+# [`MOI.SecondOrderCone`](@ref) constraints.
+
+# Since the two models are equivalent, we can conclude that for this particular
 # model, the [`MOI.SecondOrderCone`](@ref) formulation is more efficient.
 
 # In general though, the performance of a particular reformulation is problem-

--- a/docs/src/tutorials/conic/ellipse_approx.jl
+++ b/docs/src/tutorials/conic/ellipse_approx.jl
@@ -37,7 +37,7 @@
 # \text{s.t.} \quad & Z \succeq 0 \\
 #                   & \begin{bmatrix} s & z^\top \\ z & Z \\ \end{bmatrix} \succeq 0 \\
 #                   & x_i^\top Z x_i - 2x_i^\top z + s \leq 1    & \quad i=1, \ldots, m \\
-#                   & t \ge \sqrt[n]{\det(Z)},
+#                   & t \le \sqrt[n]{\det(Z)},
 # \end{aligned}
 # ```
 # where ``D = Z_*`` and ``c = Z_*^{-1} z_*``.

--- a/docs/src/tutorials/conic/ellipse_approx.jl
+++ b/docs/src/tutorials/conic/ellipse_approx.jl
@@ -185,7 +185,7 @@ print_active_bridges(model)
 #
 #  * Replacing the [`MOI.ScalarAffineFunction`](@ref) in [`MOI.GreaterThan`](@ref)
 #    constraints with the vectorized equivalent of
-#   [`MOI.VectorAffineFunction`](@ref) in [`MOI.Nonnegatives`](@ref)
+#    [`MOI.VectorAffineFunction`](@ref) in [`MOI.Nonnegatives`](@ref)
 #
 #  * Replacing the [`MOI.VectorOfVariables`](@ref) in [`MOI.RootDetConeSquare`](@ref)
 #    constraint with [`MOI.VectorAffineFunction`](@ref) in
@@ -226,7 +226,7 @@ print_active_bridges(model)
 # and [`MOI.GeometricMeanCone`](@ref) constraints.
 
 # Because SCS doesn't natively support the [`MOI.GeometricMeanCone`](@ref),
-# these constraintns were further bridged using a [`MOI.Bridges.Constraint.GeoMeanToPowerBridge`](@ref)
+# these constraints were further bridged using a [`MOI.Bridges.Constraint.GeoMeanToPowerBridge`](@ref)
 # to a series of [`MOI.PowerCone`](@ref) constraints.
 
 # However, there are many other ways that a [`MOI.GeometricMeanCone`](@ref) can

--- a/docs/src/tutorials/conic/ellipse_approx.jl
+++ b/docs/src/tutorials/conic/ellipse_approx.jl
@@ -34,13 +34,13 @@
 # ```math
 # \begin{aligned}
 # \max        \quad & t                                                                    \\
-# \text{s.t.} \quad & Z                                                    \; & \succeq \; 0 \\
-#                   & \begin{bmatrix} s & z^\top \\ z & Z \\ \end{bmatrix} \; & \succeq \; 0 \\
-#                   & x_i^\top Z x_i - 2x_i^\top z + s                     \; & \leq \; 0    &  i=1, \ldots, m \\
-#                   & t \\ge \sqrt[n]\det(Z),
+# \text{s.t.} \quad & Z \succeq 0 \\
+#                   & \begin{bmatrix} s & z^\top \\ z & Z \\ \end{bmatrix} \succeq 0 \\
+#                   & x_i^\top Z x_i - 2x_i^\top z + s \leq 0    & \quad i=1, \ldots, m \\
+#                   & t \ge \sqrt[n]{\det(Z)},
 # \end{aligned}
 # ```
-# The optimal ellipse is given by ``D = Z_*`` and ``c = Z_*^{-1} z_*``.
+# where ``D = Z_*`` and ``c = Z_*^{-1} z_*``.
 
 # ## Required packages
 

--- a/docs/src/tutorials/conic/ellipse_approx.jl
+++ b/docs/src/tutorials/conic/ellipse_approx.jl
@@ -214,6 +214,7 @@ Z_upper = [Z[i, j] for j in 1:n for i in 1:j]
 ## The former @objective(model, Max, t)
 @objective(model, Max, 1.0 * t + 0.0)
 optimize!(model)
+Test.@test isapprox(D, value.(Z); atol = 1e-6)  #src
 solve_time_1 = solve_time(model)
 
 # This formulation gives the much smaller graph:

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -337,7 +337,11 @@ function set_optimizer(
         optimizer =
             MOI.instantiate(optimizer_constructor; with_bridge_type = Float64)
         for bridge_type in model.bridge_types
-            _moi_add_bridge(optimizer, bridge_type)
+            _moi_call_bridge_function(
+                MOI.Bridges.add_bridge,
+                optimizer,
+                bridge_type{Float64},
+            )
         end
     else
         optimizer = MOI.instantiate(optimizer_constructor)

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -304,6 +304,20 @@ function test_bridges_add_before_con_set_optimizer()
     @test 2.0 == @inferred JuMP.dual(c)
 end
 
+function test_bridges_remove_bridge()
+    model = Model(mock_factory)
+    add_bridge(model, NonnegativeBridge)
+    @variable(model, x)
+    c = @constraint(model, x in Nonnegative())
+    optimize!(model)
+    @test 1.0 == @inferred value(x)
+    @test 1.0 == @inferred value(c)
+    @test 2.0 == @inferred dual(c)
+    remove_bridge(model, NonnegativeBridge)
+    @test_throws MOI.UnsupportedConstraint optimize!(model)
+    return
+end
+
 function test_bridges_add_after_con_model_optimizer()
     model = Model(mock_factory)
     @variable(model, x)
@@ -372,14 +386,14 @@ function test_bridge_graph_false()
     @variable(model, x)
     @test_throws(
         ErrorException(
-            "Cannot add bridge if `add_bridges` was set to `false` in " *
+            "Cannot use bridge if `add_bridges` was set to `false` in " *
             "the `Model` constructor.",
         ),
         add_bridge(model, NonnegativeBridge)
     )
     @test_throws(
         ErrorException(
-            "Cannot print bridge graph if `add_bridges` was set to " *
+            "Cannot use bridge if `add_bridges` was set to " *
             "`false` in the `Model` constructor.",
         ),
         print_bridge_graph(model)

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -318,6 +318,24 @@ function test_bridges_remove_bridge()
     return
 end
 
+function test_bridges_print_active_bridge()
+    model = Model(mock_factory)
+    add_bridge(model, NonnegativeBridge)
+    @variable(model, x)
+    c = @constraint(model, x in Nonnegative())
+    optimize!(model)
+    print_active_bridges(model)
+    @test sprint(print_active_bridges, model) == """
+ * Supported objective: MOI.ScalarAffineFunction{Float64}
+ * Unsupported constraint: MOI.VariableIndex-in-Main.TestModels.Nonnegative
+ |  bridged by:
+ |   Main.TestModels.NonnegativeBridge{Float64, MOI.VariableIndex}
+ |  introduces:
+ |   * Supported constraint: MOI.VariableIndex-in-MOI.GreaterThan{Float64}
+"""
+    return
+end
+
 function test_bridges_add_after_con_model_optimizer()
     model = Model(mock_factory)
     @variable(model, x)


### PR DESCRIPTION
As suggested by @blegat in https://github.com/jump-dev/JuMP.jl/issues/2348#issuecomment-1449751373, we're actually missing a few key tools to help the user understand the bridges.

This PR adds `JuMP.remove_bridge` and `JuMP.print_active_bridges`, and then extends the ellipse approximation tutorial to investigate alternate formulations.

Preview link: https://jump.dev/JuMP.jl/previews/PR3259/tutorials/conic/ellipse_approx