### PR TITLE
Prep for v1.14.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuMP"
 uuid = "4076af6c-e467-56ae-b986-b466b2749572"
 repo = "https://github.com/jump-dev/JuMP.jl.git"
-version = "1.13.0"
+version = "1.14.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ embedded in [Julia](https://julialang.org/). You can find out more about us by
 visiting [jump.dev](https://jump.dev).
 
 
-**Latest Release**: [![version](https://juliahub.com/docs/JuMP/DmXqY/1.13.0/version.svg)](https://juliahub.com/ui/Packages/JuMP/DmXqY/1.13.0) (`release-1.0` branch):
+**Latest Release**: [![version](https://juliahub.com/docs/JuMP/DmXqY/1.14.0/version.svg)](https://juliahub.com/ui/Packages/JuMP/DmXqY/1.14.0) (`release-1.0` branch):
   * Installation via the Julia package manager:
     * `import Pkg; Pkg.add("JuMP")`
   * Get help:

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
- - Updated packages used in documenntation (#3444) (#3455)
+ - Updated packages used in documentation (#3444) (#3455)
  - Fixed docstring tests (#3445)
  - Fixed printing change for MathOptInterface (#3446)
  - Fixed typos in documentation (#3448) (#3457)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,34 @@ CurrentModule = JuMP
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version 1.14.0 (August 27, 2023)
+
+### Added
+
+ - Added [DimensionalData.jl](@ref) extension (#3413)
+ - Added syntactic sugar for the [`MOI.Parameter`](@ref) set (#3443)
+    * [`Parameter`](@ref)
+    * [`ParameterRef`](@ref)
+    * [`is_parameter`](@ref)
+    * [`parameter_value`](@ref)
+    * [`set_parameter_value`](@ref)
+
+### Fixed
+
+ - Fixed `model_convert` for `BridgeableConstraint` (#3437)
+ - Fixed printing models with integer coefficients larger than `typemax(Int)`
+   (#3447)
+ - Fixed support for constant left-hand side functions in a complementarity
+   constraint (#3452)
+
+### Other
+
+ - Updated packages used in documenntation (#3444) (#3455)
+ - Fixed docstring tests (#3445)
+ - Fixed printing change for MathOptInterface (#3446)
+ - Fixed typos in documentation (#3448) (#3457)
+ - Added SCIP to callback documentation (#3449)
+
 ## Version 1.13.0 (July 27, 2023)
 
 ### Added


### PR DESCRIPTION
It seems like we're close to merging #3106. Since it's such a large change, I'd like to minimize the number of PRs in that release, so let's tag a release with the current changes.

## Pre-release

 - [x] Check that the pinned packages in `docs/Project.toml` are updated. We pin
       the versions so that changes in the solvers (changes in printing, small
       numeric changes) do not break the printing of the JuMP docs in arbitrary
       commits.
 - [x] Check that the `rev` fields in `docs/packages.toml` are updated. We pin
       the versions of solvers and extensions to ensure that changes to their
       READMEs do not break the JuMP docs in arbitrary commits, and to ensure
       that the versions are compatible with the latest JuMP and
       MathOptInterface releases.
 - [x] Update `docs/src/changelog.md`
 - [x] https://github.com/jump-dev/JuMP.jl/actions/runs/5983112229
 - [x] Change the version number in `Project.toml`
 - [x] Update the links in README.md
 - [x] The commit messages in this PR do not contain `[ci skip]`

## The release

 - [ ] After merging this pull request, comment `[at]JuliaRegistrator register` in
       the GitHub commit. This should automatically publish a new version to the
       Julia registry, as well as create a tag, and rebuild the documentation
       for this tag.

       These steps can take quite a bit of time (1 hour or more), so don't be
       surprised if the new documentation takes a while to appear. In addition,
       the links in the README will be broken until JuliaHub fetches the new
       version on their servers.

## Post-release

 - [ ] Once the tag is created, update the relevant `release-` branch. The latest
       release branch at the time of writing is `release-1.0` (we haven't
       back-ported any patches that needed to create a `release-1.Y` branch). To
       to update the release branch with the v1.10.0 tag, do:
       ```
       git checkout release-1.0
       git pull
       git merge v1.10.0
       git push
       ```