### PR TITLE
Fix use of @nospecialize with default arguments

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -172,7 +172,7 @@ GenericModel{BigFloat}
 ```
 """
 function GenericModel{T}(
-    (@nospecialize optimizer_factory) = nothing;
+    @nospecialize(optimizer_factory = nothing);
     add_bridges::Bool = true,
 ) where {T<:Real}
     inner = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{T}())

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -357,7 +357,7 @@ julia> set_optimizer(model, HiGHS.Optimizer; add_bridges = false)
 """
 function set_optimizer(
     model::GenericModel{T},
-    (@nospecialize optimizer_constructor);
+    @nospecialize(optimizer_constructor);
     add_bridges::Bool = true,
 ) where {T}
     error_if_direct_mode(model, :set_optimizer)


### PR DESCRIPTION
This is my fault for not reading the docstring carefully. (Although it worked for Julia 1.6.2+, so I guess I never bumped into the problem.)

Here's the docstring, with the relevant sentence:
```julia
help?> @nospecialize
  @nospecialize

  Applied to a function argument name, ... When applied to an argument, the
  macro must wrap the entire argument expression, e.g., @nospecialize(x::Real)
  or @nospecialize(i::Integer...) rather than wrapping just the argument name.
  ...
```

The docstring also contains this example, which I failed to see:
```julia
  function example_function(x, @nospecialize(y = 1))
      ...
  end
```

Closes #3461 