### PR TITLE
[docs] add InfiniteOpt to documentation

### DIFF
--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -122,7 +122,7 @@
 #   user = "chriscoey"
 [InfiniteOpt]
   user = "infiniteopt"
-  rev = "c280bf81cb8144077faec11d16bad7b5a09b0f6f"
+  rev = "jump-readme"
   filename = "docs/jump/README.md"
   extension = true
 # [Juniper]

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -120,6 +120,11 @@
 #   user = "GAMS-dev"
 # [Hypatia]
 #   user = "chriscoey"
+[InfiniteOpt]
+  user = "infiniteopt"
+  rev = "c280bf81cb8144077faec11d16bad7b5a09b0f6f"
+  filename = "docs/jump/README.md"
+  extension = true
 # [Juniper]
 #   user = "lanl-ansi"
 # [MadNLP]

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -122,7 +122,7 @@
 #   user = "chriscoey"
 [InfiniteOpt]
   user = "infiniteopt"
-  rev = "jump-readme"
+  rev = "v0.5.7"
   filename = "docs/jump/README.md"
   extension = true
 # [Juniper]


### PR DESCRIPTION
https://github.com/jump-dev/JuMP.jl/pull/3342 but on the `jump-dev` remote so that we can get a doc preview. I'll post the link once CI finishes.

https://jump.dev/JuMP.jl/previews/PR3343/packages/InfiniteOpt/