### PR TITLE
Fix printing of constraints in text/latex mode

### DIFF
--- a/src/print.jl
+++ b/src/print.jl
@@ -808,17 +808,16 @@ function constraint_string(
     constraint_object::AbstractConstraint;
     in_math_mode::Bool = false,
 )
-    prefix = isempty(constraint_name) ? "" : constraint_name * " : "
     constraint_str = constraint_string(mode, constraint_object)
     if mode == MIME("text/latex")
+        # Do not print names in text/latex mode.
         if in_math_mode
             return constraint_str
-        elseif isempty(prefix)
-            return _wrap_in_math_mode(constraint_str)
         else
-            return prefix * _wrap_in_inline_math_mode(constraint_str)
+            return _wrap_in_math_mode(constraint_str)
         end
     end
+    prefix = isempty(constraint_name) ? "" : constraint_name * " : "
     return prefix * constraint_str
 end
 

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -496,11 +496,11 @@ function test_extension_printing_scalaraffinefunction_constraints(
     io_test(MIME("text/plain"), linear_noname, "x $le 1")
     # io_test doesn't work here because constraints print with a mix of math
     # and non-math.
-    @test sprint(show, "text/latex", linear_le) == "linear_le : \$ x \\leq 1 \$"
-    @test sprint(show, "text/latex", linear_ge) == "linear_ge : \$ x \\geq 1 \$"
-    @test sprint(show, "text/latex", linear_eq) == "linear_eq : \$ x = 1 \$"
+    @test sprint(show, "text/latex", linear_le) == "\$\$ x \\leq 1 \$\$"
+    @test sprint(show, "text/latex", linear_ge) == "\$\$ x \\geq 1 \$\$"
+    @test sprint(show, "text/latex", linear_eq) == "\$\$ x = 1 \$\$"
     @test sprint(show, "text/latex", linear_range) ==
-          "linear_range : \$ x \\in \\[-1, 1\\] \$"
+          "\$\$ x \\in \\[-1, 1\\] \$\$"
     @test sprint(show, "text/latex", linear_noname) == "\$\$ x \\leq 1 \$\$"
     return
 end


### PR DESCRIPTION
Turns out latex printing of constraints has always been broken.

See https://github.com/jump-dev/JuMP.jl/pull/3385#issuecomment-1562255573