### PR TITLE
Add JuMP-level Nonnegatives, Nonpositives, and Zeros sets

### DIFF
--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -134,7 +134,7 @@ the constraint object `con_vector` or `con_scalar`.
    the broadcast `.==`.
 
 JuMP reformulates both constraints into the other form if needed by the solver,
-but choosing right format for a particular solver is more efficient.
+but choosing the right format for a particular solver is more efficient.
 
 You can also use `<=`, `.<=` , `>=`, and `.>=` as comparison operators in the
 constraint.

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -108,16 +108,36 @@ julia> b = [5, 6]
  5
  6
 
-julia> @constraint(model, con, A * x .== b)
+julia> @constraint(model, con_vector, A * x == b)
+con_vector : [x[1] + 2 x[2] - 5, 3 x[1] + 4 x[2] - 6] ∈ MathOptInterface.Zeros(2)
+
+julia> @constraint(model, con_scalar, A * x .== b)
 2-element Vector{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.EqualTo{Float64}}, ScalarShape}}:
- con : x[1] + 2 x[2] = 5.0
- con : 3 x[1] + 4 x[2] = 6.0
+ con_scalar : x[1] + 2 x[2] = 5.0
+ con_scalar : 3 x[1] + 4 x[2] = 6.0
 ```
 
-!!! note
-    Make sure to use [Julia's dot syntax](https://docs.julialang.org/en/v1/manual/functions/index.html#man-vectorized-1)
-    in front of the comparison operators (for example, `.==`, `.>=`, and `.<=`). If you
-    use a comparison without the dot, an error will be thrown.
+The two constraints, `==` and `.==` are similar, but subtly different. The first
+creates a single constraint that is a [`MOI.VectorAffineFunction`](@ref) in
+[`MOI.Zeros`](@ref) constraint. The second creates a vector of
+[`MOI.ScalarAffineFunction`](@ref) in [`MOI.EqualTo`](@ref) constraints.
+
+Which formulation to choose depends on the solver, and what you want to do with
+the constraint object `con_vector` or `con_scalar`.
+
+ * If you are using a conic solver, expect the dual of `con_vector` to be a
+   `Vector{Float64}`, and do not intend to delete a row in the constraint,
+   choose the `==` formulation.
+ * If you are using a solver that expects a list of scalar constraints, for
+   example HiGHS, or you wish to delete part of the constraint or access a
+   single row of the constraint, for example, `dual(con_scalar[2])`, then use
+   the broadcast `.==`.
+
+JuMP reformulates both constraints into the other form if needed by the solver,
+but choosing right format for a particular solver is more efficient.
+
+You can also use `<=`, `.<=` , `>=`, and `.>=` as comparison operators in the
+constraint.
 
 ### Containers of constraints
 
@@ -1041,7 +1061,7 @@ julia> @constraint(model, x - y in MOI.Nonnegatives(2))
 Non-zero constants are not supported in this syntax:
 ```jldoctest set_inequality
 julia> @constraint(model, x >= 1, MOI.Nonnegatives(2))
-ERROR: Operation `sub_mul` between `Vector{VariableRef}` and `Int64` is not allowed. You should use broadcast.
+ERROR: Operation `sub_mul` between `Vector{VariableRef}` and `Int64` is not allowed. This most often happens when you write a constraint like `x >= y` where `x` is an array and `y` is a constant. Use the broadcast syntax `x .- y >= 0` instead.
 Stacktrace:
 [...]
 ```

--- a/docs/src/reference/constraints.md
+++ b/docs/src/reference/constraints.md
@@ -65,6 +65,9 @@ dual_start_value
 ## Special sets
 
 ```@docs
+Nonnegatives
+Nonpositives
+Zeros
 SecondOrderCone
 RotatedSecondOrderCone
 PSDCone

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -107,20 +107,18 @@ struct PSDCone end
 function build_constraint(
     _error::Function,
     f::AbstractMatrix{<:AbstractJuMPScalar},
-    s::MOI.GreaterThan,
+    ::Nonnegatives,
     extra::PSDCone,
 )
-    @assert iszero(s.lower)
     return build_constraint(_error, f, extra)
 end
 
 function build_constraint(
     _error::Function,
     f::AbstractMatrix{<:AbstractJuMPScalar},
-    s::MOI.LessThan,
+    ::Nonpositives,
     extra::PSDCone,
 )
-    @assert iszero(s.upper)
     new_f = _MA.operate!!(*, -1, f)
     return build_constraint(_error, new_f, extra)
 end

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -45,7 +45,7 @@ end
     build_constraint(
         _error::Function,
         f::AbstractVector{<:AbstractJuMPScalar},
-        s::MOI.GreaterThan,
+        ::Nonnegatives,
         extra::Union{MOI.AbstractVectorSet,AbstractVectorSet},
     )
 
@@ -61,10 +61,9 @@ into
 function build_constraint(
     _error::Function,
     f::AbstractVector{<:AbstractJuMPScalar},
-    s::MOI.GreaterThan,
+    ::Nonnegatives,
     extra::Union{MOI.AbstractVectorSet,AbstractVectorSet},
 )
-    @assert iszero(s.lower)
     return build_constraint(_error, f, extra)
 end
 
@@ -72,7 +71,7 @@ end
     build_constraint(
         _error::Function,
         f::AbstractVector{<:AbstractJuMPScalar},
-        s::MOI.LessThan,
+        ::Nonpositives,
         extra::Union{MOI.AbstractVectorSet,AbstractVectorSet},
     )
 
@@ -88,10 +87,9 @@ into
 function build_constraint(
     _error::Function,
     f::AbstractVector{<:AbstractJuMPScalar},
-    s::MOI.LessThan,
+    ::Nonpositives,
     extra::Union{MOI.AbstractVectorSet,AbstractVectorSet},
 )
-    @assert iszero(s.upper)
     new_f = _MA.operate!!(*, -1, f)
     return build_constraint(_error, new_f, extra)
 end
@@ -105,7 +103,9 @@ function _MA.operate!!(
     if !iszero(y)
         error(
             "Operation `sub_mul` between `$(typeof(x))` and `$(typeof(y))` " *
-            "is not allowed. You should use broadcast.",
+            "is not allowed. This most often happens when you write a " *
+            "constraint like `x >= y` where `x` is an array and `y` is a " *
+            "constant. Use the broadcast syntax `x .- y >= 0` instead.",
         )
     end
     return x
@@ -119,8 +119,10 @@ function _MA.operate!!(
 )
     if !iszero(y)
         error(
-            "Operation `sub_mul` between `$(typeof(x))` and `$(typeof(y))` " *
-            "is not allowed. You should use broadcast.",
+            "Operation `sub_mul` between `$(typeof(y))` and `$(typeof(x))` " *
+            "is not allowed. This most often happens when you write a " *
+            "constraint like `x >= y` where `x` is a constant and `y` is an " *
+            "array. Use the broadcast syntax `x .- y >= 0` instead.",
         )
     end
     return _MA.operate!!(*, -1, x)


### PR DESCRIPTION
This change enables `Ax >= b` to be lowered to `Ax - b in Nonnegatives()`, and removes the confusing Vector-in-GreaterThan(0) method in build_constraint that asserted the right-hand side was zero.

Closes #3265 

I'm not sure why it didn't occur to me to do this ages ago.