### PR TITLE
Add Alpine.jl to extension-tests.yml

### DIFF
--- a/.github/workflows/extension-tests.yml
+++ b/.github/workflows/extension-tests.yml
@@ -11,6 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - package: 'Alpine'
           - package: 'BilevelJuMP'
           - package: 'InfiniteOpt'
           - package: 'LinearFractional'


### PR DESCRIPTION
Alpine isn't strictly an extension, but it uses JuMP internally, so it's a useful thing to test.