### PR TITLE
Remove setup blocks for doctests to make copy-pastable

### DIFF
--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -38,22 +38,21 @@ syntax to use depends on the type of constraint you wish to add.
 
 Create linear constraints using the [`@constraint`](@ref) macro:
 ```jldoctest
-model = Model()
-@variable(model, x[1:3])
-@constraint(model, c1, sum(x) <= 1)
-@constraint(model, c2, x[1] + 2 * x[3] >= 2)
-@constraint(model, c3, sum(i * x[i] for i in 1:3) == 3)
-@constraint(model, c4, 4 <= 2 * x[2] <= 5)
-print(model)
+julia> model = Model();
 
-# output
+julia> @variable(model, x[1:3]);
 
-Feasibility
-Subject to
- c3 : x[1] + 2 x[2] + 3 x[3] = 3.0
- c2 : x[1] + 2 x[3] ≥ 2.0
- c1 : x[1] + x[2] + x[3] ≤ 1.0
- c4 : 2 x[2] ∈ [4.0, 5.0]
+julia> @constraint(model, c1, sum(x) <= 1)
+c1 : x[1] + x[2] + x[3] ≤ 1.0
+
+julia> @constraint(model, c2, x[1] + 2 * x[3] >= 2)
+c2 : x[1] + 2 x[3] ≥ 2.0
+
+julia> @constraint(model, c3, sum(i * x[i] for i in 1:3) == 3)
+c3 : x[1] + 2 x[2] + 3 x[3] = 3.0
+
+julia> @constraint(model, c4, 4 <= 2 * x[2] <= 5)
+c4 : 2 x[2] ∈ [4.0, 5.0]
 ```
 
 ### Normalization
@@ -61,7 +60,11 @@ Subject to
 JuMP normalizes constraints by moving all of the terms containing variables to
 the left-hand side and all of the constant terms to the right-hand side. Thus,
 we get:
-```jldoctest; setup=:(model=Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @constraint(model, c, 2x + 1 <= 4x + 4)
 c : -2 x <= 3.0
 ```
@@ -70,7 +73,9 @@ c : -2 x <= 3.0
 
 In addition to affine functions, JuMP also supports constraints with quadratic
 terms. For example:
-```jldoctest con_quadratic; setup=:(model=Model())
+```jldoctest con_quadratic
+julia> model = Model();
+
 julia> @variable(model, x[i=1:2])
 2-element Vector{VariableRef}:
  x[1]
@@ -92,7 +97,9 @@ my_q : x[1]² + x[2]² - t² <= 0.0
 
 You can also add constraints to JuMP using vectorized linear algebra. For
 example:
-```jldoctest con_vector; setup=:(model = Model())
+```jldoctest con_vector
+julia> model = Model();
+
 julia> @variable(model, x[i=1:2])
 2-element Vector{VariableRef}:
  x[1]
@@ -126,7 +133,11 @@ We'll cover some brief syntax here; read the [Constraint containers](@ref)
 section for more details:
 
 Create arrays of constraints:
-```jldoctest; setup=:(model=Model(); @variable(model, x[1:3]))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x[1:3]);
+
 julia> @constraint(model, c[i=1:3], x[i] <= i^2)
 3-element Vector{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}}:
  c[1] : x[1] ≤ 1.0
@@ -138,7 +149,11 @@ c[2] : x[2] ≤ 4.0
 ```
 
 Sets can be any Julia type that supports iteration:
-```jldoctest; setup=:(model=Model(); @variable(model, x[1:3]))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x[1:3]);
+
 julia> @constraint(model, c[i=2:3, ["red", "blue"]], x[i] <= i^2)
 2-dimensional DenseAxisArray{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape},2,...} with index sets:
     Dimension 1, 2:3
@@ -152,7 +167,11 @@ c[2,red] : x[2] ≤ 4.0
 ```
 
 Sets can depend upon previous indices:
-```jldoctest; setup=:(model=Model(); @variable(model, x[1:3]))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x[1:3]);
+
 julia> @constraint(model, c[i=1:3, j=i:3], x[i] <= j)
 JuMP.Containers.SparseAxisArray{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}, 2, Tuple{Int64, Int64}} with 6 entries:
   [1, 1]  =  c[1,1] : x[1] ≤ 1.0
@@ -163,7 +182,11 @@ JuMP.Containers.SparseAxisArray{ConstraintRef{Model, MathOptInterface.Constraint
   [3, 3]  =  c[3,3] : x[3] ≤ 3.0
 ```
 and you can filter elements in the sets using the `;` syntax:
-```jldoctest; setup=:(model=Model(); @variable(model, x[1:9]))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x[1:9]);
+
 julia> @constraint(model, c[i=1:9; mod(i, 3) == 0], x[i] <= i)
 JuMP.Containers.SparseAxisArray{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}, 1, Tuple{Int64}} with 3 entries:
   [3]  =  c[3] : x[3] ≤ 3.0
@@ -234,14 +257,22 @@ A common reason for encountering this error is adding constraints in a loop.
 
 As a work-around, JuMP provides *anonymous* constraints. Create an anonymous
 constraint by omitting the name argument:
-```jldoctest; setup=:(model=Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> c = @constraint(model, 2x <= 1)
 2 x <= 1.0
 ```
 
 Create a container of anonymous constraints by dropping the name in front of
 the `[`:
-```jldoctest; setup=:(model=Model(); @variable(model, x[1:3]))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x[1:3]);
+
 julia> c = @constraint(model, [i = 1:3], x[i] <= i)
 3-element Vector{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}}:
  x[1] ≤ 1.0
@@ -430,7 +461,11 @@ ERROR: UndefVarError: c not defined
 
 If you have many [`@constraint`](@ref) calls, use the [`@constraints`](@ref)
 macro to improve readability:
-```jldoctest; setup=:(model=Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @constraints(model, begin
            2x <= 1
            c, x >= -1
@@ -552,7 +587,11 @@ multiple ways to achieve this goal; we explain three options.
 Use [`set_normalized_rhs`](@ref) to modify the right-hand side (constant)
 term of a linear or quadratic  constraint. Use [`normalized_rhs`](@ref) to query
 the right-hand side term.
-```jldoctest; setup = :(model = Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @constraint(model, con, 2x <= 1)
 con : 2 x <= 1.0
 
@@ -580,7 +619,11 @@ value using the [`fix`](@ref) function. Fixing a variable sets its lower
 and upper bound to the same value. Thus, changes in a constant term can be
 simulated by adding a new variable and fixing it to different values. Here is
 an example:
-```jldoctest; setup = :(model = Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @variable(model, const_term)
 const_term
 
@@ -602,7 +645,11 @@ The third option is to use [`add_to_function_constant`](@ref). The constant
 given is added to the function of a `func`-in-`set` constraint. In the following
 example, adding `2` to the function has the effect of removing `2` to the
 right-hand side:
-```jldoctest con_add; setup = :(model = Model(); @variable(model, x))
+```jldoctest con_add
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @constraint(model, con, 2x <= 1)
 con : 2 x <= 1.0
 
@@ -616,7 +663,11 @@ julia> normalized_rhs(con)
 ```
 
 In the case of interval constraints, the constant is removed from each bound:
-```jldoctest con_add_interval; setup = :(model = Model(); @variable(model, x))
+```jldoctest con_add_interval
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @constraint(model, con, 0 <= 2x + 1 <= 2)
 con : 2 x ∈ [-1.0, 1.0]
 
@@ -634,7 +685,11 @@ To modify the coefficients for a linear term (modifying the coefficient of a
 quadratic term is not supported) in a constraint, use
 [`set_normalized_coefficient`](@ref). To query the current coefficient, use
 [`normalized_coefficient`](@ref).
-```jldoctest; setup = :(model = Model(); @variable(model, x[1:2]))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x[1:2]);
+
 julia> @constraint(model, con, 2x[1] + x[2] <= 1)
 con : 2 x[1] + x[2] ≤ 1.0
 
@@ -680,7 +735,11 @@ con : [2 x, 5 x] ∈ MathOptInterface.Nonnegatives(2)
 Use [`delete`](@ref) to delete a constraint from a model. Use [`is_valid`](@ref)
 to check if a constraint belongs to a model and has not been deleted.
 
-```jldoctest constraints_delete; setup = :(model=Model(); @variable(model, x))
+```jldoctest constraints_delete
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @constraint(model, con, 2x <= 1)
 con : 2 x <= 1.0
 
@@ -735,7 +794,9 @@ Query the starting value for a constraint's primal and dual solution using
 [`start_value`](@ref) and [`dual_start_value`](@ref). If no start value has been
 set, the methods will return `nothing`.
 
-```jldoctest constraint_dual_start; setup=:(model=Model())
+```jldoctest constraint_dual_start
+julia> model = Model();
+
 julia> @variable(model, x)
 x
 
@@ -758,7 +819,9 @@ julia> dual_start_value(con)
 ```
 
 Vector-valued constraints require a vector:
-```jldoctest constraint_dual_start_vector; setup=:(model=Model())
+```jldoctest constraint_dual_start_vector
+julia> model = Model();
+
 julia> @variable(model, x[1:3])
 3-element Vector{VariableRef}:
  x[1]
@@ -799,7 +862,11 @@ following.
 ### [Arrays](@id constraint_arrays)
 
 One way of adding a group of constraints compactly is the following:
-```jldoctest constraint_arrays; setup=:(model=Model(); @variable(model, x))
+```jldoctest constraint_arrays
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @constraint(model, con[i = 1:3], i * x <= i + 1)
 3-element Vector{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}}:
  con[1] : x ≤ 2.0
