### PR TITLE
[docs] clarify in-place can be slower for small models

### DIFF
--- a/docs/src/tutorials/applications/power_systems.jl
+++ b/docs/src/tutorials/applications/power_systems.jl
@@ -241,8 +241,10 @@ inplace_df = solve_economic_dispatch_inplace(
 )
 print(string("elapsed time: ", time() - start, " seconds"))
 
-# Adjusting specific constraints or the objective function is faster than
-# re-building the entire model.
+# For small models, adjusting specific constraints or the objective function is
+# sometimes faster and sometimes slower than re-building the entire model.
+# However, as the problem size increases, updating the model in-place is usually
+# faster.
 
 inplace_df
 


### PR DESCRIPTION
x-ref: #3267 

I think this was actually compilation latency in the reverse direction.

On my first run, I got
```
elapsed time: 0.6746890544891357 seconds
elapsed time: 0.32920384407043457 seconds
```
and on my second I got
```
elapsed time: 0.09308099746704102 seconds
elapsed time: 0.18986296653747559 seconds
```

I'm not sure if it's because we've changed things in HiGHS and JuMP since I wrote the tutorial, or if it is to do with recent changes in compilation latency. But I've definitely given tutorials and talks where in-place is faster... (Perhaps it was also back when we used GLPK in the documentation?).

It seems like this could change in the future, so let's be more circumspect in how we word things going forward.