### PR TITLE
Speed up vectorization of symmetric matrices

### DIFF
--- a/src/sd.jl
+++ b/src/sd.jl
@@ -180,7 +180,7 @@ function reshape_set(
 )
     return PSDCone()
 end
-function vectorize(matrix::Matrix, ::SymmetricMatrixShape)
+function vectorize(matrix, ::SymmetricMatrixShape)
     n = LinearAlgebra.checksquare(matrix)
     return [matrix[i, j] for j in 1:n for i in 1:j]
 end
@@ -219,7 +219,7 @@ function reshape_vector(
     return matrix
 end
 
-function vectorize(matrix::Matrix, ::SkewSymmetricMatrixShape)
+function vectorize(matrix, ::SkewSymmetricMatrixShape)
     n = LinearAlgebra.checksquare(matrix)
     return [matrix[i, j] for j in 1:n for i in 1:j-1]
 end
@@ -246,7 +246,7 @@ function reshape_set(::MOI.PositiveSemidefiniteConeSquare, ::SquareMatrixShape)
 end
 vectorize(matrix::Matrix, ::SquareMatrixShape) = vec(matrix)
 
-function vectorize(matrix, shape::Union{SymmetricMatrixShape,SquareMatrixShape})
+function vectorize(matrix, shape::SquareMatrixShape)
     return vectorize(Matrix(matrix), shape)
 end
 
@@ -564,11 +564,7 @@ struct HermitianMatrixShape <: AbstractShape
     side_dimension::Int
 end
 
-function vectorize(matrix, shape::HermitianMatrixShape)
-    return vectorize(Matrix(matrix), shape)
-end
-
-function vectorize(matrix::Matrix, ::HermitianMatrixShape)
+function vectorize(matrix, ::HermitianMatrixShape)
     n = LinearAlgebra.checksquare(matrix)
     return vcat(
         vectorize(_real.(matrix), SymmetricMatrixShape(n)),

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -14,6 +14,7 @@ using JuMP
 using Test
 
 import LinearAlgebra
+import SparseArrays
 
 include(joinpath(@__DIR__, "utilities.jl"))
 
@@ -1592,6 +1593,16 @@ function test_semiinteger()
     c_obj = constraint_object(c)
     @test isequal_canonical(c_obj.func, y + 1)
     @test c_obj.set == MOI.Semiinteger(2.5, 3.0)
+    return
+end
+
+function test_symmetric_vectorize_allocations()
+    model = Model()
+    @variable(model, x[1:2])
+    C = SparseArrays.sparse([0 1; 0 0])
+    X = LinearAlgebra.Symmetric(C - SparseArrays.spdiagm(x))
+    @constraint(model, X in PSDCone())  # Once for compilation
+    @test (@allocated @constraint(model, X in PSDCone())) <= 944
     return
 end
 


### PR DESCRIPTION
Before https://github.com/jump-dev/JuMP.jl/pull/2107, we didn't do this conversion, I guess i just did it like to to make it similar to the `SquareMatrixShape` case but this gives unnecessary allocations if the matrix is already `Symmetric` and even more if the matrix is sparse as in https://discourse.julialang.org/t/out-of-memory-when-constructing-large-sparse-sdp-in-jump/98332/2

## Benchmark

Consider the following benchmark:
```julia
n = 1000
p = 0.01
C = sprandn(Float64, n, n, p)  
model = Model()
@variable(model, y[1:n])
@time @constraint(model, Symmetric(C - spdiagm(y)) in PSDCone())
```
On master, this gives
```
0.582551 seconds (10.06 M allocations: 696.425 MiB, 53.21% gc time)
```
After this PR, this gives
```
0.131655 seconds (2.58 M allocations: 186.525 MiB, 33.82% gc time)
```
The MOI way:
```julia
@time begin
func = MOI.VectorAffineFunction(
    [MOI.VectorAffineTerm(i, MOI.ScalarAffineTerm(1.0, index(y[i]))) for i in 1:n],
    JuMP.vectorize(C, SymmetricMatrixShape(n)),
)
set = MOI.PositiveSemidefiniteConeTriangle(n)
MOI.add_constraint(backend(model), func, set)
end
```
it gives
```
0.006370 seconds (33 allocations: 9.093 MiB)
```