### PR TITLE
[docs] don't at JuliaRegistrator in checklist

### DIFF
--- a/docs/src/developers/checklists.md
+++ b/docs/src/developers/checklists.md
@@ -30,11 +30,10 @@ done in the same commit, or separately. The last commit should have the message
  - [ ] Change the version number in `Project.toml`
  - [ ] Update the links in README.md
  - [ ] The commit messages in this PR do not contain `[ci skip]`
-       (See [Documenter#965](https://github.com/JuliaDocs/Documenter.jl/issues/965).)
 
 ## The release
 
- - [ ] After merging this pull request, comment `@JuliaRegistrator register` in
+ - [ ] After merging this pull request, comment `[at]JuliaRegistrator register` in
        the GitHub commit. This should automatically publish a new version to the
        Julia registry, as well as create a tag, and rebuild the documentation
        for this tag.


### PR DESCRIPTION
JuliaRegistrator listens to everything: https://github.com/jump-dev/JuMP.jl/pull/3417#issuecomment-1583803954

 Apparently even if you don't explicitly ping it and the command is in a code block.

`[at]JuliaRegistrator register` can you hear this?