### PR TITLE
Use _string_round when printing sets

### DIFF
--- a/docs/src/developers/extensions.md
+++ b/docs/src/developers/extensions.md
@@ -214,7 +214,7 @@ julia> function JuMP.parse_constraint_head(
 
 julia> @constraint(model, x + x := 1.0)
 Rewriting := as ==
-2 x = 1.0
+2 x = 1
 ```
 
 [`parse_constraint_call`](@ref) should be implemented to intercept an expression
@@ -246,7 +246,7 @@ julia> function JuMP.parse_constraint_call(
 
 julia> @constraint(model, my_equal_to(x + x, 1.0))
 Rewriting my_equal_to to ==
-2 x = 1.0
+2 x = 1
 ```
 
 !!! tip
@@ -289,7 +289,7 @@ julia> function JuMP.build_constraint(
        end
 
 julia> @constraint(model, my_con, x == 0, MyConstrType, d = 2)
-my_con : x ≤ 2.0
+my_con : x ≤ 2
 ```
 
 !!! note
@@ -340,7 +340,7 @@ julia> function JuMP.add_constraint(
        end
 
 julia> @constraint(model, my_con, 2x <= 1, MyTag("my_prefix"))
-my_prefix[my_con] : 2 x - 1 ≤ 0.0
+my_prefix[my_con] : 2 x - 1 ≤ 0
 ```
 
 ## The extension dictionary

--- a/docs/src/manual/complex.md
+++ b/docs/src/manual/complex.md
@@ -125,7 +125,7 @@ julia> set_silent(model)
 julia> @variable(model, x[1:2]);
 
 julia> @constraint(model, (1 + 2im) * x[1] + 3 * x[2] == 4 + 5im)
-(1.0 + 2.0im) x[1] + (3.0 + 0.0im) x[2] = 4.0 + 5.0im
+(1.0 + 2.0im) x[1] + (3.0 + 0.0im) x[2] = (4.0 + 5.0im)
 
 julia> optimize!(model)
 
@@ -145,10 +145,10 @@ julia> set_silent(model)
 julia> @variable(model, x[1:2]);
 
 julia> @constraint(model, 1 * x[1] + 3 * x[2] == 4)  # real component
-x[1] + 3 x[2] = 4.0
+x[1] + 3 x[2] = 4
 
 julia> @constraint(model, 2 * x[1] == 5)  # imag component
-2 x[1] = 5.0
+2 x[1] = 5
 
 julia> optimize!(model)
 
@@ -168,7 +168,7 @@ julia> set_silent(model)
 julia> @variable(model, x in ComplexPlane());
 
 julia> @constraint(model, (1 + 2im) * x + 3 * x == 4 + 5im)
-(4.0 + 2.0im) real(x) + (-2.0 + 4.0im) imag(x) = 4.0 + 5.0im
+(4.0 + 2.0im) real(x) + (-2.0 + 4.0im) imag(x) = (4.0 + 5.0im)
 
 julia> optimize!(model)
 
@@ -188,10 +188,10 @@ julia> @variable(model, x_real);
 julia> @variable(model, x_imag);
 
 julia> @constraint(model, x_real - 2 * x_imag + 3 * x_real == 4)
-4 x_real - 2 x_imag = 4.0
+4 x_real - 2 x_imag = 4
 
 julia> @constraint(model, x_imag + 2 * x_real + 3 * x_imag == 5)
-2 x_real + 4 x_imag = 5.0
+2 x_real + 4 x_imag = 5
 
 julia> optimize!(model)
 

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -43,16 +43,16 @@ julia> model = Model();
 julia> @variable(model, x[1:3]);
 
 julia> @constraint(model, c1, sum(x) <= 1)
-c1 : x[1] + x[2] + x[3] ≤ 1.0
+c1 : x[1] + x[2] + x[3] ≤ 1
 
 julia> @constraint(model, c2, x[1] + 2 * x[3] >= 2)
-c2 : x[1] + 2 x[3] ≥ 2.0
+c2 : x[1] + 2 x[3] ≥ 2
 
 julia> @constraint(model, c3, sum(i * x[i] for i in 1:3) == 3)
-c3 : x[1] + 2 x[2] + 3 x[3] = 3.0
+c3 : x[1] + 2 x[2] + 3 x[3] = 3
 
 julia> @constraint(model, c4, 4 <= 2 * x[2] <= 5)
-c4 : 2 x[2] ∈ [4.0, 5.0]
+c4 : 2 x[2] ∈ [4, 5]
 ```
 
 ### Normalization
@@ -66,7 +66,7 @@ julia> model = Model();
 julia> @variable(model, x);
 
 julia> @constraint(model, c, 2x + 1 <= 4x + 4)
-c : -2 x <= 3.0
+c : -2 x ≤ 3
 ```
 
 ### [Add a quadratic constraint](@id quad_constraints)
@@ -85,7 +85,7 @@ julia> @variable(model, t >= 0)
 t
 
 julia> @constraint(model, my_q, x[1]^2 + x[2]^2 <= t^2)
-my_q : x[1]² + x[2]² - t² <= 0.0
+my_q : x[1]² + x[2]² - t² ≤ 0
 ```
 
 !!! tip
@@ -120,8 +120,8 @@ con_vector : [x[1] + 2 x[2] - 5, 3 x[1] + 4 x[2] - 6] ∈ MathOptInterface.Zeros
 
 julia> @constraint(model, con_scalar, A * x .== b)
 2-element Vector{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.EqualTo{Float64}}, ScalarShape}}:
- con_scalar : x[1] + 2 x[2] = 5.0
- con_scalar : 3 x[1] + 4 x[2] = 6.0
+ con_scalar : x[1] + 2 x[2] = 5
+ con_scalar : 3 x[1] + 4 x[2] = 6
 ```
 
 The two constraints, `==` and `.==` are similar, but subtly different. The first
@@ -152,16 +152,16 @@ julia> @constraint(model, A * x <= b)
 
 julia> @constraint(model, A * x .<= b)
 2-element Vector{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}}:
- x[1] + 2 x[2] ≤ 5.0
- 3 x[1] + 4 x[2] ≤ 6.0
+ x[1] + 2 x[2] ≤ 5
+ 3 x[1] + 4 x[2] ≤ 6
 
 julia> @constraint(model, A * x >= b)
 [x[1] + 2 x[2] - 5, 3 x[1] + 4 x[2] - 6] ∈ MathOptInterface.Nonnegatives(2)
 
 julia> @constraint(model, A * x .>= b)
 2-element Vector{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.GreaterThan{Float64}}, ScalarShape}}:
