### PR TITLE
[docs] Color the Julia logs on CI

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,12 +17,12 @@ jobs:
           # Build documentation on Julia 1.6
           version: '1.6'
       - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        run: julia --color=yes --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-        run: julia --project=docs/ docs/make.jl
+        run: julia --color=yes --project=docs/ docs/make.jl
       - uses: errata-ai/vale-action@reviewdog
         with:
           files: docs/src


### PR DESCRIPTION
I noticed that they're pretty gray: https://github.com/jump-dev/JuMP.jl/actions/runs/5085355976/jobs/9138739849?pr=3386