### PR TITLE
[docs] limit internal threading in parallelism.md

### DIFF
--- a/docs/src/tutorials/algorithms/parallelism.md
+++ b/docs/src/tutorials/algorithms/parallelism.md
@@ -246,6 +246,7 @@ julia> my_lock = Threads.ReentrantLock();
 julia> Threads.@threads for i in 1:10
            model = Model(HiGHS.Optimizer)
            set_silent(model)
+           set_attribute(model, MOI.NumberOfThreads(), 1)
            @variable(model, x)
            @objective(model, Min, x)
            set_lower_bound(x, i)
@@ -268,6 +269,11 @@ julia> solutions
   6 => 6.0
   3 => 3.0
 ````
+
+!!! warning
+    For some solvers, it may be necessary to limit the number of threads used
+    internally by the solver to 1 by setting the [`MOI.NumberOfThreads`](@ref)
+    attribute.
 
 ### With distributed computing
 
@@ -320,4 +326,4 @@ Many solvers use parallelism internally. For example, commercial solvers like
 [Gurobi](https://github.com/jump-dev/Gurobi.jl) and [CPLEX](https://github.com/jump-dev/CPLEX.jl)
 both parallelize the search in branch-and-bound. Solvers supporting internal
 parallelism will typically support the [`MOI.NumberOfThreads`](@ref) attribute,
-which you can set using [`set_optimizer_attribute`](@ref).
+which you can set using [`set_attribute`](@ref).


### PR DESCRIPTION
x-ref https://discourse.julialang.org/t/error-with-highs-independent-parallel-solves/96048

The output without the attribute is:
```Julia
julia> using JuMP

julia> import HiGHS

julia> solutions = Pair{Int,Float64}[]
Pair{Int64, Float64}[]

julia> my_lock = Threads.ReentrantLock()
ReentrantLock(nothing, Base.GenericCondition{Base.Threads.SpinLock}(Base.InvasiveLinkedList{Task}(nothing, nothing), Base.Threads.SpinLock(0)), 0)

julia> function generate_model()
           profit = [79, 91, 79, 66, 72, 83, 65, 93, 59, 94, 82, 55, 74, 68, 57, 62, 62]
           desire = [99, 62, 95, 77, 55, 66, 77, 88, 59, 61, 86, 68, 50, 82, 51, 89, 56]
           weight = [85, 53, 72, 56, 75, 51, 74, 62, 61, 54, 93, 56, 52, 53, 66, 80, 64]
           N = length(profit)
           model = Model(HiGHS.Optimizer)
           set_silent(model)
           # set_attribute(model, MOI.NumberOfThreads(), 1)
           @variable(model, x[1:N], Bin)
           @constraint(model, weight' * x <= 900)
           @objective(model, Max, (profit + desire)' * x)
           optimize!(model)
           return objective_value(model)
       end
generate_model (generic function with 1 method)

julia> Threads.@threads for i in 1:Threads.nthreads()
           res = generate_model()
           Threads.lock(my_lock) do
               push!(solutions, i => res)
           end
       end
Iteration total error 0 + 1 + 0 + 0 = 1 != 2
Iteration total error 0 + 3 + 0 + 0 = 3 != 1
Iteration total error 0 + 3 + 0 + 0 = 3 != 1
Iteration total error 0 + 0 + 0 + 0 = 0 != 1
Iteration total error 0 + 0 + 0 + 0 = 0 != 1
Iteration total error 0 + -4 + 0 + 0 = -4 != 1
Iteration total error 0 + 9 + 0 + 0 = 9 != 3
Iteration total error 0 + 9 + 0 + 0 = 9 != 3
Iteration total error 0 + 3 + 0 + 0 = 3 != 1
Iteration total error 0 + -2 + 0 + 0 = -2 != 1
Iteration total error 0 + 3 + 0 + 0 = 3 != 1
Iteration total error 0 + 3 + 0 + 0 = 3 != 1
Iteration total error 0 + 9 + 0 + 0 = 9 != 3

julia> solutions
4-element Vector{Pair{Int64, Float64}}:
 3 => 2085.0
 1 => 2085.0
 4 => 2085.0
 2 => 2085.0
```


@jajhall are these prints just debugging? Or are they consequential. It happens if we multi-thread instances of HiGHS which use threading internally.