- x[1] + 2 x[2] ≥ 5.0
- 3 x[1] + 4 x[2] ≥ 6.0
+ x[1] + 2 x[2] ≥ 5
+ 3 x[1] + 4 x[2] ≥ 6
 ```
 
 ### Vectorized matrix constraints
@@ -212,8 +212,8 @@ redundant. In contrast, the broadcasting syntax adds four linear constraints:
 ```jldoctest con_symmetric_zeros
 julia> @constraint(model, X .== LinearAlgebra.I)
 2×2 Matrix{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.EqualTo{Float64}}, ScalarShape}}:
- X[1,1] = 1.0  X[1,2] = 0.0
- X[1,2] = 0.0  X[2,2] = 1.0
+ X[1,1] = 1  X[1,2] = 0
+ X[1,2] = 0  X[2,2] = 1
 ```
 
 The same holds for `LinearAlgebra.Hermitian` matrices:
@@ -234,8 +234,8 @@ julia> @constraint(model, X == LinearAlgebra.I)
 
 julia> @constraint(model, X .== LinearAlgebra.I)
 2×2 Matrix{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{ComplexF64}, MathOptInterface.EqualTo{ComplexF64}}, ScalarShape}}:
- real(X[1,1]) = 1.0 - 0.0im                               …  real(X[1,2]) + (0.0 + 1.0im) imag(X[1,2]) = 0.0 - 0.0im
- real(X[1,2]) + (0.0 - 1.0im) imag(X[1,2]) = 0.0 + 0.0im     real(X[2,2]) = 1.0 - 0.0im
+ real(X[1,1]) = (1.0 - 0.0im)                               …  real(X[1,2]) + (0.0 + 1.0im) imag(X[1,2]) = (0.0 - 0.0im)
+ real(X[1,2]) + (0.0 - 1.0im) imag(X[1,2]) = (0.0 + 0.0im)     real(X[2,2]) = (1.0 - 0.0im)
 ```
 
 ## Containers of constraints
@@ -252,12 +252,12 @@ julia> @variable(model, x[1:3]);
 
 julia> @constraint(model, c[i=1:3], x[i] <= i^2)
 3-element Vector{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}}:
- c[1] : x[1] ≤ 1.0
- c[2] : x[2] ≤ 4.0
- c[3] : x[3] ≤ 9.0
+ c[1] : x[1] ≤ 1
+ c[2] : x[2] ≤ 4
+ c[3] : x[3] ≤ 9
 
 julia> c[2]
-c[2] : x[2] ≤ 4.0
+c[2] : x[2] ≤ 4
 ```
 
 Sets can be any Julia type that supports iteration:
@@ -271,11 +271,11 @@ julia> @constraint(model, c[i=2:3, ["red", "blue"]], x[i] <= i^2)
     Dimension 1, 2:3
     Dimension 2, ["red", "blue"]
 And data, a 2×2 Matrix{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}}:
- c[2,red] : x[2] ≤ 4.0  c[2,blue] : x[2] ≤ 4.0
- c[3,red] : x[3] ≤ 9.0  c[3,blue] : x[3] ≤ 9.0
+ c[2,red] : x[2] ≤ 4  c[2,blue] : x[2] ≤ 4
+ c[3,red] : x[3] ≤ 9  c[3,blue] : x[3] ≤ 9
 
 julia> c[2, "red"]
-c[2,red] : x[2] ≤ 4.0
+c[2,red] : x[2] ≤ 4
 ```
 
 Sets can depend upon previous indices:
@@ -286,12 +286,12 @@ julia> @variable(model, x[1:3]);
 
 julia> @constraint(model, c[i=1:3, j=i:3], x[i] <= j)
 JuMP.Containers.SparseAxisArray{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}, 2, Tuple{Int64, Int64}} with 6 entries:
-  [1, 1]  =  c[1,1] : x[1] ≤ 1.0
-  [1, 2]  =  c[1,2] : x[1] ≤ 2.0
-  [1, 3]  =  c[1,3] : x[1] ≤ 3.0
-  [2, 2]  =  c[2,2] : x[2] ≤ 2.0
-  [2, 3]  =  c[2,3] : x[2] ≤ 3.0
-  [3, 3]  =  c[3,3] : x[3] ≤ 3.0
+  [1, 1]  =  c[1,1] : x[1] ≤ 1
+  [1, 2]  =  c[1,2] : x[1] ≤ 2
+  [1, 3]  =  c[1,3] : x[1] ≤ 3
+  [2, 2]  =  c[2,2] : x[2] ≤ 2
+  [2, 3]  =  c[2,3] : x[2] ≤ 3
+  [3, 3]  =  c[3,3] : x[3] ≤ 3
 ```
 and you can filter elements in the sets using the `;` syntax:
 ```jldoctest
