### PR TITLE
Add fallback for MOI.AbstractSymmetricMatrixSet{Triangle,Square}

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -781,7 +781,7 @@ end
 
 function build_constraint(
     _error::Function,
-    x::Matrix,
+    x::AbstractMatrix,
     set::MOI.AbstractVectorSet,
 )
     return _error(
@@ -793,10 +793,7 @@ end
 function build_constraint(
     _error::Function,
     ::Matrix,
-    T::Union{
-        MOI.PositiveSemidefiniteConeSquare,
-        MOI.PositiveSemidefiniteConeTriangle,
-    },
+    T::MOI.PositiveSemidefiniteConeTriangle,
 )
     return _error("instead of `$(T)`, use `JuMP.PSDCone()`.")
 end

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -653,15 +653,6 @@ function test_extension_PSD_constraint_errors(
     model = ModelType()
     @variable(model, X[1:2, 1:2])
     err = ErrorException(
-        "In `@constraint(model, X in MOI.PositiveSemidefiniteConeSquare(2))`:" *
-        " instead of `MathOptInterface.PositiveSemidefiniteConeSquare(2)`," *
-        " use `JuMP.PSDCone()`.",
-    )
-    @test_throws_strip(
-        err,
-        @constraint(model, X in MOI.PositiveSemidefiniteConeSquare(2))
-    )
-    err = ErrorException(
         "In `@constraint(model, X in MOI.PositiveSemidefiniteConeTriangle(2))`:" *
         " instead of `MathOptInterface.PositiveSemidefiniteConeTriangle(2)`," *
         " use `JuMP.PSDCone()`.",


### PR DESCRIPTION
Closes https://github.com/jump-dev/JuMP.jl/issues/2093

@blegat is this what you had in mind?

It should allow something like
```julia
@variable(model, X[1:2, 1:2], Symmetric)
@constraint(model, X in SumOfSquares.ScaledDiagonallyDominantConeTriangle(2))
```

But what is a good model to test?