### PR TITLE
Force extension-tests.yml to use JuMP branch

### DIFF
--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -36,5 +36,6 @@ jobs:
         shell: julia --color=yes {0}
         run: |
           import Pkg
+          Pkg.develop(Pkg.PackageSpec(; path = pwd()))
           Pkg.develop(ENV["PACKAGE"])
           Pkg.test(ENV["PACKAGE"])


### PR DESCRIPTION
This previously wasn't using the actual branch that it was run on.