@@ -301,9 +301,9 @@ julia> @variable(model, x[1:9]);
 
 julia> @constraint(model, c[i=1:9; mod(i, 3) == 0], x[i] <= i)
 JuMP.Containers.SparseAxisArray{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}, 1, Tuple{Int64}} with 3 entries:
-  [3]  =  c[3] : x[3] ≤ 3.0
-  [6]  =  c[6] : x[6] ≤ 6.0
-  [9]  =  c[9] : x[9] ≤ 9.0
+  [3]  =  c[3] : x[3] ≤ 3
+  [6]  =  c[6] : x[6] ≤ 6
+  [9]  =  c[9] : x[9] ≤ 9
 ```
 
 ## Registered constraints
@@ -323,7 +323,7 @@ julia> @variable(model, x)
 x
 
 julia> @constraint(model, my_c, 2x <= 1)
-my_c : 2 x ≤ 1.0
+my_c : 2 x ≤ 1
 
 julia> model
 A JuMP Model
@@ -351,7 +351,7 @@ julia> @variable(model, x)
 x
 
 julia> @constraint(model, c, 2x <= 1)
-c : 2 x <= 1.0
+c : 2 x ≤ 1
 
 julia> @constraint(model, c, 2x <= 1)
 ERROR: An object of name c is already attached to this model. If this
@@ -375,7 +375,7 @@ julia> model = Model();
 julia> @variable(model, x);
 
 julia> c = @constraint(model, 2x <= 1)
-2 x <= 1.0
+2 x ≤ 1
 ```
 
 Create a container of anonymous constraints by dropping the name in front of
@@ -387,9 +387,9 @@ julia> @variable(model, x[1:3]);
 
 julia> c = @constraint(model, [i = 1:3], x[i] <= i)
 3-element Vector{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}}:
- x[1] ≤ 1.0
- x[2] ≤ 2.0
- x[3] ≤ 3.0
+ x[1] ≤ 1
+ x[2] ≤ 2
+ x[3] ≤ 3
 ```
 
 ## Constraint names
@@ -403,7 +403,7 @@ and [`set_name(::JuMP.ConstraintRef, ::String)`](@ref):
 julia> model = Model(); @variable(model, x);
 
 julia> @constraint(model, con, x <= 1)
-con : x <= 1.0
+con : x ≤ 1
 
 julia> name(con)
 "con"
@@ -411,7 +411,7 @@ julia> name(con)
 julia> set_name(con, "my_con_name")
 
 julia> con
-my_con_name : x <= 1.0
+my_con_name : x ≤ 1
 ```
 
 Override the default choice of name using the `base_name` keyword:
@@ -420,8 +420,8 @@ julia> model = Model(); @variable(model, x);
 
 julia> con = @constraint(model, [i=1:2], x <= i, base_name = "my_con")
 2-element Vector{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}}:
- my_con[1] : x ≤ 1.0
- my_con[2] : x ≤ 2.0
+ my_con[1] : x ≤ 1
+ my_con[2] : x ≤ 2
 ```
 
 Note that names apply to each element of the container, not to the container of
@@ -434,8 +434,8 @@ julia> set_name(con[1], "c")
 
 julia> con
 2-element Vector{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}}:
- c : x ≤ 1.0
- my_con[2] : x ≤ 2.0
+ c : x ≤ 1
+ my_con[2] : x ≤ 2
 ```
 
 !!! tip
@@ -448,7 +448,7 @@ julia> con
     julia> @variable(model, x);
 
     julia> @constraint(model, con, x <= 2, set_string_name = false)
-    x <= 2.0
+    x ≤ 2
     ```
     See [Disable string names](@ref) for more information.
 
@@ -457,7 +457,7 @@ julia> con
 Retrieve a constraint from a model using [`constraint_by_name`](@ref):
 ```jldoctest constraint_name_vector
 julia> constraint_by_name(model, "c")
-c : x ≤ 1.0
+c : x ≤ 1
 ```
 
 If the name is not present, `nothing` will be returned:
@@ -472,8 +472,8 @@ julia> model = Model(); @variable(model, x);
 
 julia> con = @constraint(model, [i=1:2], x <= i, base_name = "my_con")
 2-element Vector{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}}:
- my_con[1] : x ≤ 1.0
- my_con[2] : x ≤ 2.0
+ my_con[1] : x ≤ 1
+ my_con[2] : x ≤ 2
 
 julia> constraint_by_name(model, "my_con")
 ```
@@ -485,13 +485,13 @@ julia> model = Model(); @variable(model, x);
 
 julia> model[:con] = @constraint(model, [i=1:2], x <= i, base_name = "my_con")
 2-element Vector{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}}:
- my_con[1] : x ≤ 1.0
- my_con[2] : x ≤ 2.0
+ my_con[1] : x ≤ 1
+ my_con[2] : x ≤ 2
 
 julia> model[:con]
 2-element Vector{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}}:
