### PR TITLE
WIP: Objective starting values

### DIFF
--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -985,6 +985,85 @@ function optimizer_index(x::Union{VariableRef,ConstraintRef{Model}})
     return _moi_optimizer_index(backend(model), index(x))
 end
 
+struct ObjectiveFunctionAttribute{A,F}
+    attr::A
+end
+
+"""
+    struct ObjectiveDualStart <: MOI.AbstractModelAttribute end
+
+If the objective function had a dual, it would be `-1` for the Lagrangian
+function to be the same.
+When the `MOI.Bridges.Objective.SlackBridge` is used, it creates a constraint.
+The dual of this constraint is therefore `-1` as well.
+When setting this attribute, it allows to set the constraint dual of this
+constraint.
+"""
+struct ObjectiveDualStart <: MOI.AbstractModelAttribute end
+# Defining it for `MOI.set` leads to ambiguity
+MOI.throw_set_error_fallback(::MOI.ModelLike, ::ObjectiveDualStart, value) = nothing
+
+"""
+    struct ObjectiveSlackGapPrimalStart <: MOI.AbstractModelAttribute end
+
+If the objective function had a dual, it would be `-1` for the Lagrangian
+function to be the same.
+When the `MOI.Bridges.Objective.SlackBridge` is used, it creates a constraint.
+The dual of this constraint is therefore `-1` as well.
+When setting this attribute, it allows to set the constraint dual of this
+constraint.
+"""
+struct ObjectiveSlackGapPrimalStart <: MOI.AbstractModelAttribute end
+MOI.throw_set_error_fallback(::MOI.ModelLike, ::ObjectiveSlackGapPrimalStart, value) = nothing
+
+function MOI.set(
+    b::MOI.Bridges.AbstractBridgeOptimizer,
+    attr::ObjectiveFunctionAttribute{A,F},
+    value,
+) where {A,F}
+    obj_attr = MOI.ObjectiveFunction{F}()
+    if MOI.Bridges.is_bridged(b, obj_attr)
+        return MOI.set(MOI.Bridges.recursive_model(b), attr, MOI.Bridges.bridge(b, obj_attr), value)
+    else
+        return MOI.set(b.model, attr.attr, value)
+    end
+end
+
+function MOI.set(
+    b::MOI.Bridges.AbstractBridgeOptimizer,
+    attr::Union{
+        ObjectiveDualStart,
+        ObjectiveSlackGapPrimalStart,
+    },
+    value,
+)
+    if MOI.Bridges.is_objective_bridged(b)
+        F = MOI.Bridges.Objective.function_type(MOI.Bridges.Objective.bridges(b))
+        return MOI.set(b, ObjectiveFunctionAttribute{typeof(attr),F}(attr), value)
+    else
+        return MOI.set(b.model, attr, value)
+    end
+end
+
+function MOI.set(model::MOI.ModelLike, ::ObjectiveFunctionAttribute{ObjectiveDualStart}, b::MOI.Bridges.Objective.SlackBridge, value)
+    MOI.set(model, MOI.ConstraintDualStart(), b.constraint, value)
+end
+
+function MOI.set(model::MOI.ModelLike, ::ObjectiveFunctionAttribute{ObjectiveSlackGapPrimalStart}, b::MOI.Bridges.Objective.SlackBridge{T}, value) where {T}
+    # `f(x) - slack = value` so `slack = f(x) - value`
+    fun = MOI.get(model, MOI.ConstraintFunction(), b.constraint)
+    set = MOI.get(model, MOI.ConstraintSet(), b.constraint)
+    MOI.Utilities.operate!(-, T, fun, MOI.constant(set))
+    # `fun = f - slack` so we remove the term `-slack` to get `f`
+    f = MOI.Utilities.remove_variable(fun, b.slack)
+    f_val = MOI.Utilities.eval_variables(f) do v
+        MOI.get(model, MOI.VariablePrimalStart(), v)
+    end
+    MOI.set(model, MOI.VariablePrimalStart(), b.slack, f_val - value)
+    MOI.set(model, MOI.ConstraintPrimalStart(), b.constraint, value)
+end
+
+
 """
     set_start_values(
         model::Model;
@@ -1090,6 +1169,8 @@ function set_start_values(
     for (ci, dual_start) in constraint_dual
         set_dual_start_value(ci, dual_start)
     end
+    MOI.set(model, ObjectiveDualStart(), -1.0)
+    MOI.set(model, ObjectiveSlackGapPrimalStart(), 0.0)
     return
 end
 

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -1001,7 +1001,13 @@ constraint.
 """
 struct ObjectiveDualStart <: MOI.AbstractModelAttribute end
 # Defining it for `MOI.set` leads to ambiguity
