### PR TITLE
Replace normal equivalence with object equivalence in `memoize`

### DIFF
--- a/docs/src/tutorials/nonlinear/tips_and_tricks.jl
+++ b/docs/src/tutorials/nonlinear/tips_and_tricks.jl
@@ -76,12 +76,12 @@ function memoize(foo::Function, n_outputs::Int)
     last_dx, last_dfdx = nothing, nothing
     function foo_i(i, x::T...) where {T<:Real}
         if T == Float64
-            if x != last_x
+            if x !== last_x
                 last_x, last_f = x, foo(x...)
             end
             return last_f[i]::T
         else
-            if x != last_dx
+            if x !== last_dx
                 last_dx, last_dfdx = x, foo(x...)
             end
             return last_dfdx[i]::T


### PR DESCRIPTION
It seems that object equivalence is more robust with some specific corner case on Duals. See my reply on discourse : https://discourse.julialang.org/t/cache-results-between-function-calls-in-optimization-jl/94964/12?u=franckgaga The simple example of the doc was working well with normal equivalence but that's not always the case. I'm not able to pinpoint in which situation it fails, but it's happening when `x==last_dx` is `true` BUT `typeof(x)==typeof(last_dx)` is `false`.