- my_con[1] : x ≤ 1.0
- my_con[2] : x ≤ 2.0
+ my_con[1] : x ≤ 1
+ my_con[2] : x ≤ 2
 ```
 
 ## String names, symbolic names, and bindings
@@ -525,7 +525,7 @@ julia> @variable(model, x)
 x
 
 julia> c_binding = @constraint(model, 2x <= 1, base_name = "c")
-c : 2 x <= 1.0
+c : 2 x ≤ 1
 
 julia> model
 A JuMP Model
@@ -541,13 +541,13 @@ julia> c
 ERROR: UndefVarError: c not defined
 
 julia> c_binding
-c : 2 x <= 1.0
+c : 2 x ≤ 1
 
 julia> name(c_binding)
 "c"
 
 julia> model[:c_register] = c_binding
-c : 2 x <= 1.0
+c : 2 x ≤ 1
 
 julia> model
 A JuMP Model
@@ -560,7 +560,7 @@ Solver name: No optimizer attached.
 Names registered in the model: c_register, x
 
 julia> model[:c_register]
-c : 2 x <= 1.0
+c : 2 x ≤ 1
 
 julia> model[:c_register] === c_binding
 true
@@ -582,13 +582,13 @@ julia> @constraints(model, begin
            2x <= 1
            c, x >= -1
        end)
-(2 x ≤ 1.0, c : x ≥ -1.0)
+(2 x ≤ 1, c : x ≥ -1)
 
 julia> print(model)
 Feasibility
 Subject to
- c : x ≥ -1.0
- 2 x ≤ 1.0
+ c : x ≥ -1
+ 2 x ≤ 1
 ```
 The [`@constraints`](@ref) macro returns a tuple of the constraints that were
 defined.
@@ -621,7 +621,7 @@ julia> @variable(model, x)
 x
 
 julia> @constraint(model, con, x <= 1)
-con : x <= 1.0
+con : x ≤ 1
 
 julia> @objective(model, Min, -2x)
 -2 x
@@ -705,12 +705,12 @@ julia> model = Model();
 julia> @variable(model, x);
 
 julia> @constraint(model, con, 2x <= 1)
-con : 2 x <= 1.0
+con : 2 x ≤ 1
 
 julia> set_normalized_rhs(con, 3)
 
 julia> con
-con : 2 x <= 3.0
+con : 2 x ≤ 3
 
 julia> normalized_rhs(con)
 3.0
@@ -740,7 +740,7 @@ julia> @variable(model, const_term)
 const_term
 
 julia> @constraint(model, con, 2x <= const_term + 1)
-con : 2 x - const_term <= 1.0
+con : 2 x - const_term ≤ 1
 
 julia> fix(const_term, 1.0)
 ```
@@ -763,12 +763,12 @@ julia> model = Model();
 julia> @variable(model, x);
 
 julia> @constraint(model, con, 2x <= 1)
-con : 2 x <= 1.0
+con : 2 x ≤ 1
 
 julia> add_to_function_constant(con, 2)
 
 julia> con
-con : 2 x <= -1.0
+con : 2 x ≤ -1
 
 julia> normalized_rhs(con)
 -1.0
@@ -781,12 +781,12 @@ julia> model = Model();
 julia> @variable(model, x);
 
 julia> @constraint(model, con, 0 <= 2x + 1 <= 2)
-con : 2 x ∈ [-1.0, 1.0]
+con : 2 x ∈ [-1, 1]
 
 julia> add_to_function_constant(con, 3)
 
 julia> con
-con : 2 x ∈ [-4.0, -2.0]
+con : 2 x ∈ [-4, -2]
 ```
 
 ## Modify a variable coefficient
@@ -803,12 +803,12 @@ julia> model = Model();
 julia> @variable(model, x[1:2]);
 
 julia> @constraint(model, con, 2x[1] + x[2] <= 1)
-con : 2 x[1] + x[2] ≤ 1.0
+con : 2 x[1] + x[2] ≤ 1
 
 julia> set_normalized_coefficient(con, x[2], 0)
 
 julia> con
-con : 2 x[1] ≤ 1.0
+con : 2 x[1] ≤ 1
 
 julia> normalized_coefficient(con, x[2])
 0.0
@@ -853,7 +853,7 @@ julia> model = Model();
 julia> @variable(model, x);
 
 julia> @constraint(model, con, 2x <= 1)
-con : 2 x <= 1.0
+con : 2 x ≤ 1
 
 julia> is_valid(model, con)
 true
@@ -885,7 +885,7 @@ reference:
 julia> unregister(model, :con)
 
 julia> @constraint(model, con, 2x <= 1)
-con : 2 x <= 1.0
+con : 2 x ≤ 1
 ```
 
 !!! info
@@ -913,7 +913,7 @@ julia> @variable(model, x)
 x
 
 julia> @constraint(model, con, x >= 10)
-con : x ≥ 10.0
+con : x ≥ 10
 
 julia> start_value(con)
 
@@ -981,21 +981,21 @@ julia> @variable(model, x);
 
 julia> @constraint(model, con[i = 1:3], i * x <= i + 1)
 3-element Vector{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}}:
- con[1] : x ≤ 2.0
- con[2] : 2 x ≤ 3.0
- con[3] : 3 x ≤ 4.0
+ con[1] : x ≤ 2
+ con[2] : 2 x ≤ 3
+ con[3] : 3 x ≤ 4
 ```
 JuMP returns references to the three constraints in an `Array` that is bound to
 the Julia variable `con`. This array can be accessed and sliced as you would
 with any Julia array:
 ```jldoctest constraint_arrays
 julia> con[1]
-con[1] : x <= 2.0
+con[1] : x ≤ 2
 
 julia> con[2:3]
 2-element Vector{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}}:
- con[2] : 2 x ≤ 3.0
- con[3] : 3 x ≤ 4.0
+ con[2] : 2 x ≤ 3
+ con[3] : 3 x ≤ 4
 ```
 
 Anonymous containers can also be constructed by dropping the name (for example, `con`)
