### PR TITLE
[docs] update Column generation tutorial

### DIFF
--- a/docs/src/tutorials/algorithms/cutting_stock_column_generation.jl
+++ b/docs/src/tutorials/algorithms/cutting_stock_column_generation.jl
@@ -116,7 +116,7 @@ set_silent(model)
 @objective(model, Min, sum(y))
 model
 
-# Unfortunately, we cant't solve this formulation because it takes a very long
+# Unfortunately, we can't solve this formulation because it takes a very long
 # time to solve. (Try removing the time limit.)
 
 set_time_limit_sec(model, 5.0)
@@ -205,7 +205,7 @@ function solve_pricing(data::Data, π::Vector{Float64})
     return SparseArrays.sparse(round.(Int, value.(y)))
 end
 
-# If we solve the pricing problem with an artifical dual vector:
+# If we solve the pricing problem with an artificial dual vector:
 
 π = [1.0 / i for i in 1:I]
 solve_pricing(data, π)

--- a/docs/src/tutorials/algorithms/cutting_stock_column_generation.jl
+++ b/docs/src/tutorials/algorithms/cutting_stock_column_generation.jl
@@ -250,7 +250,7 @@ solution_summary(model)
 
 # For example, the dual of `demand[13]` is:
 
-undo_relax = relax_integrality(model)  # undo_relax is used later
+unset_integer.(x)
 optimize!(model)
 π_13 = dual(demand[13])
 
@@ -360,7 +360,7 @@ sum(ceil.(Int, solution.rolls))
 # Alternatively, we can re-introduce the integrality constraints and resolve the
 # problem:
 
-undo_relax()  # `undo_relax` was the return value from `relax_integrality`
+set_integer.(x)
 optimize!(model)
 solution = DataFrames.DataFrame([
     (pattern = p, rolls = value(x_p)) for (p, x_p) in enumerate(x)


### PR DESCRIPTION
I'm giving a few tutorials in October at https://cermics-lab.enpc.fr/seso2023/ and https://julia-users-paris.github.io/workshop/en/.

My plan is to work through a few of these examples, with little exercises at the bottom for people to try. I think it makes sense to add these to the JuMP documentation.

x-ref https://github.com/jump-dev/JuMP.jl/pull/3459

Preview: https://jump.dev/JuMP.jl/previews/PR3465/tutorials/algorithms/cutting_stock_column_generation/