-MOI.throw_set_error_fallback(::MOI.ModelLike, ::ObjectiveDualStart, value) = nothing
+function MOI.throw_set_error_fallback(
+    ::MOI.ModelLike,
+    ::ObjectiveDualStart,
+    value,
+)
+    return nothing
+end
 
 """
     struct ObjectiveSlackGapPrimalStart <: MOI.AbstractModelAttribute end
@@ -1014,7 +1020,13 @@ When setting this attribute, it allows to set the constraint dual of this
 constraint.
 """
 struct ObjectiveSlackGapPrimalStart <: MOI.AbstractModelAttribute end
-MOI.throw_set_error_fallback(::MOI.ModelLike, ::ObjectiveSlackGapPrimalStart, value) = nothing
+function MOI.throw_set_error_fallback(
+    ::MOI.ModelLike,
+    ::ObjectiveSlackGapPrimalStart,
+    value,
+)
+    return nothing
+end
 
 function MOI.set(
     b::MOI.Bridges.AbstractBridgeOptimizer,
@@ -1023,7 +1035,12 @@ function MOI.set(
 ) where {A,F}
     obj_attr = MOI.ObjectiveFunction{F}()
     if MOI.Bridges.is_bridged(b, obj_attr)
-        return MOI.set(MOI.Bridges.recursive_model(b), attr, MOI.Bridges.bridge(b, obj_attr), value)
+        return MOI.set(
+            MOI.Bridges.recursive_model(b),
+            attr,
+            MOI.Bridges.bridge(b, obj_attr),
+            value,
+        )
     else
         return MOI.set(b.model, attr.attr, value)
     end
@@ -1031,25 +1048,38 @@ end
 
 function MOI.set(
     b::MOI.Bridges.AbstractBridgeOptimizer,
-    attr::Union{
-        ObjectiveDualStart,
-        ObjectiveSlackGapPrimalStart,
-    },
+    attr::Union{ObjectiveDualStart,ObjectiveSlackGapPrimalStart},
     value,
 )
     if MOI.Bridges.is_objective_bridged(b)
-        F = MOI.Bridges.Objective.function_type(MOI.Bridges.Objective.bridges(b))
-        return MOI.set(b, ObjectiveFunctionAttribute{typeof(attr),F}(attr), value)
+        F = MOI.Bridges.Objective.function_type(
+            MOI.Bridges.Objective.bridges(b),
+        )
+        return MOI.set(
+            b,
+            ObjectiveFunctionAttribute{typeof(attr),F}(attr),
+            value,
+        )
     else
         return MOI.set(b.model, attr, value)
     end
 end
 
-function MOI.set(model::MOI.ModelLike, ::ObjectiveFunctionAttribute{ObjectiveDualStart}, b::MOI.Bridges.Objective.SlackBridge, value)
-    MOI.set(model, MOI.ConstraintDualStart(), b.constraint, value)
+function MOI.set(
+    model::MOI.ModelLike,
+    ::ObjectiveFunctionAttribute{ObjectiveDualStart},
+    b::MOI.Bridges.Objective.SlackBridge,
+    value,
+)
+    return MOI.set(model, MOI.ConstraintDualStart(), b.constraint, value)
 end
 
-function MOI.set(model::MOI.ModelLike, ::ObjectiveFunctionAttribute{ObjectiveSlackGapPrimalStart}, b::MOI.Bridges.Objective.SlackBridge{T}, value) where {T}
+function MOI.set(
+    model::MOI.ModelLike,
+    ::ObjectiveFunctionAttribute{ObjectiveSlackGapPrimalStart},
+    b::MOI.Bridges.Objective.SlackBridge{T},
+    value,
+) where {T}
     # `f(x) - slack = value` so `slack = f(x) - value`
     fun = MOI.get(model, MOI.ConstraintFunction(), b.constraint)
     set = MOI.get(model, MOI.ConstraintSet(), b.constraint)
@@ -1057,12 +1087,11 @@ function MOI.set(model::MOI.ModelLike, ::ObjectiveFunctionAttribute{ObjectiveSla
     # `fun = f - slack` so we remove the term `-slack` to get `f`
     f = MOI.Utilities.remove_variable(fun, b.slack)
     f_val = MOI.Utilities.eval_variables(f) do v
-        MOI.get(model, MOI.VariablePrimalStart(), v)
+        return MOI.get(model, MOI.VariablePrimalStart(), v)
     end
     MOI.set(model, MOI.VariablePrimalStart(), b.slack, f_val - value)
-    MOI.set(model, MOI.ConstraintPrimalStart(), b.constraint, value)
+    return MOI.set(model, MOI.ConstraintPrimalStart(), b.constraint, value)
 end
-
 
 """
     set_start_values(


### PR DESCRIPTION
Proof of concept solution for https://github.com/jump-dev/JuMP.jl/issues/3270 copy-pasted from `src/copy_dual.jl` of https://github.com/jump-dev/DiffOpt.jl/pull/231/
Most of it should be in MOI which is why it's more of a POC PR.
The example of https://github.com/jump-dev/JuMP.jl/issues/3270 works after this PR:
```julia
julia> using SCS, JuMP

julia> model = Model(SCS.Optimizer);

julia> @variable(model, x);

julia> @objective(model, Min, x^2);

julia> optimize!(model)
------------------------------------------------------------------
	       SCS v3.2.1 - Splitting Conic Solver
	(c) Brendan O'Donoghue, Stanford University, 2012
------------------------------------------------------------------
problem:  variables n: 2, constraints m: 3
cones: 	  q: soc vars: 3, qsize: 1
settings: eps_abs: 1.0e-04, eps_rel: 1.0e-04, eps_infeas: 1.0e-07
	  alpha: 1.50, scale: 1.00e-01, adaptive_scale: 1
	  max_iters: 100000, normalize: 1, rho_x: 1.00e-06
	  acceleration_lookback: 10, acceleration_interval: 10
lin-sys:  sparse-direct-amd-qdldl
	  nnz(A): 3, nnz(P): 0
------------------------------------------------------------------
 iter | pri res | dua res |   gap   |   obj   |  scale  | time (s)
------------------------------------------------------------------
     0| 2.07e+01  1.00e+00  2.83e+01 -1.41e+01  1.00e-01  9.90e-05 
    25| 1.14e-05  2.44e-08  1.61e-05  8.04e-06  1.00e-01  1.18e-04 
------------------------------------------------------------------
status:  solved
timings: total: 1.19e-04s = setup: 7.40e-05s + solve: 4.48e-05s
	 lin-sys: 3.28e-06s, cones: 2.97e-06s, accel: 9.37e-07s
------------------------------------------------------------------
objective = 0.000008
------------------------------------------------------------------

julia> set_start_values(model)

julia> model.moi_backend.optimizer.model.model_cache.varattr
Dict{MathOptInterface.AbstractVariableAttribute, Dict{MathOptInterface.VariableIndex, Any}} with 1 entry:
  VariablePrimalStart() => Dict(VariableIndex(2)=>0.0, VariableIndex(1)=>0.0)

julia> model.moi_backend.optimizer.model.model_cache.conattr
Dict{MathOptInterface.AbstractConstraintAttribute, Dict{MathOptInterface.ConstraintIndex, Any}} with 2 entries:
  ConstraintDualStart()   => Dict(ConstraintIndex{VectorAffineFunction{Float64}, SecondOrderCone}(1)=>[0.707107, -0.707107, -0.0])
  ConstraintPrimalStart() => Dict(ConstraintIndex{VectorAffineFunction{Float64}, SecondOrderCone}(1)=>[0.707107, 0.707107, 0.0])

julia> optimize!(model)
------------------------------------------------------------------
	       SCS v3.2.1 - Splitting Conic Solver
	(c) Brendan O'Donoghue, Stanford University, 2012
------------------------------------------------------------------
problem:  variables n: 2, constraints m: 3
cones: 	  q: soc vars: 3, qsize: 1
settings: eps_abs: 1.0e-04, eps_rel: 1.0e-04, eps_infeas: 1.0e-07
	  alpha: 1.50, scale: 1.00e-01, adaptive_scale: 1
	  max_iters: 100000, normalize: 1, rho_x: 1.00e-06
	  acceleration_lookback: 10, acceleration_interval: 10
lin-sys:  sparse-direct-amd-qdldl
	  nnz(A): 3, nnz(P): 0
------------------------------------------------------------------
 iter | pri res | dua res |   gap   |   obj   |  scale  | time (s)
------------------------------------------------------------------
     0| 2.61e-15  2.22e-16  3.55e-15 -1.78e-15  1.00e-01  5.50e-05 
------------------------------------------------------------------
status:  solved
timings: total: 5.61e-05s = setup: 4.21e-05s + solve: 1.40e-05s
	 lin-sys: 6.56e-07s, cones: 1.33e-06s, accel: 2.90e-08s
------------------------------------------------------------------
objective = -0.000000
------------------------------------------------------------------
```