### PR TITLE
Fix performance of Containers.rowtable

### DIFF
--- a/src/Containers/tables.jl
+++ b/src/Containers/tables.jl
@@ -50,7 +50,7 @@ function rowtable(
     f::Function,
     x::Union{Array,DenseAxisArray,SparseAxisArray};
     header::Vector{Symbol} = Symbol[],
-)
+)::Vector{<:NamedTuple}
     if isempty(header)
         header = Symbol[Symbol("x$i") for i in 1:ndims(x)]
         push!(header, :y)
@@ -61,8 +61,8 @@ function rowtable(
             "Invalid number of column names provided: Got $got, expected $want.",
         )
     end
-    names = tuple(header...)
-    return [NamedTuple{names}((args..., f(x[i]))) for (i, args) in _rows(x)]
+    elements = [(args..., x[i]) for (i, args) in Containers._rows(x)]
+    return NamedTuple{tuple(header...)}.(elements)
 end
 
 rowtable(x; kwargs...) = rowtable(identity, x; kwargs...)

--- a/src/Containers/tables.jl
+++ b/src/Containers/tables.jl
@@ -61,7 +61,7 @@ function rowtable(
             "Invalid number of column names provided: Got $got, expected $want.",
         )
     end
-    elements = [(args..., x[i]) for (i, args) in Containers._rows(x)]
+    elements = [(args..., f(x[i])) for (i, args) in Containers._rows(x)]
     return NamedTuple{tuple(header...)}.(elements)
 end
 


### PR DESCRIPTION
Closes #3404.

Julia 1.6

```julia
julia> using JuMP.Containers

julia> Containers.@container(x[i=1:100, j=1:50], i + j);

julia> function foo(x, header)
           names = tuple(header...)
           return [NamedTuple{names}((args..., x[i])) for (i, args) in Containers._rows(x)]
       end
foo (generic function with 1 method)

julia> function bar(x, header)
           elements = [(args..., x[i]) for (i, args) in Containers._rows(x)]
           return NamedTuple{tuple(header...)}.(elements)
       end
bar (generic function with 1 method)

julia> @assert foo(x, [:i, :j, :k]) == bar(x, [:i, :j, :k])

julia> @time foo(x, [:i, :j, :k]);
  0.006314 seconds (30.02 k allocations: 1.597 MiB)

julia> @time bar(x, [:i, :j, :k]);
  0.000154 seconds (23 allocations: 502.297 KiB)
```

Julia 1.9

```Julia
julia> using JuMP.Containers

julia> Containers.@container(x[i=1:100, j=1:50], i + j);

julia> function foo(x, header)
           names = tuple(header...)
           return [NamedTuple{names}((args..., x[i])) for (i, args) in Containers._rows(x)]
       end
foo (generic function with 1 method)

julia> function bar(x, header)
           elements = [(args..., x[i]) for (i, args) in Containers._rows(x)]
           return NamedTuple{tuple(header...)}.(elements)
       end
bar (generic function with 1 method)

julia> @assert foo(x, [:i, :j, :k]) == bar(x, [:i, :j, :k])

julia> @time foo(x, [:i, :j, :k]);
  0.378728 seconds (140.02 k allocations: 5.545 MiB)

julia> @time bar(x, [:i, :j, :k]);
  0.000079 seconds (18 allocations: 482.516 KiB)
```

I don't understand the reason for the regression in 1.9. But this is better regardless.