@@ -1003,8 +1003,8 @@ before the square brackets:
 ```jldoctest constraint_arrays
 julia> con = @constraint(model, [i = 1:2], i * x <= i + 1)
 2-element Vector{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}}:
- x ≤ 2.0
- 2 x ≤ 3.0
+ x ≤ 2
+ 2 x ≤ 3
 ```
 
 Just like [`@variable`](@ref), JuMP will form an `Array` of constraints when it
@@ -1031,8 +1031,8 @@ julia> @constraint(model, con[i = 1:2, j = 2:3], i * x <= j + 1)
     Dimension 1, Base.OneTo(2)
     Dimension 2, 2:3
 And data, a 2×2 Matrix{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}}:
- con[1,2] : x ≤ 3.0    con[1,3] : x ≤ 4.0
- con[2,2] : 2 x ≤ 3.0  con[2,3] : 2 x ≤ 4.0
+ con[1,2] : x ≤ 3    con[1,3] : x ≤ 4
+ con[2,2] : 2 x ≤ 3  con[2,3] : 2 x ≤ 4
 ```
 
 ### SparseAxisArrays
@@ -1049,8 +1049,8 @@ julia> @variable(model, x);
 
 julia> @constraint(model, con[i = 1:2, j = 1:2; i != j], i * x <= j + 1)
 JuMP.Containers.SparseAxisArray{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}, 2, Tuple{Int64, Int64}} with 2 entries:
-  [1, 2]  =  con[1,2] : x ≤ 3.0
-  [2, 1]  =  con[2,1] : 2 x ≤ 2.0
+  [1, 2]  =  con[1,2] : x ≤ 3
+  [2, 1]  =  con[2,1] : 2 x ≤ 2
 ```
 
 !!! warning
@@ -1138,15 +1138,15 @@ The same also applies for [`all_constraints`](@ref):
 ```jldoctest con_access
 julia> all_constraints(model; include_variable_in_set_constraints = true)
 5-element Vector{ConstraintRef}:
- x[1] + x[2] ≤ 1.0
- x[1] ≥ 1.0
- x[2] ≥ 2.0
+ x[1] + x[2] ≤ 1
+ x[1] ≥ 1
+ x[2] ≥ 2
  x[1] integer
  x[2] integer
 
 julia> all_constraints(model; include_variable_in_set_constraints = false)
 1-element Vector{ConstraintRef}:
- x[1] + x[2] ≤ 1.0
+ x[1] + x[2] ≤ 1
 ```
 
 If you need finer-grained control on which constraints to include, use a variant
@@ -1192,10 +1192,10 @@ julia> model = Model();
 julia> @variable(model, x[1:3]);
 
 julia> @constraint(model, 2 * x[1] <= 1)
-2 x[1] ≤ 1.0
+2 x[1] ≤ 1
 
 julia> @constraint(model, 2 * x[1] in MOI.LessThan(1.0))
-2 x[1] ≤ 1.0
+2 x[1] ≤ 1
 ```
 
 You can also use any set defined by MathOptInterface:
@@ -1395,14 +1395,14 @@ julia> @variable(model, a, Bin)
 a
 
 julia> @constraint(model, a => {x + y <= 1})
-a => {x + y ≤ 1.0}
+a => {x + y ≤ 1}
 ```
 
 If the constraint must hold when `a` is zero, add `!` or `¬` before the binary
 variable;
 ```jldoctest indicator
 julia> @constraint(model, !a => {x + y <= 1})
-!a => {x + y ≤ 1.0}
+!a => {x + y ≤ 1}
 ```
 
 ## Semidefinite constraints

--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -202,7 +202,7 @@ as LaTeX.
 julia> print(model)
 Max x
 Subject to
- x ≥ 0.0
+ x ≥ 0
 ```
 
 !!! warning
@@ -216,7 +216,7 @@ Use [`latex_formulation`](@ref) to display the model in LaTeX form.
 julia> latex_formulation(model)
 $$ \begin{aligned}
 \max\quad & x\\
-\text{Subject to} \quad & x \geq 0.0\\
+\text{Subject to} \quad & x \geq 0\\
 \end{aligned} $$
 ```
 

--- a/docs/src/manual/objective.md
+++ b/docs/src/manual/objective.md
@@ -286,5 +286,5 @@ julia> @objective(model, Min, [obj1, obj2])   # Two-objective problem
  2 x[1]
 
 julia> @constraint(model, obj3 <= 2.0)
-x[1] + x[2] ≤ 2.0
+x[1] + x[2] ≤ 2
 ```

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -25,11 +25,11 @@ julia> begin
        end
 Max -12 x - 20 y[a]
 Subject to
- 6 x + 8 y[a] ≥ 100.0
- c1 : 7 x + 12 y[a] ≥ 120.0
- x ≥ 0.0
- y[a] ≤ 1.0
- y[b] ≤ 1.0
+ 6 x + 8 y[a] ≥ 100
+ c1 : 7 x + 12 y[a] ≥ 120
+ x ≥ 0
+ y[a] ≤ 1
+ y[b] ≤ 1
 ```
 
 ## Solutions summary
@@ -428,8 +428,8 @@ julia> begin
        end
 Max x[1]
 Subject to