@@ -842,7 +909,11 @@ of constraints is very similar to the
 [syntax for constructing](@ref variable_jump_arrays) a `DenseAxisArray` of
 variables.
 
-```jldoctest constraint_jumparrays; setup=:(model=Model(); @variable(model, x))
+```jldoctest constraint_jumparrays
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @constraint(model, con[i = 1:2, j = 2:3], i * x <= j + 1)
 2-dimensional DenseAxisArray{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape},2,...} with index sets:
     Dimension 1, Base.OneTo(2)
@@ -859,7 +930,11 @@ The syntax for constructing a
 similar to the [syntax for constructing](@ref variable_sparseaxisarrays) a
 `SparseAxisArray` of variables.
 
-```jldoctest constraint_jumparrays; setup=:(model=Model(); @variable(model, x))
+```jldoctest constraint_jumparrays
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @constraint(model, con[i = 1:2, j = 1:2; i != j], i * x <= j + 1)
 JuMP.Containers.SparseAxisArray{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}, 2, Tuple{Int64, Int64}} with 2 entries:
   [1, 2]  =  con[1,2] : x ≤ 3.0
@@ -883,7 +958,13 @@ keyword. For syntax and the reason behind this, take a look at the
 
 Containers are often used to create constraints over a set of indices. However,
 you'll often have cases in which you are repeating the indices:
