### PR TITLE
Prep for v1.13.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuMP"
 uuid = "4076af6c-e467-56ae-b986-b466b2749572"
 repo = "https://github.com/jump-dev/JuMP.jl.git"
-version = "1.12.0"
+version = "1.13.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ embedded in [Julia](https://julialang.org/). You can find out more about us by
 visiting [jump.dev](https://jump.dev).
 
 
-**Latest Release**: [![version](https://juliahub.com/docs/JuMP/DmXqY/1.12.0/version.svg)](https://juliahub.com/ui/Packages/JuMP/DmXqY/1.12.0) (`release-1.0` branch):
+**Latest Release**: [![version](https://juliahub.com/docs/JuMP/DmXqY/1.13.0/version.svg)](https://juliahub.com/ui/Packages/JuMP/DmXqY/1.13.0) (`release-1.0` branch):
   * Installation via the Julia package manager:
     * `import Pkg; Pkg.add("JuMP")`
   * Get help:

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,7 +7,7 @@ CurrentModule = JuMP
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Version 1.13.0 (July 26, 2023)
+## Version 1.13.0 (July 27, 2023)
 
 ### Added
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
- - Added support for generic number type (#3377) (#3385)
+ - Added support for generic number types (#3377) (#3385)
  - Added fallback for [`MOI.AbstractSymmetricMatrixSetTriangle`](@ref) and
    [`MOI.AbstractSymmetricMatrixSetSquare`](@ref) (#3424)
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
  - Added support for generic number type (#3377) (#3385)
- - Added fallback for [`MOI.AbstractSymmetricMatrixSet`](@ref) (#3424)
+ - Added fallback for [`MOI.AbstractSymmetricMatrixSetTriangle`](@ref) and
+   [`MOI.AbstractSymmetricMatrixSetSquare`](@ref) (#3424)
 
 ### Fixed
 
@@ -26,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Added Loraine.jl to the installation table (#3426)
  - Removed Penopt.jl from packages.toml (#3428)
  - Improved problem statement in cannery example of tutorial (#3430)
- - Minor cleanups in [`DenseAxisArray`](@ref) implementation (#3429)
+ - Minor cleanups in [`Containers.DenseAxisArray`](@ref) implementation (#3429)
  - Changed `nested_problems.jl`: outer/inner to upper/lower (#3433)
  - Removed second SDP relaxation due to unreliable numerics in OPF tutorial
    (#3432)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,7 +7,7 @@ CurrentModule = JuMP
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Version 1.13.0 (July 25, 2023)
+## Version 1.13.0 (July 26, 2023)
 
 ### Added
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Improved problem statement in cannery example of tutorial (#3430)
  - Minor cleanups in [`Containers.DenseAxisArray`](@ref) implementation (#3429)
  - Changed `nested_problems.jl`: outer/inner to upper/lower (#3433)
- - Removed second SDP relaxation due to unreliable numerics in OPF tutorial
+ - Removed second SDP relaxation in OPF tutorial
    (#3432)
 
 ## Version 1.12.0 (June 19, 2023)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,30 @@ CurrentModule = JuMP
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version 1.13.0 (July 24, 2023)
+
+### Added
+
+ - Added support for generic number type (#3377) (#3385)
+ - Added fallback for [`MOI.AbstractSymmetricMatrixSet`](@ref) (#3424)
+
+### Fixed
+
+ - Fixed [`set_start_values`](@ref) with
+   [`MOI.Bridge.Objective.SlackBridge`](@ref) (#3422)
+ - Fixed flakey doctest in `variables.md` (#3425)
+ - Fixed names on `CITATION.bib` (#3423)
+
+### Other
+
+ - Added Loraine.jl to the installation table (#3426)
+ - Removed Penopt.jl from packages.toml (#3428)
+ - Improved problem statement in cannery example of tutorial (#3430)
+ - Minor cleanups in [`DenseAxisArray`](@ref) implementation (#3429)
+ - Changed `nested_problems.jl` : outer/inner to upper/lower (#3433)
+ - Removed second SDP relaxation due to unreliable numerics in OPF tutorial
+   (#3432)
+
 ## Version 1.12.0 (June 19, 2023)
 
 ### Added

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,7 +7,7 @@ CurrentModule = JuMP
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Version 1.13.0 (July 24, 2023)
+## Version 1.13.0 (July 25, 2023)
 
 ### Added
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
  - Fixed [`set_start_values`](@ref) with
-   [`MOI.Bridge.Objective.SlackBridge`](@ref) (#3422)
+   [`MOI.Bridges.Objective.SlackBridge`](@ref) (#3422)
  - Fixed flakey doctest in `variables.md` (#3425)
  - Fixed names on `CITATION.bib` (#3423)
 
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Removed Penopt.jl from packages.toml (#3428)
  - Improved problem statement in cannery example of tutorial (#3430)
  - Minor cleanups in [`DenseAxisArray`](@ref) implementation (#3429)
- - Changed `nested_problems.jl` : outer/inner to upper/lower (#3433)
+ - Changed `nested_problems.jl`: outer/inner to upper/lower (#3433)
  - Removed second SDP relaxation due to unreliable numerics in OPF tutorial
    (#3432)
 


### PR DESCRIPTION
We need to wait for

- [x] https://github.com/jump-dev/JuMP.jl/pull/3434

## Pre-release

 - [ ] Check that the pinned packages in `docs/Project.toml` are updated. We pin
       the versions so that changes in the solvers (changes in printing, small
       numeric changes) do not break the printing of the JuMP docs in arbitrary
       commits.
 - [ ] Check that the `rev` fields in `docs/packages.toml` are updated. We pin
       the versions of solvers and extensions to ensure that changes to their
       READMEs do not break the JuMP docs in arbitrary commits, and to ensure
       that the versions are compatible with the latest JuMP and
       MathOptInterface releases.
 - [x] Update `docs/src/changelog.md`
 - [x] https://github.com/jump-dev/JuMP.jl/actions/runs/5642902565
 - [x] Change the version number in `Project.toml`
 - [x] Update the links in README.md
 - [x] The commit messages in this PR do not contain `[ci skip]`

## The release

 - [ ] After merging this pull request, comment `[at]JuliaRegistrator register` in
       the GitHub commit. This should automatically publish a new version to the
       Julia registry, as well as create a tag, and rebuild the documentation
       for this tag.

       These steps can take quite a bit of time (1 hour or more), so don't be
       surprised if the new documentation takes a while to appear. In addition,
       the links in the README will be broken until JuliaHub fetches the new
       version on their servers.

## Post-release

 - [ ] Once the tag is created, update the relevant `release-` branch. The latest
       release branch at the time of writing is `release-1.0` (we haven't
       back-ported any patches that needed to create a `release-1.Y` branch). To
       to update the release branch with the v1.10.0 tag, do:
       ```
       git checkout release-1.0
       git pull
       git merge v1.10.0
       git push
       ```