### PR TITLE
Add JuMP-level sets for Semicontinuous and Semiinteger

### DIFF
--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -1301,26 +1301,26 @@ julia> @constraint(model, [t; u; x] in RotatedSecondOrderCone())
 Semi-continuous variables are constrained to the set
 ``x \in \{0\} \cup [l, u]``.
 
-Create a semi-continuous variable using the `MOI.Semicontinuous` set:
+Create a semi-continuous variable using the [`Semicontinuous`](@ref) set:
 ```jldoctest
 julia> model = Model();
 
 julia> @variable(model, x);
 
-julia> @constraint(model, x in MOI.Semicontinuous(1.5, 3.5))
+julia> @constraint(model, x in Semicontinuous(1.5, 3.5))
 x in MathOptInterface.Semicontinuous{Float64}(1.5, 3.5)
 ```
 
 Semi-integer variables  are constrained to the set
 ``x \in \{0\} \cup \{l, l+1, \dots, u\}``.
 
-Create a semi-integer variable using the `MOI.Semiinteger` set:
+Create a semi-integer variable using the [`Semiinteger`](@ref) set:
 ```jldoctest
 julia> model = Model();
 
 julia> @variable(model, x);
 
-julia> @constraint(model, x in MOI.Semiinteger(1.0, 3.0))
+julia> @constraint(model, x in Semiinteger(1.0, 3.0))
 x in MathOptInterface.Semiinteger{Float64}(1.0, 3.0)
 ```
 

--- a/docs/src/reference/constraints.md
+++ b/docs/src/reference/constraints.md
@@ -80,6 +80,8 @@ SymmetricMatrixSpace
 HermitianMatrixSpace
 HermitianMatrixShape
 moi_set
+Semicontinuous
+Semiinteger
 ```
 
 ## Printing

--- a/docs/src/reference/extensions.md
+++ b/docs/src/reference/extensions.md
@@ -7,6 +7,7 @@ section of the manual.
 
 ```@docs
 AbstractVectorSet
+AbstractScalarSet
 ```
 
 ## Extend `@variable`

--- a/docs/src/tutorials/linear/tips_and_tricks.jl
+++ b/docs/src/tutorials/linear/tips_and_tricks.jl
@@ -253,7 +253,7 @@ M = 100
 # **Example** $$x \in \{0\}\cup [1, 2]$$
 
 model = Model();
-@variable(model, x in MOI.Semicontinuous(1.0, 2.0))
+@variable(model, x in Semicontinuous(1.0, 2.0))
 
 # ## Semi-integer variables
 
@@ -262,7 +262,7 @@ model = Model();
 # $$x \in \{0\} \cup [l, u] \cap \mathbb{Z}.$$
 
 model = Model();
-@variable(model, x in MOI.Semiinteger(5.0, 10.0))
+@variable(model, x in Semiinteger(5.0, 10.0))
 
 # ## Special Ordered Sets of Type 1
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -545,6 +545,10 @@ Return the set of the constraint `constraint` in the function-in-set form as a
     moi_set(s::AbstractVectorSet, dim::Int)
 
 Returns the MOI set of dimension `dim` corresponding to the JuMP set `s`.
+
+    moi_set(s::AbstractScalarSet)
+
+Returns the MOI set corresponding to the JuMP set `s`.
 """
 moi_set(constraint::AbstractConstraint) = constraint.set
 

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -1573,4 +1573,26 @@ function test_symmetric_in_zeros()
     return
 end
 
+function test_semicontinuous()
+    model = Model()
+    @variable(model, x in Semicontinuous(2, 3))
+    @variable(model, y)
+    c = @constraint(model, y + 1 in Semicontinuous(2.5, 3))
+    c_obj = constraint_object(c)
+    @test isequal_canonical(c_obj.func, y + 1)
+    @test c_obj.set == MOI.Semicontinuous(2.5, 3.0)
+    return
+end
+
+function test_semiinteger()
+    model = Model()
+    @variable(model, x in Semiinteger(2, 3))
+    @variable(model, y)
+    c = @constraint(model, y + 1 in Semiinteger(2.5, 3))
+    c_obj = constraint_object(c)
+    @test isequal_canonical(c_obj.func, y + 1)
+    @test c_obj.set == MOI.Semiinteger(2.5, 3.0)
+    return
+end
+
 end


### PR DESCRIPTION
Closes #3300 

I've seen a couple of people bump into this, where it wasn't obvious that you otherwise need `Float64` arguments.

Here's the most recent motivating bug report: https://github.com/COPT-Public/COPT.jl/issues/20