### PR TITLE
[docs] add p-norm example

### DIFF
--- a/docs/src/tutorials/conic/tips_and_tricks.jl
+++ b/docs/src/tutorials/conic/tips_and_tricks.jl
@@ -223,11 +223,10 @@ value(t), value(x)
 # can be modeled using a set of power cones. See the [Mosek Modeling Cookbook](https://docs.mosek.com/modeling-cookbook/powo.html#p-norm-cones)
 # for the derivation.
 
-function p_norm(x0::Vector, p)
-    N = length(x0)
+function p_norm(x::Vector, p)
+    N = length(x)
     model = Model(SCS.Optimizer)
     set_silent(model)
-    @variable(model, x[i = 1:N] == x0[i])
     @variable(model, r[1:N])
     @variable(model, t)
     @constraint(model, [i = 1:N], [r[i], t, x[i]] in MOI.PowerCone(1 / p))
@@ -237,8 +236,8 @@ function p_norm(x0::Vector, p)
     return value(t)
 end
 
-x0 = rand(5);
-LinearAlgebra.norm(x0, 4), p_norm(x0, 4)
+x = rand(5);
+LinearAlgebra.norm(x, 4), p_norm(x, 4)
 
 # ## Positive Semidefinite Cone
 

--- a/docs/src/tutorials/conic/tips_and_tricks.jl
+++ b/docs/src/tutorials/conic/tips_and_tricks.jl
@@ -220,7 +220,7 @@ value(t), value(x)
 # ## P-Norm
 
 # The p-norm ``||x||_p = \left(\sum\limits_{i} |x_i|^p\right)^{\frac{1}{p}}``
-# can be modeled using a set of power cones. See the [Mosek Modeling Cookbook](https://docs.mosek.com/modeling-cookbook/powo.html#p-norm-cones)
+# can be modeled using [`MOI.PowerCone`](@ref)s. See the [Mosek Modeling Cookbook](https://docs.mosek.com/modeling-cookbook/powo.html#p-norm-cones)
 # for the derivation.
 
 function p_norm(x::Vector, p)

--- a/docs/src/tutorials/conic/tips_and_tricks.jl
+++ b/docs/src/tutorials/conic/tips_and_tricks.jl
@@ -219,7 +219,7 @@ value(t), value(x)
 
 # ## P-Norm
 
-# The p-norm ``||x||_p = \left(\sum\limits_{i} |x_i|^p\right)^{\frac{1}{p})``
+# The p-norm ``||x||_p = \left(\sum\limits_{i} |x_i|^p\right)^{\frac{1}{p}}``
 # can be modeled using a set of power cones. See the [Mosek Modeling Cookbook](https://docs.mosek.com/modeling-cookbook/powo.html#p-norm-cones)
 # for the derivation.
 

--- a/docs/src/tutorials/conic/tips_and_tricks.jl
+++ b/docs/src/tutorials/conic/tips_and_tricks.jl
@@ -217,6 +217,29 @@ value(t), value(x)
 # that offers an alternative formulation that can be more efficient for some
 # formulations.
 
+# ## P-Norm
+
+# The p-norm ``||x||_p = \left(\sum\limits_{i} |x_i|^p\right)^{\frac{1}{p})``
+# can be modeled using a set of power cones. See the [Mosek Modeling Cookbook](https://docs.mosek.com/modeling-cookbook/powo.html#p-norm-cones)
+# for the derivation.
+
+function p_norm(x0::Vector, p)
+    N = length(x0)
+    model = Model(SCS.Optimizer)
+    set_silent(model)
+    @variable(model, x[i = 1:N] == x0[i])
+    @variable(model, r[1:N])
+    @variable(model, t)
+    @constraint(model, [i = 1:N], [r[i], t, x[i]] in MOI.PowerCone(1 / p))
+    @constraint(model, sum(r) == t)
+    @objective(model, Min, t)
+    optimize!(model)
+    return value(t)
+end
+
+x0 = rand(5);
+LinearAlgebra.norm(x0, 4), p_norm(x0, 4)
+
 # ## Positive Semidefinite Cone
 
 # The set of positive semidefinite matrices (PSD) of dimension $n$ form a cone


### PR DESCRIPTION
Came up on Discourse: https://discourse.julialang.org/t/nonlinear-optimization-using-jump-the-solver-does-not-support-nonlinear-problems-i-e-nlobjective-and-nlconstraint/95978

Preview: https://jump.dev/JuMP.jl/previews/PR3282/tutorials/conic/tips_and_tricks/#P-Norm