### PR TITLE
Fix missing MA.promote_operation method with LinearAlgebra.I

### DIFF
--- a/src/mutable_arithmetics.jl
+++ b/src/mutable_arithmetics.jl
@@ -133,6 +133,14 @@ function _MA.promote_operation(
     return GenericQuadExpr{T,V}
 end
 
+function _MA.promote_operation(
+    ::typeof(*),
+    ::Type{T},
+    ::Type{LinearAlgebra.Diagonal{Bool,Vector{Bool}}}, # LinearAlgebra.I(N)
+) where {T<:AbstractJuMPScalar}
+    return LinearAlgebra.Diagonal{T,Vector{T}}
+end
+
 function _MA.isequal_canonical(x::T, y::T) where {T<:AbstractJuMPScalar}
     return isequal_canonical(x, y)
 end

--- a/test/test_expr.jl
+++ b/test/test_expr.jl
@@ -441,4 +441,12 @@ function test_expression_ambiguities()
     return
 end
 
+function test_linear_algebra_scaling_matrix()
+    model = Model()
+    @variable(model, x)
+    A = [1 2; 3 4]
+    @test @expression(model, A + x * I(2)) == A + x * I(2) == A + [1 0; 0 1] * x
+    return
+end
+
 end  # TestExpr


### PR DESCRIPTION
Part of #3287 