-```jldoctest repeated_containers; setup=:(model=Model(); @variable(model, x[1:2]); @variable(model, y[1:2]))
+```jldoctest repeated_containers
+julia> model = Model();
+
+julia> @variable(model, x[1:2]);
+
+julia> @variable(model, y[1:2]);
+
 julia> @constraints(model, begin
            [i=1:2, j=1:2, k=1:2], i * x[j] <= k
            [i=1:2, j=1:2, k=1:2], i * y[j] <= k
@@ -993,7 +1074,11 @@ functions and sets, read [Standard form problem](@ref).
     ```
 
 For example, the following two constraints are equivalent:
-```jldoctest moi; setup=:(model=Model(); @variable(model, x[1:3]))
+```jldoctest moi
+julia> model = Model();
+
+julia> @variable(model, x[1:3]);
+
 julia> @constraint(model, 2 * x[1] <= 1)
 2 x[1] ≤ 1.0
 
@@ -1105,7 +1190,11 @@ Semi-continuous variables are constrained to the set
 ``x \in \{0\} \cup [l, u]``.
 
 Create a semi-continuous variable using the `MOI.Semicontinuous` set:
-```jldoctest; setup = :(model = Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @constraint(model, x in MOI.Semicontinuous(1.5, 3.5))
 x in MathOptInterface.Semicontinuous{Float64}(1.5, 3.5)
 ```
@@ -1114,7 +1203,11 @@ Semi-integer variables  are constrained to the set
 ``x \in \{0\} \cup \{l, l+1, \dots, u\}``.
 
 Create a semi-integer variable using the `MOI.Semiinteger` set:
-```jldoctest; setup = :(model = Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @constraint(model, x in MOI.Semiinteger(1.0, 3.0))
 x in MathOptInterface.Semiinteger{Float64}(1.0, 3.0)
 ```
@@ -1125,7 +1218,9 @@ In a Special Ordered Set of Type 1 (often denoted SOS-I or SOS1), at most one
 element can take a non-zero value.
 
 Construct SOS-I constraints using the [`SOS1`](@ref) set:
-```jldoctest con_sos; setup=:(model = Model())
+```jldoctest con_sos
+julia> model = Model();
+
 julia> @variable(model, x[1:3])
 3-element Vector{VariableRef}:
  x[1]
@@ -1175,7 +1270,9 @@ constraint holds when the binary variable takes the value `1`. The constraint
 may or may not hold when the binary variable takes the value `0`.
 
 To enforce the constraint `x + y <= 1` when the binary variable `a` is `1`, use:
-```jldoctest indicator; setup=:(model = Model())
+```jldoctest indicator
+julia> model = Model();
+
 julia> @variable(model, x)
 x
 
@@ -1199,7 +1296,9 @@ julia> @constraint(model, !a => {x + y <= 1})
 ## Semidefinite constraints
 
 To constrain a matrix to be positive semidefinite (PSD), use [`PSDCone`](@ref):
-```jldoctest con_psd; setup=:(model = Model())
+```jldoctest con_psd
+julia> model = Model();
+
 julia> @variable(model, X[1:2, 1:2])
 2×2 Matrix{VariableRef}:
  X[1,1]  X[1,2]
@@ -1279,7 +1378,9 @@ JuMP supports mixed complementarity constraints via `complements(F(x), x)` or
 obtained from the variable bounds on `x`.
 
 For example, to define the problem `2x - 1 ⟂ x` with `x ∈ [0, ∞)`, do:
-```jldoctest complementarity; setup=:(model=Model())
+```jldoctest complementarity
+julia> model = Model();
+
 julia> @variable(model, x >= 0)
 x
 

--- a/docs/src/manual/containers.md
+++ b/docs/src/manual/containers.md
@@ -384,7 +384,7 @@ julia> Containers.@container([i=1:3, j=1:5], i + j)
  4  5  6  7  8
 ```
 or an instance of `Base.OneTo`:
-```jldoctest; setup=:(model = Model())
+```jldoctest
 julia> set = Base.OneTo(3)
 Base.OneTo(3)
 

--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -289,7 +289,9 @@ and [`Base.write`](@ref).
 For most common file formats, the file type will be detected from the extension.
 
 For example, here is how to write an [MPS file](https://en.wikipedia.org/wiki/MPS_(format)):
-```jldoctest file_formats; setup=:(model = Model())
+```jldoctest file_formats
+julia> model = Model();
+
 julia> write_to_file(model, "model.mps")
 ```
 
@@ -304,7 +306,11 @@ Other supported file formats include:
 
 To write to a specific `io::IO`, use [`Base.write`](@ref). Specify the file type
 by passing a [`MOI.FileFormats.FileFormat`](@ref) enum.
-```jldoctest file_formats; setup=:(model = Model(); io = IOBuffer())
+```jldoctest file_formats
+julia> model = Model();
+
+julia> io = IOBuffer();
+
 julia> write(io, model; format = MOI.FileFormats.FORMAT_MPS)
 ```
 

--- a/docs/src/manual/nlp.md
+++ b/docs/src/manual/nlp.md
@@ -26,7 +26,11 @@ There are three main changes to solve nonlinear programs in JuMP.
 
 Use [`@NLobjective`](@ref) to set a nonlinear objective.
 
-```jldoctest; setup=:(model = Model(); @variable(model, x[1:2]))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x[1:2]);
+
 julia> @NLobjective(model, Min, exp(x[1]) - sqrt(x[2]))
 ```
 To modify a nonlinear objective, call [`@NLobjective`](@ref) again.
@@ -35,7 +39,11 @@ To modify a nonlinear objective, call [`@NLobjective`](@ref) again.
 
 Use [`@NLconstraint`](@ref) to add a nonlinear constraint.
 
-```jldoctest nonlinear_constraint; setup=:(model = Model(); @variable(model, x[1:2]))
+```jldoctest nonlinear_constraint
+julia> model = Model();
+
+julia> @variable(model, x[1:2]);
+
 julia> @NLconstraint(model, exp(x[1]) <= 1)
 exp(x[1]) - 1.0 ≤ 0
 
@@ -65,7 +73,11 @@ Use [`@NLexpression`](@ref) to create nonlinear expression objects. The syntax
 is identical to [`@expression`](@ref), except that the expression can contain
 nonlinear terms.
 
-```jldoctest nl_expression; setup=:(model = Model(); @variable(model, x[1:2]))
+```jldoctest nl_expression
+julia> model = Model();
+
+julia> @variable(model, x[1:2]);
+
 julia> expr = @NLexpression(model, exp(x[1]) + sqrt(x[2]))
 subexpression[1]: exp(x[1]) + sqrt(x[2])
 
@@ -120,7 +132,11 @@ expressions.
 The initial value of the parameter must be provided on the right-hand side of
 the `==` sign.
 
-```jldoctest nonlinear_parameters; setup=:(model = Model(); @variable(model, x))
+```jldoctest nonlinear_parameters
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @NLparameter(model, p[i = 1:2] == i)
 2-element Vector{NonlinearParameter}:
  parameter[1] == 1.0
@@ -213,7 +229,11 @@ For example, if `x` is a JuMP variable, the code `3x` will return an
 constraints. However, the code `sin(x)` is an error. All nonlinear
 expressions must be inside of macros.
 
-```jldoctest; setup=:(model = Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> expr = sin(x) + 1
 ERROR: sin is not defined for type AbstractVariableRef. Are you trying to build a nonlinear problem? Make sure you use @NLconstraint/@NLobjective.
 [...]
@@ -227,7 +247,15 @@ subexpression[1]: sin(x) + 1.0
 Except for the splatting syntax discussed below, all expressions
 must be simple scalar operations. You cannot use `dot`, matrix-vector products,
 vector slices, etc.
-```jldoctest nlp_scalar_only; setup=:(model = Model(); @variable(model, x[1:2]); @variable(model, y); c = [1, 2])
+```jldoctest nlp_scalar_only
+julia> model = Model();
+
+julia> @variable(model, x[1:2]);
+
+julia> @variable(model, y);
+
+julia> c = [1, 2];
+
 julia> @NLobjective(model, Min, c' * x + 3y)
 ERROR: Unexpected array [1 2] in nonlinear expression. Nonlinear expressions may contain only scalar expressions.
 [...]
@@ -631,7 +659,9 @@ or if you experience compilation issues with the macro input (see
 
 Use [`add_nonlinear_expression`](@ref) to add a nonlinear expression to the model.
 
-```jldoctest; setup=:(using JuMP; model = Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, x)
 x
 
@@ -642,7 +672,11 @@ julia> expr_ref = add_nonlinear_expression(model, expr)
 subexpression[1]: x + sin(x ^ 2.0)
 ```
 This is equivalent to
-```jldoctest; setup=:(using JuMP; model = Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> expr_ref = @NLexpression(model, x + sin(x^2))
 subexpression[1]: x + sin(x ^ 2.0)
 ```
@@ -654,14 +688,22 @@ subexpression[1]: x + sin(x ^ 2.0)
 
 Use [`set_nonlinear_objective`](@ref) to set a nonlinear objective.
 
-```jldoctest; setup=:(using JuMP; model = Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> expr = :($(x) + $(x)^2)
 :(x + x ^ 2)
 
 julia> set_nonlinear_objective(model, MIN_SENSE, expr)
 ```
 This is equivalent to
-```jldoctest; setup=:(using JuMP; model = Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @NLobjective(model, Min, x + x^2)
 ```
 
@@ -672,7 +714,11 @@ julia> @NLobjective(model, Min, x + x^2)
 
 Use [`add_nonlinear_constraint`](@ref) to add a nonlinear constraint.
 
-```jldoctest; setup=:(using JuMP; model = Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> expr = :($(x) + $(x)^2)
 :(x + x ^ 2)
 
@@ -681,7 +727,11 @@ julia> add_nonlinear_constraint(model, :($(expr) <= 1))
 ```
 
 This is equivalent to
-```jldoctest; setup=:(using JuMP; model = Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @NLconstraint(model, Min, x + x^2 <= 1)
 (x + x ^ 2.0) - 1.0 ≤ 0
 ```

--- a/docs/src/manual/objective.md
+++ b/docs/src/manual/objective.md
@@ -17,13 +17,21 @@ functions, see [Nonlinear Modeling](@ref).
 Use the [`@objective`](@ref) macro to set a linear objective function.
 
 Use `Min` to create a minimization objective:
-```jldoctest; setup = :(model=Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @objective(model, Min, 2x + 1)
 2 x + 1
 ```
 
 Use `Max` to create a maximization objective:
-```jldoctest; setup = :(model=Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @objective(model, Max, 2x + 1)
 2 x + 1
 ```
@@ -33,13 +41,19 @@ julia> @objective(model, Max, 2x + 1)
 Use the [`@objective`](@ref) macro to set a quadratic objective function.
 
 Use `^2` to have a variable squared:
-```jldoctest; setup = :(model=Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @objective(model, Min, x^2 + 2x + 1)
 x² + 2 x + 1
 ```
 
 You can also have bilinear terms between variables:
-```jldoctest; setup = :(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, x)
 x
 
@@ -53,7 +67,11 @@ x*y + x + y
 ## Query the objective function
 
 Use [`objective_function`](@ref) to return the current objective function.
-```jldoctest; setup = :(model=Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @objective(model, Min, 2x + 1)
 2 x + 1
 
@@ -65,7 +83,9 @@ julia> objective_function(model)
 
 Use [`value`](@ref) to evaluate an objective function at a point specifying values for variables.
 
-```jldoctest; setup = :(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, x[1:2]);
 
 julia> @objective(model, Min, 2x[1]^2 + x[1] + 0.5*x[2])
@@ -83,7 +103,11 @@ julia> value(z -> point[z], f)
 ## Query the objective sense
 
 Use [`objective_sense`](@ref) to return the current objective sense.
-```jldoctest; setup = :(model=Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @objective(model, Min, 2x + 1)
 2 x + 1
 
@@ -95,7 +119,11 @@ MIN_SENSE::OptimizationSense = 0
 
 To modify an objective, call [`@objective`](@ref) with the new objective
 function.
-```jldoctest; setup = :(model=Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @objective(model, Min, 2x)
 2 x
 
@@ -105,7 +133,11 @@ julia> @objective(model, Max, -2x)
 
 Alternatively, use [`set_objective_function`](@ref).
 
-```jldoctest; setup = :(model=Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @objective(model, Min, 2x)
 2 x
 
@@ -118,7 +150,11 @@ julia> set_objective_function(model, new_objective)
 ## Modify an objective coefficient
 
 Use [`set_objective_coefficient`](@ref) to modify an objective coefficient.
-```jldoctest; setup = :(model=Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @objective(model, Min, 2x)
 2 x
 
@@ -135,7 +171,11 @@ julia> objective_function(model)
 ## Modify the objective sense
 
 Use [`set_objective_sense`](@ref) to modify the objective sense.
-```jldoctest; setup = :(model=Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @objective(model, Min, 2x)
 2 x
 
@@ -150,7 +190,11 @@ MAX_SENSE::OptimizationSense = 1
 
 Alternatively, call [`@objective`](@ref) and pass the existing objective
 function.
-```jldoctest; setup = :(model=Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @objective(model, Min, 2x)
 2 x
 
@@ -162,7 +206,9 @@ julia> @objective(model, Max, objective_function(model))
 
 Define a multi-objective optimization problem by passing a vector of objectives:
 
-```jldoctest; setup = :(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, x[1:2]);
 
 julia> @objective(model, Min, [1 + x[1], 2 * x[2]])
@@ -188,7 +234,9 @@ Note that you must set a single objective sense, that is, you cannot have
 both minimization and maximization objectives. Work around this limitation by
 choosing `Min` and negating any objectives you want to maximize:
 
-```jldoctest; setup = :(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, x[1:2]);
 
 julia> @expression(model, obj1, 1 + x[1])
@@ -207,7 +255,9 @@ Defining your objectives as expressions allows flexibility in how you can solve
 variations of the same problem, with some objectives removed and constrained to
 be no worse that a fixed value.
 
-```jldoctest; setup = :(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, x[1:2]);
 
 julia> @expression(model, obj1, 1 + x[1])

--- a/docs/src/manual/variables.md
+++ b/docs/src/manual/variables.md
@@ -79,7 +79,9 @@ variables. We'll cover some brief syntax here; read the [Variable containers](@r
 section for more details.
 
 You can create arrays of JuMP variables:
-```jldoctest; setup=:(model = Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, x[1:2, 1:2])
 2×2 Matrix{VariableRef}:
  x[1,1]  x[1,2]
@@ -90,7 +92,9 @@ x[1,2]
 ```
 
 Index sets can be named, and bounds can depend on those names:
-```jldoctest; setup=:(model = Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, sqrt(i) <= x[i = 1:3] <= i^2)
 3-element Vector{VariableRef}:
  x[1]
@@ -102,7 +106,9 @@ x[2]
 ```
 
 Sets can be any Julia type that supports iteration:
-```jldoctest; setup=:(model = Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, x[i = 2:3, j = 1:2:3, ["red", "blue"]] >= 0)
 3-dimensional DenseAxisArray{VariableRef,3,...} with index sets:
     Dimension 1, 2:3
@@ -122,7 +128,9 @@ x[2,1,red]
 ```
 
 Sets can depend upon previous indices:
-```jldoctest; setup=:(model = Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, u[i = 1:2, j = i:3])
 JuMP.Containers.SparseAxisArray{VariableRef, 2, Tuple{Int64, Int64}} with 5 entries:
   [1, 1]  =  u[1,1]
@@ -132,7 +140,9 @@ JuMP.Containers.SparseAxisArray{VariableRef, 2, Tuple{Int64, Int64}} with 5 entr
   [2, 3]  =  u[2,3]
 ```
 and we can filter elements in the sets using the `;` syntax:
-```jldoctest; setup=:(model = Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, v[i = 1:9; mod(i, 3) == 0])
 JuMP.Containers.SparseAxisArray{VariableRef, 1, Tuple{Int64}} with 3 entries:
   [3]  =  v[3]
@@ -215,7 +225,9 @@ A common reason for encountering this error is adding variables in a loop.
 
 As a work-around, JuMP provides *anonymous* variables. Create a scalar valued
 anonymous variable by omitting the name argument:
-```jldoctest; setup=:(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> x = @variable(model)
 _[1]
 ```
@@ -228,7 +240,9 @@ the variable.
 
 Create a container of anonymous JuMP variables by dropping the name in front of
 the `[`:
-```jldoctest; setup=:(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> y = @variable(model, [1:2])
 2-element Vector{VariableRef}:
  _[1]
@@ -238,7 +252,9 @@ julia> y = @variable(model, [1:2])
 The `<=` and `>=` short-hand cannot be used to set bounds on scalar-valued
 anonymous JuMP variables. Instead, use the `lower_bound` and `upper_bound`
 keywords:
-```jldoctest; setup=:(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> x_lower = @variable(model, lower_bound = 1.0)
 _[1]
 
@@ -506,7 +522,9 @@ julia> fix_value(x)
 Binary variables are constrained to the set ``x \in \{0, 1\}``.
 
 Create a binary variable by passing `Bin` as an optional positional argument:
-```jldoctest variables_binary; setup=:(model=Model())
+```jldoctest variables_binary
+julia> model = Model();
+
 julia> @variable(model, x, Bin)
 x
 ```
@@ -525,12 +543,16 @@ false
 ```
 
 Binary variables can also be created by setting the `binary` keyword to `true`:
-```jldoctest; setup=:(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, x, binary=true)
 x
 ```
 or by using [`set_binary`](@ref):
-```jldoctest; setup=:(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, x)
 x
 
@@ -542,7 +564,9 @@ julia> set_binary(x)
 Integer variables are constrained to the set ``x \in \mathbb{Z}``.
 
 Create an integer variable by passing `Int` as an optional positional argument:
-```jldoctest variables_integer; setup=:(model=Model())
+```jldoctest variables_integer
+julia> model = Model();
+
 julia> @variable(model, x, Int)
 x
 ```
@@ -562,12 +586,16 @@ false
 
 Integer variables can also be created by setting the `integer` keyword to
 `true`:
-```jldoctest; setup=:(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, x, integer=true)
 x
 ```
 or by using [`set_integer`](@ref):
-```jldoctest; setup=:(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, x)
 x
 
@@ -590,7 +618,9 @@ or a warmstart) for each variable:
 The starting value of a variable can be queried using [`start_value`](@ref). If
 no start value has been set, [`start_value`](@ref) will return `nothing`.
 
-```jldoctest variables_start; setup=:(model=Model())
+```jldoctest variables_start
+julia> model = Model();
+
 julia> @variable(model, x)
 x
 
@@ -610,7 +640,9 @@ julia> start_value(y)
 
 The `start` keyword argument can depend on the indices of a variable container:
 
-```jldoctest; setup=:(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, z[i = 1:2], start = i^2)
 2-element Vector{VariableRef}:
  z[1]
@@ -643,7 +675,9 @@ julia> start_value.(z)
 Use [`delete`](@ref) to delete a variable from a model. Use [`is_valid`](@ref)
 to check if a variable belongs to a model and has not been deleted.
 
-```jldoctest variables_delete; setup=:(model=Model())
+```jldoctest variables_delete
+julia> model = Model();
+
 julia> @variable(model, x)
 x
 
@@ -704,7 +738,9 @@ explain each of these in the following.
 We have already seen the creation of an array of JuMP variables with the
 `x[1:2]` syntax. This can be extended to create multi-dimensional
 arrays of JuMP variables. For example:
-```jldoctest variables_arrays; setup=:(model=Model())
+```jldoctest variables_arrays
+julia> model = Model();
+
 julia> @variable(model, x[1:2, 1:2])
 2×2 Matrix{VariableRef}:
  x[1,1]  x[1,2]
@@ -723,7 +759,9 @@ julia> x[2, :]
 ```
 
 Variable bounds can depend upon the indices:
-```jldoctest; setup=:(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, x[i=1:2, j=1:2] >= 2i + j)
 2×2 Matrix{VariableRef}:
  x[1,1]  x[1,2]
@@ -749,7 +787,9 @@ product or a location. The syntax is the same as that above, except with an
 arbitrary vector as an index as opposed to a one-based range. The biggest
 difference is that instead of returning an `Array` of JuMP variables, JuMP will
 return a `DenseAxisArray`. For example:
-```jldoctest variables_jump_arrays; setup=:(model=Model())
+```jldoctest variables_jump_arrays
+julia> model = Model();
+
 julia> @variable(model, x[1:2, [:A,:B]])
 2-dimensional DenseAxisArray{VariableRef,2,...} with index sets:
     Dimension 1, Base.OneTo(2)
@@ -773,7 +813,9 @@ And data, a 2-element Vector{VariableRef}:
 ```
 
 Bounds can depend upon indices:
-```jldoctest; setup=:(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, x[i=2:3, j=1:2:3] >= 0.5i + j)
 2-dimensional DenseAxisArray{VariableRef,2,...} with index sets:
     Dimension 1, 2:3
@@ -797,7 +839,9 @@ The third container type that JuMP natively supports is `SparseAxisArray`.
 These arrays are created when the indices do not form a rectangular set.
 For example, this applies when indices have a dependence upon previous
 indices (called *triangular indexing*). JuMP supports this as follows:
-```jldoctest; setup=:(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, x[i=1:2, j=i:2])
 JuMP.Containers.SparseAxisArray{VariableRef, 2, Tuple{Int64, Int64}} with 3 entries:
   [1, 1]  =  x[1,1]
@@ -808,7 +852,9 @@ JuMP.Containers.SparseAxisArray{VariableRef, 2, Tuple{Int64, Int64}} with 3 entr
 We can also conditionally create variables via a JuMP-specific syntax. This
 syntax appends a comparison check that depends upon the named indices and is
 separated from the indices by a semi-colon (`;`). For example:
-```jldoctest; setup=:(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, x[i=1:4; mod(i, 2)==0])
 JuMP.Containers.SparseAxisArray{VariableRef, 1, Tuple{Int64}} with 2 entries:
   [2]  =  x[2]
@@ -822,7 +868,9 @@ evaluates the conditional for each combination. If there are many index
 dimensions and a large amount of sparsity, this can be inefficient.
 
 For example:
-```jldoctest; setup=:(model=Model()), filter=r"[0-9\.]+ seconds.+"
+```jldoctest; filter=r"[0-9\.]+ seconds.+"
+julia> model = Model();
+
 julia> N = 10
 10
 
@@ -869,7 +917,9 @@ tightest container type that can store the JuMP variables. Thus, it will prefer
 to create an Array before a DenseAxisArray and a DenseAxisArray before a
 SparseAxisArray. However, because this happens at compile time, JuMP does not
 always make the best choice. To illustrate this, consider the following example:
-```jldoctest variable_force_container; setup=:(model=Model())
+```jldoctest variable_force_container
+julia> model = Model();
+
 julia> A = 1:2
 1:2
 
@@ -907,7 +957,9 @@ of JuMP variables.
 
 For example, the following code creates a dictionary with symmetric matrices as
 the values:
-```jldoctest; setup=:(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> variables = Dict{Symbol,Array{VariableRef,2}}(
            key => @variable(model, [1:2, 1:2], Symmetric, base_name = "$(key)")
            for key in [:A, :B]
@@ -948,7 +1000,9 @@ model[:x]
 Declare a square matrix of JuMP variables to be positive semidefinite by passing
 `PSD` as an optional positional argument:
 
-```jldoctest; setup=:(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, x[1:2, 1:2], PSD)
 2×2 LinearAlgebra.Symmetric{VariableRef, Matrix{VariableRef}}:
  x[1,1]  x[1,2]
@@ -968,7 +1022,9 @@ Declare a square matrix of JuMP variables to be symmetric (but not necessarily
 positive semidefinite) by passing `Symmetric`  as an optional positional
 argument:
 
-```jldoctest; setup=:(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, x[1:2, 1:2], Symmetric)
 2×2 LinearAlgebra.Symmetric{VariableRef, Matrix{VariableRef}}:
  x[1,1]  x[1,2]
@@ -979,7 +1035,9 @@ julia> @variable(model, x[1:2, 1:2], Symmetric)
 
 If you have many [`@variable`](@ref) calls, JuMP provides the macro
 [`@variables`](@ref) that can improve readability:
-```jldoctest; setup=:(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variables(model, begin
            x
            y[i=1:2] >= i, (start = i, base_name = "Y_$i")
@@ -1024,7 +1082,9 @@ constraining variables on creation.
 
 For example, the following creates a vector of variables that belong to the
 [`SecondOrderCone`](@ref):
-```jldoctest constrained_variables; setup=:(model=Model())
+```jldoctest constrained_variables
+julia> model = Model();
+
 julia> @variable(model, y[1:3] in SecondOrderCone())
 3-element Vector{VariableRef}:
  y[1]
@@ -1058,7 +1118,9 @@ x = @variable(model, [1:3], set = SecondOrderCone())
 
 An alternative to the syntax in [Semidefinite variables](@ref), declare a matrix
 of JuMP variables to be positive semidefinite using [`PSDCone`](@ref):
-```jldoctest; setup=:(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, x[1:2, 1:2] in PSDCone())
 2×2 LinearAlgebra.Symmetric{VariableRef, Matrix{VariableRef}}:
  x[1,1]  x[1,2]
@@ -1069,7 +1131,9 @@ julia> @variable(model, x[1:2, 1:2] in PSDCone())
 
 As an alternative to the syntax in [Symmetric variables](@ref), declare a matrix
 of JuMP variables to be symmetric using [`SymmetricMatrixSpace`](@ref):
-```jldoctest; setup=:(model=Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, x[1:2, 1:2] in SymmetricMatrixSpace())
 2×2 LinearAlgebra.Symmetric{VariableRef, Matrix{VariableRef}}:
  x[1,1]  x[1,2]
@@ -1080,7 +1144,9 @@ julia> @variable(model, x[1:2, 1:2] in SymmetricMatrixSpace())
 
 Declare a matrix of JuMP variables to be skew-symmetric using
 [`SkewSymmetricMatrixSpace`](@ref):
-```jldoctest skewsymmetric; setup=:(model=Model())
+```jldoctest skewsymmetric
+julia> model = Model();
+
 julia> @variable(model, x[1:2, 1:2] in SkewSymmetricMatrixSpace())
 2×2 Matrix{AffExpr}:
  0        x[1,2]

--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -186,8 +186,8 @@ and the given axes. Exactly `N` axes must be provided, and their lengths must
 match `size(data)` in the corresponding dimensions.
 
 # Example
-```jldoctest; setup=:(using JuMP)
-julia> array = JuMP.Containers.DenseAxisArray([1 2; 3 4], [:a, :b], 2:3)
+```jldoctest
+julia> array = Containers.DenseAxisArray([1 2; 3 4], [:a, :b], 2:3)
 2-dimensional DenseAxisArray{Int64,2,...} with index sets:
     Dimension 1, Symbol[:a, :b]
     Dimension 2, 2:3
@@ -217,8 +217,8 @@ Construct an uninitialized DenseAxisArray with element-type `T` indexed over the
 given axes.
 
 # Example
-```jldoctest; setup=:(using JuMP)
-julia> array = JuMP.Containers.DenseAxisArray{Float64}(undef, [:a, :b], 1:2);
+```jldoctest
+julia> array = Containers.DenseAxisArray{Float64}(undef, [:a, :b], 1:2);
 
 julia> fill!(array, 1.0)
 2-dimensional DenseAxisArray{Float64,2,...} with index sets:

--- a/src/Containers/SparseAxisArray.jl
+++ b/src/Containers/SparseAxisArray.jl
@@ -18,14 +18,14 @@ structure than `sa` even if `f(zero(T))` is not zero.
 
 ## Examples
 
-```jldoctest; setup=:(using JuMP)
+```jldoctest
 julia> dict = Dict((:a, 2) => 1.0, (:a, 3) => 2.0, (:b, 3) => 3.0)
 Dict{Tuple{Symbol,Int64},Float64} with 3 entries:
   (:b, 3) => 3.0
   (:a, 2) => 1.0
   (:a, 3) => 2.0
 
-julia> array = JuMP.Containers.SparseAxisArray(dict)
+julia> array = Containers.SparseAxisArray(dict)
 JuMP.Containers.SparseAxisArray{Float64,2,Tuple{Symbol,Int64}} with 3 entries:
   [b, 3]  =  3.0
   [a, 2]  =  1.0

--- a/src/Containers/container.jl
+++ b/src/Containers/container.jl
@@ -34,7 +34,7 @@ Create a container with indices `indices` and values at given indices given by
 
 ## Examples
 
-```@jldoctest; setup=:(using JuMP)
+```jldoctest
 julia> Containers.container((i, j) -> i + j, Containers.vectorized_product(Base.OneTo(3), Base.OneTo(3)))
 3×3 Array{Int64,2}:
  2  3  4

--- a/src/Containers/macro.jl
+++ b/src/Containers/macro.jl
@@ -268,7 +268,7 @@ in conjunction with [`build_ref_sets`](@ref).
 
 ## Examples
 
-```jldoctest; setup=:(using JuMP)
+```jldoctest
 julia> macro foo(ref_sets, code)
            index_vars, indices = Containers.build_ref_sets(error, ref_sets)
            return Containers.container_code(
@@ -351,7 +351,7 @@ The type of container can be controlled by the `container` keyword.
 
 ## Examples
 
-```jldoctest; setup=:(using JuMP)
+```jldoctest
 julia> Containers.@container([i = 1:3, j = 1:3], i + j)
 3×3 Array{Int64,2}:
  2  3  4

--- a/src/Containers/tables.jl
+++ b/src/Containers/tables.jl
@@ -28,7 +28,7 @@ If `header` is left empty, then the default header is `[:x1, :x2, ..., :xN, :y]`
 
 ## Example
 
-```jldoctest; setup=:(using JuMP)
+```jldoctest
 julia> model = Model();
 
 julia> @variable(model, x[i=1:2, j=i:2] >= 0, start = i+j);

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -594,7 +594,9 @@ See also: [`object_dictionary`](@ref).
 
 ## Examples
 
-```jldoctest; setup=:(model = Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, x)
 x
 

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -137,7 +137,11 @@ Create a [`GenericAffExpr`](@ref) by passing a constant and a vector of pairs.
 
 ## Examples
 
-```jldoctest; setup=:(using JuMP; model = Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> GenericAffExpr(1.0, [x => 1.0])
 x + 1
 """
@@ -153,7 +157,11 @@ arguments.
 
 ## Examples
 
-```jldoctest; setup=:(using JuMP; model = Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> GenericAffExpr(1.0, x => 1.0)
 x + 1
 """
@@ -267,7 +275,11 @@ See also: [`map_coefficients`](@ref)
 
 ## Example
 
-```jldoctest; setup=:(using JuMP; model = Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> a = GenericAffExpr(1.0, x => 1.0)
 x + 1
 
@@ -297,7 +309,11 @@ See also: [`map_coefficients_inplace!`](@ref)
 
 ## Example
 
-```jldoctest; setup=:(using JuMP; model = Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> a = GenericAffExpr(1.0, x => 1.0)
 x + 1
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -285,16 +285,8 @@ know the type of the function and set since its returned type can be inferred
 while for the method above (i.e. without `F` and `S`), the exact return type of
 the constraint index cannot be inferred.
 
-```jldoctest objective_function; setup = :(using JuMP), filter = r"Stacktrace:.*"s
-julia> using JuMP
-
-julia> model = Model()
-A JuMP Model
-Feasibility problem with:
-Variables: 0
-Model mode: AUTOMATIC
-CachingOptimizer state: NO_OPTIMIZER
-Solver name: No optimizer attached.
+```jldoctest objective_function; filter = r"Stacktrace:.*"s
+julia> model = Model();
 
 julia> @variable(model, x)
 x
@@ -697,16 +689,19 @@ Note that prior to this step, JuMP will aggregate multiple terms containing the
 same variable. For example, given a constraint `2x + 3x <= 2`,
 `set_normalized_coefficient(con, x, 4)` will create the constraint `4x <= 2`.
 
-```jldoctest; setup = :(using JuMP), filter=r"≤|<="
-model = Model()
-@variable(model, x)
-@constraint(model, con, 2x + 3x <= 2)
-set_normalized_coefficient(con, x, 4)
-con
+```jldoctest; filter=r"≤|<="
+julia> model = Model();
 
-# output
+julia> @variable(model, x)
+x
 
-con : 4 x <= 2.0
+julia> @constraint(model, con, 2x + 3x <= 2)
+con : 5 x ≤ 2.0
+
+julia> set_normalized_coefficient(con, x, 4)
+
+julia> con
+con : 4 x ≤ 2.0
 ```
 """
 function set_normalized_coefficient(
@@ -742,15 +737,18 @@ maps the row to a new coefficient.
 Note that prior to this step, during constraint creation, JuMP will aggregate
 multiple terms containing the same variable.
 
-```jldoctest; setup = :(using JuMP), filter=r"≤|<="
-model = Model()
-@variable(model, x)
-@constraint(model, con, [2x + 3x, 4x] in MOI.Nonnegatives(2))
-set_normalized_coefficients(con, x, [(1, 2.0), (2, 5.0)])
-con
+```jldoctest; filter=r"≤|<="
+julia> model = Model();
 
-# output
+julia> @variable(model, x)
+x
 
+julia> @constraint(model, con, [2x + 3x, 4x] in MOI.Nonnegatives(2))
+con : [5 x, 4 x] ∈ MathOptInterface.Nonnegatives(2)
+
+julia> set_normalized_coefficients(con, x, [(1, 2.0), (2, 5.0)])
+
+julia> con
 con : [2 x, 5 x] ∈ MathOptInterface.Nonnegatives(2)
 ```
 """
@@ -798,7 +796,11 @@ right-hand side of the constraint. For example, given a constraint `2x + 1 <=
 2`, `set_normalized_rhs(con, 4)` will create the constraint `2x <= 4`, not `2x +
 1 <= 4`.
 
-```jldoctest; setup = :(using JuMP; model = Model(); @variable(model, x)), filter=r"≤|<="
+```jldoctest; filter=r"≤|<="
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @constraint(model, con, 2x + 1 <= 2)
 con : 2 x <= 1.0
 
@@ -886,7 +888,11 @@ will be translated by `-value`. For example, given a constraint `2x <=
 ## Examples
 
 For scalar constraints, the set is translated by `-value`:
-```jldoctest; setup = :(using JuMP; model = Model(); @variable(model, x)), filter=r"≤|<="
+```jldoctest; filter=r"≤|<="
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> @constraint(model, con, 0 <= 2x - 1 <= 2)
 con : 2 x ∈ [1.0, 3.0]
 
@@ -897,7 +903,13 @@ con : 2 x ∈ [-3.0, -1.0]
 ```
 
 For vector constraints, the constant is added to the function:
-```jldoctest; setup = :(using JuMP; model = Model(); @variable(model, x); @variable(model, y)), filter=r"≤|<="
+```jldoctest; filter=r"≤|<="
+julia> model = Model();
+
+julia> @variable(model, x);
+
+julia> @variable(model, y);
+
 julia> @constraint(model, con, [x + y, x, y] in SecondOrderCone())
 con : [x + y, x, y] ∈ MathOptInterface.SecondOrderCone(3)
 
@@ -1180,7 +1192,7 @@ has type `function_type` and the set has type `set_type`.
 See also [`list_of_constraint_types`](@ref) and [`all_constraints`](@ref).
 
 # Example
-```jldoctest; setup=:(using JuMP)
+```jldoctest
 julia> model = Model();
 
 julia> @variable(model, x >= 0, Bin);
@@ -1227,7 +1239,7 @@ ordered by creation time.
 See also [`list_of_constraint_types`](@ref) and [`num_constraints`](@ref).
 
 # Example
-```jldoctest; setup=:(using JuMP)
+```jldoctest
 julia> model = Model();
 
 julia> @variable(model, x >= 0, Bin);
@@ -1286,7 +1298,7 @@ and `S` is an MOI set type such that `all_constraints(model, F, S)` returns
 a nonempty list.
 
 # Example
-```jldoctest; setup=:(using JuMP)
+```jldoctest
 julia> model = Model();
 
 julia> @variable(model, x >= 0, Bin);
@@ -1327,7 +1339,7 @@ program), pass `count_variable_in_set_constraints = false`.
 
 ## Examples
 
-```jldoctest; setup=:(using JuMP)
+```jldoctest
 julia> model = Model();
 
 julia> @variable(model, x >= 0, Int);
@@ -1366,7 +1378,7 @@ constraints (e.g., the rows in the constraint matrix of a linear program), pass
 
 ## Examples
 
-```jldoctest; setup=:(using JuMP)
+```jldoctest
 julia> model = Model();
 
 julia> @variable(model, x >= 0, Int);

--- a/src/feasibility_checker.jl
+++ b/src/feasibility_checker.jl
@@ -39,7 +39,7 @@ Euclidean distance in the corresponding set.
 
 ## Examples
 
-```jldoctest; setup=:(using JuMP)
+```jldoctest
 julia> model = Model();
 
 julia> @variable(model, 0.5 <= x <= 1);
@@ -84,7 +84,7 @@ argument instead of a dictionary as the second argument.
 
 ## Examples
 
-```jldoctest; setup=:(using JuMP)
+```jldoctest
 julia> model = Model();
 
 julia> @variable(model, 0.5 <= x <= 1);

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -16,7 +16,7 @@ of a macro with [`Containers._extract_kw_args`](@ref).
 
 ## Examples
 
-```jldoctest; setup = :(using JuMP)
+```jldoctest
 julia> call = :(f(1, a=2))
 :(f(1, a=2))
 
@@ -44,7 +44,7 @@ additional positional arguments to `call`s that already have keyword arguments.
 
 ## Examples
 
-```jldoctest; setup = :(using JuMP)
+```jldoctest
 julia> call = :(f(1, a=2))
 :(f(1, a = 2))
 
@@ -163,7 +163,7 @@ Converts a sense symbol to a set `set` such that
 ## Example
 
 Once a custom set is defined you can directly create a JuMP constraint with it:
-```jldoctest operator_to_set; setup = :(using JuMP)
+```jldoctest operator_to_set
 julia> struct CustomSet{T} <: MOI.AbstractScalarSet
            value::T
        end
@@ -938,13 +938,13 @@ create arrays of `ScalarConstraint` or `VectorConstraint`.
 
 ## Examples
 
-```jldoctest; setup = :(using JuMP)
-model = Model();
-@variable(model, x);
-@build_constraint(2x >= 1)
+```jldoctest
+julia> model = Model();
 
-# output
-ScalarConstraint{GenericAffExpr{Float64,VariableRef},MathOptInterface.GreaterThan{Float64}}(2 x, MathOptInterface.GreaterThan{Float64}(1.0))
+julia> @variable(model, x);
+
+julia> @build_constraint(2x >= 1)
+ScalarConstraint{AffExpr, MathOptInterface.GreaterThan{Float64}}(2 x, MathOptInterface.GreaterThan{Float64}(1.0))
 ```
 """
 macro build_constraint(constraint_expr)
@@ -1106,7 +1106,7 @@ multiple lines wrapped in a `begin ... end` block.
 
 The macro returns a tuple containing the expressions that were defined.
 
-# Examples
+## Example
 
 ```julia
 @expressions(model, begin
@@ -1128,16 +1128,17 @@ be placed on separate lines as in the following example.
 
 The macro returns a tuple containing the parameters that were defined.
 
-# Example
-```jldoctest; setup=:(using JuMP)
-model = Model()
-@NLparameters(model, begin
-    x == 10
-    b == 156
-end)
-value(x)
+## Example
 
-# output
+```jldoctest
+julia> model = Model();
+
+julia> @NLparameters(model, begin
+           x == 10
+           b == 156
+       end);
+
+julia> value(x)
 10.0
 ```
  """ :(@NLparameters)
@@ -1245,14 +1246,8 @@ expression of JuMP variables.
 ## Examples
 
 To minimize the value of the variable `x`, do as follows:
-```jldoctest @objective; setup = :(using JuMP)
-julia> model = Model()
-A JuMP Model
-Feasibility problem with:
-Variables: 0
-Model mode: AUTOMATIC
-CachingOptimizer state: NO_OPTIMIZER
-Solver name: No optimizer attached.
+```jldoctest @objective
+julia> model = Model();
 
 julia> @variable(model, x)
 x
@@ -2533,12 +2528,13 @@ with initial value set to `value`. Nonlinear parameters may be used only in
 nonlinear expressions.
 
 # Example
-```jldoctest; setup=:(using JuMP)
-model = Model()
-@NLparameter(model, x == 10)
-value(x)
+```jldoctest
+julia> model = Model();
 
-# output
+julia> @NLparameter(model, x == 10)
+x == 10.0
+
+julia> value(x)
 10.0
 ```
 
@@ -2550,12 +2546,13 @@ used only in nonlinear expressions.
 
 ## Example
 
-```jldoctest; setup=:(using JuMP)
-model = Model()
-x = @NLparameter(model, value = 10)
-value(x)
+```jldoctest
+julia> model = Model();
 
-# output
+julia> x = @NLparameter(model, value = 10)
+parameter[1] == 10.0
+
+julia> value(x)
 10.0
 ```
 
@@ -2568,13 +2565,17 @@ Uses the same syntax for specifying index sets as [`@variable`](@ref).
 
 ## Example
 
-```jldoctest; setup=:(using JuMP)
-model = Model()
-@NLparameter(model, y[i = 1:10] == 2 * i)
-value(y[9])
+```jldoctest
+julia> model = Model();
 
-# output
-18.0
+julia> @NLparameter(model, y[i = 1:3] == 2 * i)
+3-element Vector{NonlinearParameter}:
+ parameter[1] == 2.0
+ parameter[2] == 4.0
+ parameter[3] == 6.0
+
+julia> value(y[2])
+4.0
 ```
 
     @NLparameter(model, [...] == value_expr)
@@ -2585,13 +2586,17 @@ sets). Uses the same syntax for specifying index sets as [`@variable`](@ref).
 
 ## Example
 
-```jldoctest; setup=:(using JuMP)
-model = Model()
-y = @NLparameter(model, [i = 1:10] == 2 * i)
-value(y[9])
+```jldoctest
+julia> model = Model();
 
-# output
-18.0
+julia> y = @NLparameter(model, [i = 1:3] == 2 * i)
+3-element Vector{NonlinearParameter}:
+ parameter[1] == 2.0
+ parameter[2] == 4.0
+ parameter[3] == 6.0
+
+julia> value(y[2])
+4.0
 ```
 """
 macro NLparameter(model, args...)

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -153,7 +153,11 @@ programmatically, and you cannot use [`@NLobjective`](@ref).
 
 ## Examples
 
-```jldoctest; setup=:(using JuMP; model = Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> set_nonlinear_objective(model, MIN_SENSE, :(\$(x) + \$(x)^2))
 ```
 """
@@ -223,12 +227,13 @@ Return the current value stored in the nonlinear parameter `p`.
 
 # Example
 
-```jldoctest; setup=:(using JuMP)
-model = Model()
-@NLparameter(model, p == 10)
-value(p)
+```jldoctest
+julia> model = Model();
 
-# output
+julia> @NLparameter(model, p == 10)
+p == 10.0
+
+julia> value(p)
 10.0
 ```
 """
@@ -242,13 +247,16 @@ end
 Store the value `v` in the nonlinear parameter `p`.
 
 # Example
-```jldoctest; setup=:(using JuMP)
-model = Model()
-@NLparameter(model, p == 0)
-set_value(p, 5)
-value(p)
+```jldoctest
+julia> model = Model();
 
-# output
+julia> @NLparameter(model, p == 0)
+p == 0.0
+
+julia> set_value(p, 5)
+5
+
+julia> value(p)
 5.0
 ```
 """
@@ -304,7 +312,11 @@ programmatically, and you cannot use [`@NLexpression`](@ref).
 
 ## Examples
 
-```jldoctest; setup=:(using JuMP; model = Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> add_nonlinear_expression(model, :(\$(x) + \$(x)^2))
 subexpression[1]: x + x ^ 2.0
 ```
@@ -430,7 +442,11 @@ programmatically, and you cannot use [`@NLconstraint`](@ref).
 
 ## Examples
 
-```jldoctest; setup=:(using JuMP; model = Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> add_nonlinear_constraint(model, :(\$(x) + \$(x)^2 <= 1))
 (x + x ^ 2.0) - 1.0 ≤ 0
 ```
@@ -647,20 +663,34 @@ that the inputs are `Float64`.
 
 ## Examples
 
-```jldoctest; setup=:(using JuMP)
-model = Model()
-@variable(model, x)
-f(x::T) where {T<:Real} = x^2
-register(model, :foo, 1, f; autodiff = true)
-@NLobjective(model, Min, foo(x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x)
+x
+
+julia> f(x::T) where {T<:Real} = x^2
+f (generic function with 1 method)
+
+julia> register(model, :foo, 1, f; autodiff = true)
+
+julia> @NLobjective(model, Min, foo(x))
 ```
 
-```jldoctest; setup=:(using JuMP)
-model = Model()
-@variable(model, x[1:2])
-g(x::T, y::T) where {T<:Real} = x * y
-register(model, :g, 2, g; autodiff = true)
-@NLobjective(model, Min, g(x[1], x[2]))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x[1:2])
+2-element Vector{VariableRef}:
+ x[1]
+ x[2]
+
+julia> g(x::T, y::T) where {T<:Real} = x * y
+g (generic function with 1 method)
+
+julia> register(model, :g, 2, g; autodiff = true)
+
+julia> @NLobjective(model, Min, g(x[1], x[2]))
 ```
 """
 function register(
@@ -709,26 +739,44 @@ not assume that the inputs are `Float64`.
 
 ## Examples
 
-```jldoctest; setup=:(using JuMP)
-model = Model()
-@variable(model, x)
-f(x::T) where {T<:Real} = x^2
-∇f(x::T) where {T<:Real} = 2 * x
-register(model, :foo, 1, f, ∇f; autodiff = true)
-@NLobjective(model, Min, foo(x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x)
+x
+
+julia> f(x::T) where {T<:Real} = x^2
+f (generic function with 1 method)
+
+julia> ∇f(x::T) where {T<:Real} = 2 * x
+∇f (generic function with 1 method)
+
+julia> register(model, :foo, 1, f, ∇f; autodiff = true)
+
+julia> @NLobjective(model, Min, foo(x))
 ```
 
-```jldoctest; setup=:(using JuMP)
-model = Model()
-@variable(model, x[1:2])
-g(x::T, y::T) where {T<:Real} = x * y
-function ∇g(g::AbstractVector{T}, x::T, y::T) where {T<:Real}
-    g[1] = y
-    g[2] = x
-    return
-end
-register(model, :g, 2, g, ∇g; autodiff = true)
-@NLobjective(model, Min, g(x[1], x[2]))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x[1:2])
+2-element Vector{VariableRef}:
+ x[1]
+ x[2]
+
+julia> g(x::T, y::T) where {T<:Real} = x * y
+g (generic function with 1 method)
+
+julia> function ∇g(g::AbstractVector{T}, x::T, y::T) where {T<:Real}
+           g[1] = y
+           g[2] = x
+           return
+       end
+∇g (generic function with 1 method)
+
+julia> register(model, :g, 2, g, ∇g)
+
+julia> @NLobjective(model, Min, g(x[1], x[2]))
 ```
 """
 function register(
@@ -783,14 +831,25 @@ derivatives of the function `f` respectively.
 
 ## Examples
 
-```jldoctest; setup=:(using JuMP)
-model = Model()
-@variable(model, x)
-f(x::Float64) = x^2
-∇f(x::Float64) = 2 * x
-∇²f(x::Float64) = 2.0
-register(model, :foo, 1, f, ∇f, ∇²f)
-@NLobjective(model, Min, foo(x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x)
+x
+
+julia> f(x::Float64) = x^2
+f (generic function with 1 method)
+
+julia> ∇f(x::Float64) = 2 * x
+∇f (generic function with 1 method)
+
+julia> ∇²f(x::Float64) = 2.0
+∇²f (generic function with 1 method)
+
+julia> register(model, :foo, 1, f, ∇f, ∇²f)
+
+julia> @NLobjective(model, Min, foo(x))
+
 ```
 """
 function register(

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -164,10 +164,13 @@ set_objective_function(model, func)
 
 ## Examples
 
-```jldoctest; setup=:(using JuMP)
-model = Model()
-@variable(model, x)
-set_objective(model, MIN_SENSE, x)
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x)
+x
+
+julia> set_objective(model, MIN_SENSE, x)
 ```
 """
 function set_objective(model::AbstractModel, sense::MOI.OptimizationSense, func)
@@ -199,14 +202,8 @@ Error if the objective is not convertible to type `T`.
 
 ## Examples
 
-```jldoctest objective_function; setup = :(using JuMP)
-julia> model = Model()
-A JuMP Model
-Feasibility problem with:
-Variables: 0
-Model mode: AUTOMATIC
-CachingOptimizer state: NO_OPTIMIZER
-Solver name: No optimizer attached.
+```jldoctest objective_function
+julia> model = Model();
 
 julia> @variable(model, x)
 x

--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -62,7 +62,11 @@ vector of ([`UnorderedPair`](@ref), coefficient) pairs.
 
 ## Example
 
-```jldoctest; setup=:(using JuMP; model = Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> GenericQuadExpr(GenericAffExpr(1.0, x => 2.0), [UnorderedPair(x, x) => 3.0])
 3 x² + 2 x + 1
 ```
@@ -167,7 +171,11 @@ See also: [`map_coefficients`](@ref)
 
 ## Example
 
-```jldoctest; setup=:(using JuMP; model = Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> a = @expression(model, x^2 + x + 1)
 x² + x + 1
 
@@ -197,7 +205,11 @@ See also: [`map_coefficients_inplace!`](@ref)
 
 ## Example
 
-```jldoctest; setup=:(using JuMP; model = Model(); @variable(model, x))
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x);
+
 julia> a = @expression(model, x^2 + x + 1)
 x² + x + 1
 

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -16,7 +16,9 @@ symmetric.
 
 ## Examples
 
-```jldoctest; setup=:(model = Model())
+```jldoctest
+julia> model = Model();
+
 julia> @variable(model, Q[1:2, 1:2] in SymmetricMatrixSpace())
 2×2 LinearAlgebra.Symmetric{VariableRef,Array{VariableRef,2}}:
  Q[1,1]  Q[1,2]
@@ -33,8 +35,13 @@ skew-symmetric.
 
 ## Examples
 
-```jldoctest; setup=:(model = Model())
-@variable(model, Q[1:2, 1:2] in SkewSymmetricMatrixSpace())
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, Q[1:2, 1:2] in SkewSymmetricMatrixSpace())
+2×2 Matrix{AffExpr}:
+ 0        Q[1,2]
+ -Q[1,2]  0
 ```
 """
 struct SkewSymmetricMatrixSpace end
@@ -53,7 +60,7 @@ vectorization is constrained to belong to the
 ## Examples
 
 Consider the following example:
-```jldoctest PSDCone; setup = :(using JuMP)
+```jldoctest PSDCone
 julia> model = Model();
 
 julia> @variable(model, x)
@@ -428,7 +435,7 @@ and [`@constraint`](@ref) macros.
 ## Examples
 
 Consider the following example:
-```jldoctest; setup = :(using JuMP)
+```jldoctest
 julia> model = Model();
 
 julia> @variable(model, H[1:3, 1:3] in HermitianPSDCone())

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -136,7 +136,7 @@ shortcut for the `MOI.SecondOrderCone`.
 ## Examples
 
 The following constrains ``\\|(x-1, x-2)\\|_2 \\le t`` and ``t \\ge 0``:
-```jldoctest; setup = :(using JuMP)
+```jldoctest
 julia> model = Model();
 
 julia> @variable(model, x)
@@ -163,7 +163,7 @@ euclidean norm of a vector `x` to be less than or equal to ``2tu`` where `t` and
 ## Examples
 
 The following constrains ``\\|(x-1, x-2)\\|^2_2 \\le 2tx`` and ``t, x \\ge 0``:
-```jldoctest; setup = :(using JuMP)
+```jldoctest
 julia> model = Model();
 
 julia> @variable(model, x)

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -70,7 +70,8 @@ Given a [`SymmetricMatrixShape`](@ref) of vectorized form
 `[1, 2, 3] in MOI.PositiveSemidefinieConeTriangle(2)`, the
 following code returns the set of the original constraint
 `Symmetric(Matrix[1 2; 2 3]) in PSDCone()`:
-```jldoctest; setup = :(using JuMP)
+
+```jldoctest
 julia> reshape_set(MOI.PositiveSemidefiniteConeTriangle(2), SymmetricMatrixShape(2))
 PSDCone()
 ```
@@ -87,7 +88,8 @@ Return an object in its original shape `shape` given its vectorized form
 
 Given a [`SymmetricMatrixShape`](@ref) of vectorized form `[1, 2, 3]`, the
 following code returns the matrix `Symmetric(Matrix[1 2; 2 3])`:
-```jldoctest; setup = :(using JuMP)
+
+```jldoctest
 julia> reshape_vector([1, 2, 3], SymmetricMatrixShape(2))
 2×2 LinearAlgebra.Symmetric{Int64,Array{Int64,2}}:
  1  2

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -220,7 +220,7 @@ end
 Returns the model to which `v` belongs.
 
 # Example
-```jldoctest; setup=:(using JuMP)
+```jldoctest
 julia> model = Model();
 
 julia> x = @variable(model)
@@ -433,7 +433,7 @@ Returns the reference of the variable with name attribute `name` or `Nothing` if
 no variable has this name attribute. Throws an error if several variables have
 `name` as their name attribute.
 
-```jldoctest objective_function; setup = :(using JuMP), filter = r"Stacktrace:.*"s
+```jldoctest objective_function; filter = r"Stacktrace:.*"s
 julia> model = Model();
 
 julia> @variable(model, x)
@@ -1313,7 +1313,7 @@ Complex plane object that can be used to create a complex variable in the
 
 Consider the following example:
 
-```jldoctest; setup = :(using JuMP)
+```jldoctest
 julia> model = Model();
 
 julia> @variable(model, x in ComplexPlane())
@@ -1473,15 +1473,15 @@ Returns a list of all variables currently in the model. The variables are
 ordered by creation time.
 
 # Example
-```jldoctest; setup=:(using JuMP)
-model = Model()
-@variable(model, x)
-@variable(model, y)
-all_variables(model)
+```jldoctest
+julia> model = Model();
 
-# output
+julia> @variable(model, x);
 
-2-element Array{VariableRef,1}:
+julia> @variable(model, y);
+
+julia> all_variables(model)
+2-element Vector{VariableRef}:
  x
  y
 ```
@@ -1562,7 +1562,7 @@ original model. The behavior of this function is undefined if additional
 changes are made to the affected variables in the meantime.
 
 # Example
-```jldoctest; setup=:(using JuMP)
+```jldoctest
 julia> model = Model();
 
 julia> @variable(model, x, Bin);
@@ -1615,7 +1615,7 @@ changes are made to the affected variables in the meantime.
 
 ## Example
 
-```jldoctest; setup=:(using JuMP)
+```jldoctest
 julia> model = Model();
 
 julia> @variable(model, x, Bin, start = 1);


### PR DESCRIPTION
This caught me out in a couple of places recently.