### PR TITLE
Add ci for release v0.18

### DIFF
--- a/.github/workflow/TagBot.yml
+++ b/.github/workflow/TagBot.yml
@@ -1,0 +1,15 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflow/ci.yml
+++ b/.github/workflow/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+on:
+  push:
+    branches:
+      - master
+      - release-*
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Since JuMP doesn't have binary dependencies, only test on a subset of
+        # possible platforms.
+        include:
+          - version: '1'  # The latest point-release (Linux)
+            os: ubuntu-latest
+            arch: x64
+          - version: '1'  # The latest point-release (Windows)
+            os: windows-latest
+            arch: x64
+          - version: '1.6'  # 1.6 LTS (64-bit Linux)
+            os: ubuntu-latest
+            arch: x64
+          - version: '1.6'  # 1.6 LTS (32-bit Linux)
+            os: ubuntu-latest
+            arch: x86
+          - version: '1.0'  # 1.0 LTS (64-bit Linux)
+            os: ubuntu-latest
+            arch: x64
+          - version: '1.0'  # 1.0 LTS (32-bit Linux)
+            os: ubuntu-latest
+            arch: x86
+          - version: 'nightly'
+            os: ubuntu-latest
+            arch: x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          depwarn: error
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info


### PR DESCRIPTION
Same as for master but I added v1.0. We cannot drop it from v0.18 since you cannot drop a Julia version without doing a breaking release.