### PR TITLE
Fix tests for upcoming MOI v1.14.0 release

### DIFF
--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -325,14 +325,10 @@ function test_bridges_print_active_bridge()
     c = @constraint(model, x in Nonnegative())
     optimize!(model)
     print_active_bridges(model)
-    @test sprint(print_active_bridges, model) == """
- * Supported objective: MOI.ScalarAffineFunction{Float64}
- * Unsupported constraint: MOI.VariableIndex-in-Main.TestModels.Nonnegative
- |  bridged by:
- |   Main.TestModels.NonnegativeBridge{Float64, MOI.VariableIndex}
- |  introduces:
- |   * Supported constraint: MOI.VariableIndex-in-MOI.GreaterThan{Float64}
-"""
+    contents = sprint(print_active_bridges, model)
+    @test occursin("Nonnegative", contents)
+    @test occursin("NonnegativeBridge", contents)
+    @test occursin("GreaterThan", contents)
     return
 end
 


### PR DESCRIPTION
https://github.com/jump-dev/MathOptInterface.jl/pull/2132 changes the printing of `print_active_bridges`.

So this PR changes the test to check that we mention `Nonnegative`, `NonnegativeBridge`, and `GreaterThan`. That should be safe enough to check that something was printed, and that it mentions the bridge and the bridged constraint.