### PR TITLE
Fix printing of models with large integers

### DIFF
--- a/src/print.jl
+++ b/src/print.jl
@@ -72,8 +72,8 @@ end
 # e.g.   5.3  =>  5.3
 #        1.0  =>  1
 function _string_round(x::Union{Float32,Float64})
-    if isinteger(x) && typemin(Int) <= x <= typemax(Int)
-        return string(round(Int, x))
+    if isinteger(x) && typemin(Int64) <= x <= typemax(Int64)
+        return string(round(Int64, x))
     end
     return string(x)
 end

--- a/src/print.jl
+++ b/src/print.jl
@@ -72,7 +72,10 @@ end
 # e.g.   5.3  =>  5.3
 #        1.0  =>  1
 function _string_round(x::Union{Float32,Float64})
-    return isinteger(x) ? string(round(Int, x)) : string(x)
+    if isinteger(x) && typemin(Int) <= x <= typemax(Int)
+        return string(round(Int, x))
+    end
+    return string(x)
 end
 
 _string_round(::typeof(abs), x::Real) = _string_round(abs(x))

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -952,9 +952,11 @@ function test_print_model_with_huge_integers()
     model = Model()
     @variable(model, x)
     c = @constraint(model, 1e20 * x == 42)
-    @test sprint(io -> show(io, MIME("text/plain"), c)) == "1.0e20 x = 42"
+    eq = JuMP._math_symbol(MIME("text/plain"), :eq)
+    @test sprint(io -> show(io, MIME("text/plain"), c)) == "1.0e20 x $eq 42"
+    eq = JuMP._math_symbol(MIME("text/latex"), :eq)
     @test sprint(io -> show(io, MIME("text/latex"), c)) ==
-          "\$\$ 1.0e20 x = 42 \$\$"
+          "\$\$ 1.0e20 x $eq 42 \$\$"
     return
 end
 

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -897,4 +897,65 @@ function test_print_complex_string_round()
     return
 end
 
+function test_print_huge_integer_string_round()
+    @test JuMP._string_round(-1 + Float32(typemax(Int32))) == "2147483648"
+    @test JuMP._string_round(-1 + Float32(typemin(Int32))) == "-2147483648"
+    @test JuMP._string_round(-1 + Float64(typemax(Int32))) == "2147483646"
+    @test JuMP._string_round(-1 + Float64(typemin(Int32))) == "-2147483649"
+
+    @test JuMP._string_round(Float32(typemax(Int32))) == "2147483648"
+    @test JuMP._string_round(Float32(typemin(Int32))) == "-2147483648"
+    @test JuMP._string_round(Float64(typemax(Int32))) == "2147483647"
+    @test JuMP._string_round(Float64(typemin(Int32))) == "-2147483648"
+
+    @test JuMP._string_round(1 + Float32(typemax(Int32))) == "2147483648"
+    @test JuMP._string_round(1 + Float32(typemin(Int32))) == "-2147483648"
+    @test JuMP._string_round(1 + Float64(typemax(Int32))) == "2147483648"
+    @test JuMP._string_round(1 + Float64(typemin(Int32))) == "-2147483647"
+
+    @test JuMP._string_round(2 * Float32(typemax(Int32))) == "4294967296"
+    @test JuMP._string_round(2 * Float32(typemin(Int32))) == "-4294967296"
+    @test JuMP._string_round(2 * Float64(typemax(Int32))) == "4294967294"
+    @test JuMP._string_round(2 * Float64(typemin(Int32))) == "-4294967296"
+
+    @test JuMP._string_round(-1 + Float32(typemax(Int64))) == "9.223372e18"
+    @test JuMP._string_round(-1 + Float32(typemin(Int64))) ==
+          "-9223372036854775808"
+    @test JuMP._string_round(-1 + Float64(typemax(Int64))) ==
+          "9.223372036854776e18"
+    @test JuMP._string_round(-1 + Float64(typemin(Int64))) ==
+          "-9223372036854775808"
+
+    @test JuMP._string_round(Float32(typemax(Int64))) == "9.223372e18"
+    @test JuMP._string_round(Float32(typemin(Int64))) == "-9223372036854775808"
+    @test JuMP._string_round(Float64(typemax(Int64))) == "9.223372036854776e18"
+    @test JuMP._string_round(Float64(typemin(Int64))) == "-9223372036854775808"
+
+    @test JuMP._string_round(1 + Float32(typemax(Int64))) == "9.223372e18"
+    @test JuMP._string_round(1 + Float32(typemin(Int64))) ==
+          "-9223372036854775808"
+    @test JuMP._string_round(1 + Float64(typemax(Int64))) ==
+          "9.223372036854776e18"
+    @test JuMP._string_round(1 + Float64(typemin(Int64))) ==
+          "-9223372036854775808"
+
+    @test JuMP._string_round(2 * Float32(typemax(Int64))) == "1.8446744e19"
+    @test JuMP._string_round(2 * Float32(typemin(Int64))) == "-1.8446744e19"
+    @test JuMP._string_round(2 * Float64(typemax(Int64))) ==
+          "1.8446744073709552e19"
+    @test JuMP._string_round(2 * Float64(typemin(Int64))) ==
+          "-1.8446744073709552e19"
+    return
+end
+
+function test_print_model_with_huge_integers()
+    model = Model()
+    @variable(model, x)
+    c = @constraint(model, 1e20 * x == 42)
+    @test sprint(io -> show(io, MIME("text/plain"), c)) == "1.0e20 x = 42"
+    @test sprint(io -> show(io, MIME("text/latex"), c)) ==
+          "\$\$ 1.0e20 x = 42 \$\$"
+    return
+end
+
 end


### PR DESCRIPTION
Consider:
```
using JuMP, Ipopt
opt_model = Model(Ipopt.Optimizer, add_bridges = false)
@variable(opt_model, p)
@constraint(opt_model, p * 1e20 == 42)
print(opt_model)
```
```
InexactError: trunc(Int64, 1.0e20)

Stacktrace:
  [1] trunc
    @ ./float.jl:893 [inlined]
  [2] round
    @ ./float.jl:384 [inlined]
  [3] _string_round
    @ ~/.julia/packages/JuMP/jZvaU/src/print.jl:75 [inlined]
```

This did come up in an non-artificial situation.

In general, FP->Int cast, where the source FP value is larger than the largest integer of the target type is UB, and julia rightfully notices that.

Tests seem to suggest that edge cases at least don't cause UB.