- c1 : x[1] + x[2] ≤ 1.0
- c2 : x[1] - x[2] ≤ 1.0
+ c1 : x[1] + x[2] ≤ 1
+ c2 : x[1] - x[2] ≤ 1
  x[2] ≥ -0.5
  x[2] ≤ 0.5
 ```
@@ -600,7 +600,7 @@ julia> @objective(model, Min, [3x1 + x2, -x1 - 2x2])
  -x1 - 2 x2
 
 julia> @constraint(model, 3x1 - x2 <= 6)
-3 x1 - x2 ≤ 6.0
+3 x1 - x2 ≤ 6
 
 julia> optimize!(model)
 

--- a/docs/src/manual/variables.md
+++ b/docs/src/manual/variables.md
@@ -83,11 +83,11 @@ x_fixed
 julia> print(model)
 Feasibility
 Subject to
- x_fixed = 4.0
- x_lower ≥ 0.0
- x_interval ≥ 2.0
- x_upper ≤ 1.0
- x_interval ≤ 3.0
+ x_fixed = 4
+ x_lower ≥ 0
+ x_interval ≥ 2
+ x_upper ≤ 1
+ x_interval ≤ 3
 ```
 
 !!! warning
@@ -1093,8 +1093,8 @@ julia> @variables(model, begin
 julia> print(model)
 Feasibility
 Subject to
- Y_1[1] ≥ 1.0
- Y_2[2] ≥ 2.0
+ Y_1[1] ≥ 1
+ Y_2[2] ≥ 2
  z binary
 ```
 The [`@variables`](@ref) macro returns a tuple of the variables that were

--- a/src/print.jl
+++ b/src/print.jl
@@ -658,24 +658,26 @@ Return a `String` representing the membership to the set `set` using print mode
 function in_set_string end
 
 function in_set_string(mode::MIME, set::MOI.LessThan)
-    return string(_math_symbol(mode, :leq), " ", set.upper)
+    return string(_math_symbol(mode, :leq), " ", _string_round(set.upper))
 end
 
 function in_set_string(mode::MIME, set::MOI.GreaterThan)
-    return string(_math_symbol(mode, :geq), " ", set.lower)
+    return string(_math_symbol(mode, :geq), " ", _string_round(set.lower))
 end
 
 function in_set_string(mode::MIME, set::MOI.EqualTo)
-    return string(_math_symbol(mode, :eq), " ", set.value)
+    return string(_math_symbol(mode, :eq), " ", _string_round(set.value))
 end
 
 function in_set_string(::MIME"text/latex", set::MOI.Interval)
-    return string("\\in \\[", set.lower, ", ", set.upper, "\\]")
+    lower, upper = _string_round(set.lower), _string_round(set.upper)
+    return string("\\in \\[", lower, ", ", upper, "\\]")
 end
 
 function in_set_string(mode::MIME"text/plain", set::MOI.Interval)
     in = _math_symbol(mode, :in)
-    return string("$in [", set.lower, ", ", set.upper, "]")
+    lower, upper = _string_round(set.lower), _string_round(set.upper)
+    return string("$in [", lower, ", ", upper, "]")
 end
 
 in_set_string(::MIME"text/plain", ::MOI.ZeroOne) = "binary"

--- a/test/JuMPExtension.jl
+++ b/test/JuMPExtension.jl
@@ -646,16 +646,16 @@ function test_model_extension_printing()
     Test.@test JuMP.model_string(MIME("text/plain"), model_1) == """
 Max a - b + 2 a1 - 10 x
 Subject to
- a + b - 10 c - 2 x + c1 $(repl(:leq)) 1.0
- a*b $(repl(:leq)) 2.0
+ a + b - 10 c - 2 x + c1 $(repl(:leq)) 1
+ a*b $(repl(:leq)) 2
  [-a + 1, u[1], u[2], u[3]] $(repl(:in)) MathOptInterface.SecondOrderCone(4)
 """
 
     Test.@test JuMP.model_string(MIME("text/latex"), model_1) == """
 \$\$ \\begin{aligned}
 \\max\\quad & a - b + 2 a1 - 10 x\\\\
-\\text{Subject to} \\quad & a + b - 10 c - 2 x + c1 \\leq 1.0\\\\
- & a\\times b \\leq 2.0\\\\
+\\text{Subject to} \\quad & a + b - 10 c - 2 x + c1 \\leq 1\\\\
+ & a\\times b \\leq 2\\\\
  & [-a + 1, u_{1}, u_{2}, u_{3}] \\in \\text{MathOptInterface.SecondOrderCone(4)}\\\\
 \\end{aligned} \$\$"""
 

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -722,9 +722,9 @@ function test_AffExpr_in_macros()
     con1 = @constraint(model, 3 * temp - x - 2 >= 0)
     con2 = @constraint(model, (2 + 2) * ((3 + 4) * (1 + a)) == 0)
     con3 = @constraint(model, 1 + 0 * temp == 0)
-    @test string(con1) == "2 x + 6 y $ge -1.0"
-    @test string(con2) == "28 x $eq -28.0"
-    @test string(con3) == "0 $eq -1.0"
+    @test string(con1) == "2 x + 6 y $ge -1"
+    @test string(con2) == "28 x $eq -28"
+    @test string(con3) == "0 $eq -1"
     return
 end
 
@@ -741,10 +741,10 @@ function test_constraints()
     @test string(model) ==
           "Feasibility\n" *
           "Subject to\n" *
-          " x + y[1] $eq 1.0\n" *
-          " ref[1] : 2 y[1] $ge 1.0\n" *
-          " ref[2] : y[1] + y[2] $ge 2.0\n" *
-          " ref[3] : y[1] + y[3] $ge 3.0\n"
+          " x + y[1] $eq 1\n" *
+          " ref[1] : 2 y[1] $ge 1\n" *
+          " ref[2] : y[1] + y[2] $ge 2\n" *
+          " ref[3] : y[1] + y[3] $ge 3\n"
     return
 end
 

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -486,24 +486,24 @@ function test_extension_printing_scalaraffinefunction_constraints(
     @constraint(model, linear_eq, x + 0 == 1)
     @constraint(model, linear_range, -1 <= x + 0 <= 1)
     linear_noname = @constraint(model, x + 0 <= 1)
-    io_test(MIME("text/plain"), linear_le, "linear_le : x $le 1.0")
-    io_test(MIME("text/plain"), linear_eq, "linear_eq : x $eq 1.0")
+    io_test(MIME("text/plain"), linear_le, "linear_le : x $le 1")
+    io_test(MIME("text/plain"), linear_eq, "linear_eq : x $eq 1")
     io_test(
         MIME("text/plain"),
         linear_range,
-        "linear_range : x $in_sym [-1.0, 1.0]",
+        "linear_range : x $in_sym [-1, 1]",
     )
-    io_test(MIME("text/plain"), linear_noname, "x $le 1.0")
+    io_test(MIME("text/plain"), linear_noname, "x $le 1")
     # io_test doesn't work here because constraints print with a mix of math
     # and non-math.
     @test sprint(show, "text/latex", linear_le) ==
-          "linear_le : \$ x \\leq 1.0 \$"
+          "linear_le : \$ x \\leq 1 \$"
     @test sprint(show, "text/latex", linear_ge) ==
-          "linear_ge : \$ x \\geq 1.0 \$"
-    @test sprint(show, "text/latex", linear_eq) == "linear_eq : \$ x = 1.0 \$"
+          "linear_ge : \$ x \\geq 1 \$"
+    @test sprint(show, "text/latex", linear_eq) == "linear_eq : \$ x = 1 \$"
     @test sprint(show, "text/latex", linear_range) ==
-          "linear_range : \$ x \\in \\[-1.0, 1.0\\] \$"
-    @test sprint(show, "text/latex", linear_noname) == "\$\$ x \\leq 1.0 \$\$"
+          "linear_range : \$ x \\in \\[-1, 1\\] \$"
+    @test sprint(show, "text/latex", linear_noname) == "\$\$ x \\leq 1 \$\$"
     return
 end
 
@@ -537,7 +537,7 @@ function test_extension_printing_scalarquadraticfunction_constraints(
     @variable(model, x)
     quad_constr = @constraint(model, 2x^2 <= 1)
 
-    io_test(MIME("text/plain"), quad_constr, "2 x$sq $le 1.0")
+    io_test(MIME("text/plain"), quad_constr, "2 x$sq $le 1")
     # TODO: Test in IJulia mode.
     return
 end
@@ -553,7 +553,7 @@ function test_extension_printing_indicator_constraints(
     @variable(model, y)
     ind_constr = @constraint(model, !x => {y <= 1})
 
-    io_test(MIME("text/plain"), ind_constr, "!x => {y $le 1.0}")
+    io_test(MIME("text/plain"), ind_constr, "!x => {y $le 1}")
     # TODO: Test in IJulia mode.
     return
 end
@@ -595,8 +595,8 @@ function test_model_printing()
         """
 Max a - b + 2 a1 - 10 x
 Subject to
- con : a + b - 10 c + c1 - 2 x $le 1.0
- a*b $le 2.0
+ con : a + b - 10 c + c1 - 2 x $le 1
+ a*b $le 2
  [a  b;
   b  x] $inset $(PSDCone())
  [a, b, c] $inset $(MOI.PositiveSemidefiniteConeTriangle(2))
@@ -604,15 +604,15 @@ Subject to
   c  x] $inset $(PSDCone())
  [a, b, c, x] $inset $(MOI.PositiveSemidefiniteConeSquare(2))
  soc : [-a + 1, u[1], u[2], u[3]] $inset $(MOI.SecondOrderCone(4))
- fi $eq 9.0
- a $ge 1.0
- c $ge -1.0
- a1 $ge 1.0
- c1 $ge -1.0
- b $le 1.0
- c $le 1.0
- b1 $le 1.0
- c1 $le 1.0
+ fi $eq 9
+ a $ge 1
+ c $ge -1
+ a1 $ge 1
+ c1 $ge -1
+ b $le 1
+ c $le 1
+ b1 $le 1
+ c1 $le 1
  a1 integer
  b1 integer
  c1 integer
@@ -655,8 +655,8 @@ Names registered in the model: a, a1, b, b1, c, c1, con, fi, soc, u, x, y, z""";
         model_1,
         "\\begin{aligned}\n" *
         "\\max\\quad & a - b + 2 a1 - 10 x\\\\\n" *
-        "\\text{Subject to} \\quad & a + b - 10 c + c1 - 2 x \\leq 1.0\\\\\n" *
-        " & a\\times b \\leq 2.0\\\\\n" *
+        "\\text{Subject to} \\quad & a + b - 10 c + c1 - 2 x \\leq 1\\\\\n" *
+        " & a\\times b \\leq 2\\\\\n" *
         " & \\begin{bmatrix}\n" *
         "a & b\\\\\n" *
         "\\cdot & x\\\\\n" *
@@ -668,15 +668,15 @@ Names registered in the model: a, a1, b, b1, c, c1, con, fi, soc, u, x, y, z""";
         "\\end{bmatrix} \\in \\text{$(PSDCone())}\\\\\n" *
         " & [a, b, c, x] \\in \\text{MathOptInterface.PositiveSemidefiniteConeSquare(2)}\\\\\n" *
         " & [-a + 1, u_{1}, u_{2}, u_{3}] \\in \\text{MathOptInterface.SecondOrderCone(4)}\\\\\n" *
-        " & fi = 9.0\\\\\n" *
-        " & a \\geq 1.0\\\\\n" *
-        " & c \\geq -1.0\\\\\n" *
-        " & a1 \\geq 1.0\\\\\n" *
-        " & c1 \\geq -1.0\\\\\n" *
-        " & b \\leq 1.0\\\\\n" *
-        " & c \\leq 1.0\\\\\n" *
-        " & b1 \\leq 1.0\\\\\n" *
-        " & c1 \\leq 1.0\\\\\n" *
+        " & fi = 9\\\\\n" *
+        " & a \\geq 1\\\\\n" *
+        " & c \\geq -1\\\\\n" *
+        " & a1 \\geq 1\\\\\n" *
+        " & c1 \\geq -1\\\\\n" *
+        " & b \\leq 1\\\\\n" *
+        " & c \\leq 1\\\\\n" *
+        " & b1 \\leq 1\\\\\n" *
+        " & c1 \\leq 1\\\\\n" *
         " & a1 \\in \\mathbb{Z}\\\\\n" *
         " & b1 \\in \\mathbb{Z}\\\\\n" *
         " & c1 \\in \\mathbb{Z}\\\\\n" *
@@ -788,7 +788,7 @@ function test_SingleVariable_constraints()
     model = Model()
     @variable(model, x >= 10)
     zero_one = @constraint(model, x in MOI.ZeroOne())
-    io_test(MIME("text/plain"), LowerBoundRef(x), "x $ge 10.0")
+    io_test(MIME("text/plain"), LowerBoundRef(x), "x $ge 10")
     io_test(MIME("text/plain"), zero_one, "x binary")
     # TODO: Test in IJulia mode
     return

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -496,10 +496,8 @@ function test_extension_printing_scalaraffinefunction_constraints(
     io_test(MIME("text/plain"), linear_noname, "x $le 1")
     # io_test doesn't work here because constraints print with a mix of math
     # and non-math.
-    @test sprint(show, "text/latex", linear_le) ==
-          "linear_le : \$ x \\leq 1 \$"
-    @test sprint(show, "text/latex", linear_ge) ==
-          "linear_ge : \$ x \\geq 1 \$"
+    @test sprint(show, "text/latex", linear_le) == "linear_le : \$ x \\leq 1 \$"
+    @test sprint(show, "text/latex", linear_ge) == "linear_ge : \$ x \\geq 1 \$"
     @test sprint(show, "text/latex", linear_eq) == "linear_eq : \$ x = 1 \$"
     @test sprint(show, "text/latex", linear_range) ==
           "linear_range : \$ x \\in \\[-1, 1\\] \$"

--- a/test/test_reified.jl
+++ b/test/test_reified.jl
@@ -44,7 +44,7 @@ function test_reified_equal_to()
     @variable(model, z, Bin)
     c = @constraint(model, z <--> {x == 1})
     eq_sym = JuMP._math_symbol(MIME("text/plain"), :eq)
-    @test sprint(show, c) == "z <--> {x $eq_sym 1.0}"
+    @test sprint(show, c) == "z <--> {x $eq_sym 1}"
     obj = constraint_object(c)
     @test obj.func == AffExpr[z, x]
     @test obj.set == MOI.Reified(MOI.EqualTo(1.0))

--- a/test/test_variable.jl
+++ b/test/test_variable.jl
@@ -1408,13 +1408,13 @@ function test_fix_discrete_variables()
     @variable(model, 1 <= y <= 10, Int, start = 2)
     @objective(model, Min, x + y)
     @test sprint(print, model) ==
-          "Min x + y\nSubject to\n y $ge 1.0\n y $le 10.0\n y integer\n x binary\n"
+          "Min x + y\nSubject to\n y $ge 1\n y $le 10\n y integer\n x binary\n"
     undo_relax = fix_discrete_variables(start_value, model)
     @test sprint(print, model) ==
-          "Min x + y\nSubject to\n x $eq 1.0\n y $eq 2.0\n"
+          "Min x + y\nSubject to\n x $eq 1\n y $eq 2\n"
     undo_relax()
     @test sprint(print, model) ==
-          "Min x + y\nSubject to\n y $ge 1.0\n y $le 10.0\n y integer\n x binary\n"
+          "Min x + y\nSubject to\n y $ge 1\n y $le 10\n y integer\n x binary\n"
     return
 end
 

--- a/test/test_variable.jl
+++ b/test/test_variable.jl
@@ -1410,8 +1410,7 @@ function test_fix_discrete_variables()
     @test sprint(print, model) ==
           "Min x + y\nSubject to\n y $ge 1\n y $le 10\n y integer\n x binary\n"
     undo_relax = fix_discrete_variables(start_value, model)
-    @test sprint(print, model) ==
-          "Min x + y\nSubject to\n x $eq 1\n y $eq 2\n"
+    @test sprint(print, model) == "Min x + y\nSubject to\n x $eq 1\n y $eq 2\n"
     undo_relax()
     @test sprint(print, model) ==
           "Min x + y\nSubject to\n y $ge 1\n y $le 10\n y integer\n x binary\n"


### PR DESCRIPTION
Closes #3339 

I don't know about this. If we're thinking of supporting arbitrary number types in JuMP, I'd lean the other way, and _remove_ the rounding when printing?