### PR TITLE
[docs] update The diet problem

### DIFF
--- a/docs/src/tutorials/linear/diet.jl
+++ b/docs/src/tutorials/linear/diet.jl
@@ -6,7 +6,7 @@
 # # The diet problem
 
 # The purpose of this tutorial is to demonstrate how to incorporate DataFrames
-# into a JuMP mdoel. As an example, we use classic [Stigler diet problem](https://en.wikipedia.org/wiki/Stigler_diet).
+# into a JuMP model. As an example, we use classic [Stigler diet problem](https://en.wikipedia.org/wiki/Stigler_diet).
 
 # ## Required packages
 
@@ -53,7 +53,7 @@ import Test  #hide
 
 dir = mktempdir()
 
-# The first file is a list of foods with their macronutrient profile:
+# The first file is a list of foods with their macro-nutrient profile:
 
 food_csv_filename = joinpath(dir, "diet_foods.csv")
 open(food_csv_filename, "w") do io


### PR DESCRIPTION
I'm giving a few tutorials in October at https://cermics-lab.enpc.fr/seso2023/ and https://julia-users-paris.github.io/workshop/en/.

My plan is to work through a few of these examples, with little exercises at the bottom for people to try. I think it makes sense to add these to the JuMP documentation.

x-ref #3459 

Preview: https://jump.dev/JuMP.jl/previews/PR3460/tutorials/linear/diet/