### PR TITLE
Add Hermitian tag in variable macro

### DIFF
--- a/docs/src/manual/variables.md
+++ b/docs/src/manual/variables.md
@@ -1260,8 +1260,17 @@ julia> first(all_constraints(model, Vector{VariableRef}, MOI.HermitianPositiveSe
 
 ### Example: Hermitian variables
 
-Declare a matrix of JuMP variables to be Hermitian using
-[`HermitianMatrixSpace`](@ref):
+Declare a matrix of JuMP variables to be Hermitian using the `Hermitian` tag:
+```jldoctest hermitian
+julia> model = Model();
+
+julia> @variable(model, x[1:2, 1:2], Hermitian)
+2×2 LinearAlgebra.Hermitian{GenericAffExpr{ComplexF64, VariableRef}, Matrix{GenericAffExpr{ComplexF64, VariableRef}}}:
+ real(x[1,1])                               …  real(x[1,2]) + (0.0 + 1.0im) imag(x[1,2])
+ real(x[1,2]) + (0.0 - 1.0im) imag(x[1,2])     real(x[2,2])
+```
+
+This is equivalent to declaring the variable in [`HermitianMatrixSpace`](@ref):
 ```jldoctest hermitian
 julia> model = Model();
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -2499,7 +2499,15 @@ macro variable(args...)
         end
         set = :(JuMP.SymmetricMatrixSpace())
     end
-    extra = filter(x -> (x != :PSD && x != :Symmetric), extra) # filter out PSD and sym tag
+    if any(t -> (t == :Hermitian), extra)
+        if set !== nothing
+            _error(
+                "Cannot specify `Hermitian` when the set is already specified, the variable is constrained to belong to `$set`.",
+            )
+        end
+        set = :(JuMP.HermitianMatrixSpace())
+    end
+    extra = filter(x -> (x != :PSD && x != :Symmetric && x != :Hermitian), extra) # filter out PSD, Symmetric and Hermitian tags
     for ex in extra
         if ex == :Int
             _set_integer_or_error(_error, infoexpr)

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -13,6 +13,7 @@ module TestMacros
 using JuMP
 using Test
 
+import LinearAlgebra
 import SparseArrays
 
 include(joinpath(@__DIR__, "utilities.jl"))

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -1931,4 +1931,12 @@ function test_matrix_in_vector_set()
     return
 end
 
+function test_hermitian_variable_tag()
+    model = Model()
+    @variable(model, x[1:3, 1:3], Hermitian)
+    @test x isa LinearAlgebra.Hermitian
+    @test num_variables(model) == 9
+    return
+end
+
 end  # module

--- a/test/test_variable.jl
+++ b/test/test_variable.jl
@@ -1256,6 +1256,17 @@ function _test_Hermitian(model, H)
     @test H[2, 1] == conj(H[1, 2])
 end
 
+function test_extension_variable_Hermitian_tag(
+    ModelType = Model,
+    VariableRefType = VariableRef,
+)
+    model = ModelType()
+    @variable(model, H[1:2, 1:2], Hermitian)
+    _test_Hermitian(model, H)
+    @test num_constraints(model; count_variable_in_set_constraints = true) == 0
+    return
+end
+
 function test_extension_variable_Hermitian(
     ModelType = Model,
     VariableRefType = VariableRef,


### PR DESCRIPTION
Requires https://github.com/jump-dev/JuMP.jl/pull/3292 to be merged first.

Another option is to reexport the symbol of `LinearAlgebra.Hermitian` and `LinearAlgebra.Symmetric` and to overload `build_variable`. I always felt it a bit annoying to ask to user to load `LinearAlgebra` intself to use the `Symmetric` symbol which is part of the JuMP syntax.
The issue is that it won't work if the user `import` JuMP because then `Symmetric` won't be in the scope so it would be breaking.

Closes https://github.com/jump-dev/JuMP.jl/issues/3291