### PR TITLE
[docs] update Rocket Control tutorial

### DIFF
--- a/docs/src/tutorials/nonlinear/rocket_control.jl
+++ b/docs/src/tutorials/nonlinear/rocket_control.jl
@@ -106,7 +106,7 @@ fix(u_t[T], 0.0; force = true)
 
 # Forces are defined as functions:
 
-D(x_h, x_v) = D_c * x_v^2 * exp(-h_c * (x_h - h_0) / h_0),
+D(x_h, x_v) = D_c * x_v^2 * exp(-h_c * (x_h - h_0) / h_0)
 g(x_h) = g_0 * (h_0 / x_h)^2
 
 # The dynamical equations are implemented as constraints.


### PR DESCRIPTION
I'm giving a few tutorials in October at https://cermics-lab.enpc.fr/seso2023/ and https://julia-users-paris.github.io/workshop/en/.

My plan is to work through a few of these examples, with little exercises at the bottom for people to try. I think it makes sense to add these to the JuMP documentation.

x-ref https://github.com/jump-dev/JuMP.jl/pull/3459

Preview: https://jump.dev/JuMP.jl/previews/PR3463/tutorials/nonlinear/rocket_control/