### PR TITLE
[Containers] throw nice error on sum(::DenseAxisArray; dims)

### DIFF
--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -827,8 +827,11 @@ end
 function Base.sum(
     f::Function,
     x::Union{DenseAxisArray,DenseAxisArrayView};
-    dims::Int,
+    dims = Colon(),
 )
+    if dims == Colon()
+        return sum(f(xi) for xi in x)
+    end
     return error(
         "`sum(x::DenseAxisArray; dims)` is not supported. Convert the array " *
         "to an `Array` using `sum(Array(x); dims=$dims)`, or use an explicit " *
@@ -836,6 +839,6 @@ function Base.sum(
     )
 end
 
-function Base.sum(x::Union{DenseAxisArray,DenseAxisArrayView}; dims::Int)
+function Base.sum(x::Union{DenseAxisArray,DenseAxisArrayView}; dims = Colon())
     return sum(identity, x; dims = dims)
 end

--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -823,3 +823,19 @@ Base.print_array(io::IO, x::DenseAxisArrayView) = show(io, x)
 function Base.summary(io::IO, x::DenseAxisArrayView)
     return print(io, "view(::DenseAxisArray, ", join(x.axes, ", "), "), over")
 end
+
+function Base.sum(
+    f::Function,
+    x::Union{DenseAxisArray,DenseAxisArrayView};
+    dims::Int,
+)
+    return error(
+        "`sum(x::DenseAxisArray; dims)` is not supported. Convert the array " *
+        "to an `Array` using `sum(Array(x); dims=$dims)`, or use an explicit " *
+        "for-loop summation instead.",
+    )
+end
+
+function Base.sum(x::Union{DenseAxisArray,DenseAxisArrayView}; dims::Int)
+    return sum(identity, x; dims = dims)
+end

--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -825,10 +825,10 @@ function Base.summary(io::IO, x::DenseAxisArrayView)
 end
 
 function Base.sum(
-    f::Function,
+    f::F,
     x::Union{DenseAxisArray,DenseAxisArrayView};
     dims = Colon(),
-)
+) where {F<:Function}
     if dims == Colon()
         return sum(f(xi) for xi in x)
     end

--- a/test/Containers/test_DenseAxisArray.jl
+++ b/test/Containers/test_DenseAxisArray.jl
@@ -846,7 +846,11 @@ function test_containers_denseaxisarrayview_kwarg_setindex()
 end
 
 function test_sum_dims()
-    Containers.@container(x[i=1:2, j=1:2], i+j, container = DenseAxisArray)
+    Containers.@container(
+        x[i=1:2, j=1:2],
+        i+j,
+        container = DenseAxisArray,
+    )
     @test_throws(
         ErrorException(
             "`sum(x::DenseAxisArray; dims)` is not supported. Convert the array " *

--- a/test/Containers/test_DenseAxisArray.jl
+++ b/test/Containers/test_DenseAxisArray.jl
@@ -847,8 +847,8 @@ end
 
 function test_sum_dims()
     Containers.@container(
-        x[i=1:2, j=1:2],
-        i+j,
+        x[i = 1:2, j = 1:2],
+        i + j,
         container = DenseAxisArray,
     )
     @test_throws(

--- a/test/Containers/test_DenseAxisArray.jl
+++ b/test/Containers/test_DenseAxisArray.jl
@@ -845,4 +845,17 @@ function test_containers_denseaxisarrayview_kwarg_setindex()
     return
 end
 
+function test_sum_dims()
+    Containers.@container(x[i=1:2, j=1:2], i+j, container = DenseAxisArray)
+    @test_throws(
+        ErrorException(
+            "`sum(x::DenseAxisArray; dims)` is not supported. Convert the array " *
+            "to an `Array` using `sum(Array(x); dims=2)`, or use an explicit " *
+            "for-loop summation instead.",
+        ),
+        sum(x; dims = 2),
+    )
+    return
+end
+
 end  # module


### PR DESCRIPTION
Closes https://github.com/jump-dev/JuMP.jl/issues/3319

Taking a deeper look at fixing #3319, we actually run into the problem that `Base` doesn't drop flattened dimensions. So sum on a matrix still returns a `Matrix`:
```Julia
julia> x = [3 4; 4 5]
2×2 Matrix{Int64}:
 3  4
 4  5

julia> sum(x; dims = 1)
1×2 Matrix{Int64}:
 7  9

julia> sum(x; dims = 2)
2×1 Matrix{Int64}:
 7
 9
```
This happens even if the flattened dimension is in the middle:
```Julia
julia> x = rand(2, 2, 2)
2×2×2 Array{Float64, 3}:
[:, :, 1] =
 0.997592  0.424427
 0.673536  0.116184

[:, :, 2] =
 0.19444    0.853501
 0.0667024  0.725102

julia> sum(x; dims = 2)
2×1×2 Array{Float64, 3}:
[:, :, 1] =
 1.4220191127794288
 0.7897194338439628

[:, :, 2] =
 1.047941194519167
 0.7918042254294069
```

Our problem, then, is that what is the key for a flattened dimension of `DenseAxisArray`? We don't have a good answer, so I've opted to throw a nicer error asking the user to convert to a regular Array.