### PR TITLE
Change argument order of NonlinearOperator

### DIFF
--- a/docs/src/manual/nonlinear.md
+++ b/docs/src/manual/nonlinear.md
@@ -405,7 +405,7 @@ the operator using [`add_nonlinear_operator`](@ref) and define a new method
 which manually creates a [`NonlinearExpr`](@ref):
 ```jldoctest nonlinear_invalid_redefinition
 julia> _ = add_nonlinear_operator(model, 1, f; name = :f)
-NonlinearOperator(:f, f)
+NonlinearOperator(f, :f)
 
 julia> f(x::AbstractJuMPScalar) = NonlinearExpr(:f, Any[x])
 f (generic function with 2 methods)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -525,7 +525,7 @@ julia> op_and(true, x)
 true && x
 ```
 """
-const op_and = NonlinearOperator(:&&, &)
+const op_and = NonlinearOperator(&, :&&)
 # Note that the function is `&` instead of `&&` because `&&` is special lowering
 # syntax and is not a regular Julia function, but the MOI operator is `:&&`.
 
@@ -549,7 +549,7 @@ julia> op_or(true, x)
 true || x
 ```
 """
-const op_or = NonlinearOperator(:||, |)
+const op_or = NonlinearOperator(|, :||)
 # Note that the function is `|` instead of `||` because `||` is special lowering
 # syntax and is not a regular Julia function, but the MOI operator is `:||`.
 
@@ -573,7 +573,7 @@ julia> op_strictly_less_than(x, 2)
 x < 2
 ```
 """
-const op_strictly_less_than = NonlinearOperator(:<, <)
+const op_strictly_less_than = NonlinearOperator(<, :<)
 
 """
     op_strictly_greater_than(x, y)
@@ -595,7 +595,7 @@ julia> op_strictly_greater_than(x, 2)
 x > 2
 ```
 """
-const op_strictly_greater_than = NonlinearOperator(:>, >)
+const op_strictly_greater_than = NonlinearOperator(>, :>)
 
 """
     op_less_than_or_equal_to(x, y)
@@ -617,7 +617,7 @@ julia> op_less_than_or_equal_to(x, 2)
 x <= 2
 ```
 """
-const op_less_than_or_equal_to = NonlinearOperator(:<=, <=)
+const op_less_than_or_equal_to = NonlinearOperator(<=, :<=)
 
 """
     op_greater_than_or_equal_to(x, y)
@@ -639,7 +639,7 @@ julia> op_greater_than_or_equal_to(x, 2)
 x >= 2
 ```
 """
-const op_greater_than_or_equal_to = NonlinearOperator(:>=, >=)
+const op_greater_than_or_equal_to = NonlinearOperator(>=, :>=)
 
 """
     op_equal_to(x, y)
@@ -661,7 +661,7 @@ julia> op_equal_to(x, 2)
 x == 2
 ```
 """
-const op_equal_to = NonlinearOperator(:(==), ==)
+const op_equal_to = NonlinearOperator(==, :(==))
 
 function _rewrite_to_jump_logic(x)
     if Meta.isexpr(x, :call)

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -763,7 +763,7 @@ function _MA.promote_operation(
 end
 
 """
-    NonlinearOperator(head::Symbol, func::Function)
+    NonlinearOperator(func::Function, head::Symbol = Symbol(func))
 
 A callable struct (functor) representing a function named `head`.
 
@@ -795,10 +795,10 @@ julia> ∇²f(x::Float64) = 2.0
 ∇²f (generic function with 1 method)
 
 julia> @operator(model, op_f, 1, f, ∇f, ∇²f)
-NonlinearOperator(:op_f, f)
+NonlinearOperator(f, :op_f)
 
-julia> bar = NonlinearOperator(:op_f, f)
-NonlinearOperator(:op_f, f)
+julia> bar = NonlinearOperator(f, :op_f)
+NonlinearOperator(f, :op_f)
 
 julia> @objective(model, Min, bar(x))
 op_f(x)
@@ -808,13 +808,15 @@ julia> bar(2.0)
 ```
 """
 struct NonlinearOperator{F}
-    head::Symbol
     func::F
+    head::Symbol
 end
+
+NonlinearOperator(f::Function) = NonlinearOperator(f, Symbol(f))
 
 # Make it so that we don't print the complicated type parameter
 function Base.show(io::IO, f::NonlinearOperator)
-    return print(io, "NonlinearOperator(:$(f.head), $(f.func))")
+    return print(io, "NonlinearOperator(:$(f.func), $(f.head))")
 end
 
 # Fast overload for unary calls
@@ -906,7 +908,7 @@ julia> ∇²f(x::Float64) = 2.0
 ∇²f (generic function with 1 method)
 
 julia> op_f = add_nonlinear_operator(model, 1, f, ∇f, ∇²f)
-NonlinearOperator(:f, f)
+NonlinearOperator(f, :f)
 
 julia> @objective(model, Min, op_f(x))
 f(x)
@@ -936,7 +938,7 @@ function add_nonlinear_operator(
     # MOI.Nonlinear will automatically check for autodiff and common mistakes
     # and throw a nice informative error.
     MOI.set(model, MOI.UserDefinedFunction(name, dim), tuple(f, args...))
-    return NonlinearOperator(name, f)
+    return NonlinearOperator(f, name)
 end
 
 function _catch_redefinition_constant_error(op::Symbol, f::Function)
@@ -1022,7 +1024,7 @@ julia> ∇²f(x::Float64) = 2.0
 ∇²f (generic function with 1 method)
 
 julia> @operator(model, op_f, 1, f, ∇f, ∇²f)
-NonlinearOperator(:op_f, f)
+NonlinearOperator(f, :op_f)
 
 julia> @objective(model, Min, op_f(x))
 op_f(x)
@@ -1031,7 +1033,7 @@ julia> op_f(2.0)
 4.0
 
 julia> model[:op_f]
-NonlinearOperator(:op_f, f)
+NonlinearOperator(f, :op_f)
 
 julia> model[:op_f](x)
 op_f(x)
@@ -1050,7 +1052,7 @@ julia> f(x) = x^2
 f (generic function with 1 method)
 
 julia> @operator(model, op_f, 1, f)
-NonlinearOperator(:op_f, f)
+NonlinearOperator(f, :op_f)
 ```
 is equivalent to
 ```jldoctest
@@ -1060,7 +1062,7 @@ julia> f(x) = x^2
 f (generic function with 1 method)
 
 julia> op_f = model[:op_f] = add_nonlinear_operator(model, 1, f; name = :op_f)
-NonlinearOperator(:op_f, f)
+NonlinearOperator(f, :op_f)
 ```
 """
 macro operator(model, op, dim, f, args...)

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -814,7 +814,7 @@ end
 
 # Make it so that we don't print the complicated type parameter
 function Base.show(io::IO, f::NonlinearOperator)
-    return print(io, "NonlinearOperator(:$(f.func), $(f.head))")
+    return print(io, "NonlinearOperator($(f.func), :$(f.head))")
 end
 
 # Fast overload for unary calls

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -763,7 +763,7 @@ function _MA.promote_operation(
 end
 
 """
-    NonlinearOperator(func::Function, head::Symbol = Symbol(func))
+    NonlinearOperator(func::Function, head::Symbol)
 
 A callable struct (functor) representing a function named `head`.
 
@@ -811,8 +811,6 @@ struct NonlinearOperator{F}
     func::F
     head::Symbol
 end
-
-NonlinearOperator(f::Function) = NonlinearOperator(f, Symbol(f))
 
 # Make it so that we don't print the complicated type parameter
 function Base.show(io::IO, f::NonlinearOperator)

--- a/test/test_nlp_expr.jl
+++ b/test/test_nlp_expr.jl
@@ -480,11 +480,23 @@ function test_register_univariate()
     @variable(model, x)
     @operator(model, f, 1, x -> x^2)
     @test f isa NonlinearOperator
-    @test sprint(show, f) == "NonlinearOperator(:f, $(f.func))"
+    @test sprint(show, f) == "NonlinearOperator($(f.func), :f)"
     @test isequal_canonical(@expression(model, f(x)), f(x))
     @test isequal_canonical(f(x), GenericNonlinearExpr(:f, Any[x]))
     attrs = MOI.get(model, MOI.ListOfModelAttributesSet())
     @test MOI.UserDefinedFunction(:f, 1) in attrs
+    return
+end
+
+function test_operator_univariate()
+    model = Model()
+    @variable(model, x)
+    f(x) = x^2
+    op_f = NonlinearOperator(f)
+    @test f isa NonlinearOperator
+    @test sprint(show, f) == "NonlinearOperator($f, :f)"
+    @test isequal_canonical(@expression(model, f(x)), f(x))
+    @test isequal_canonical(f(x), GenericNonlinearExpr(:f, Any[x]))
     return
 end
 
@@ -624,7 +636,7 @@ function test_value_expression()
     y = QuadExpr(x + 1)
     @test value(f, my_foo(y)) ≈ (value(f, y) - 1)^2
     @test value(f, my_bar(2.2, x)) ≈ sqrt(2.2 - 1.1)
-    bad_udf = NonlinearOperator(:bad_udf, f)
+    bad_udf = NonlinearOperator(f, :bad_udf)
     @test_throws(
         ErrorException(
             "Unable to evaluate nonlinear operator bad_udf because it was " *

--- a/test/test_nlp_expr.jl
+++ b/test/test_nlp_expr.jl
@@ -492,7 +492,7 @@ function test_operator_univariate()
     model = Model()
     @variable(model, x)
     f(x) = x^2
-    op_f = NonlinearOperator(f)
+    op_f = NonlinearOperator(f, :f)
     @test f isa NonlinearOperator
     @test sprint(show, f) == "NonlinearOperator($f, :f)"
     @test isequal_canonical(@expression(model, f(x)), f(x))

--- a/test/test_nlp_expr.jl
+++ b/test/test_nlp_expr.jl
@@ -488,18 +488,6 @@ function test_register_univariate()
     return
 end
 
-function test_operator_univariate()
-    model = Model()
-    @variable(model, x)
-    f(x) = x^2
-    op_f = NonlinearOperator(f, :f)
-    @test f isa NonlinearOperator
-    @test sprint(show, f) == "NonlinearOperator($f, :f)"
-    @test isequal_canonical(@expression(model, f(x)), f(x))
-    @test isequal_canonical(f(x), GenericNonlinearExpr(:f, Any[x]))
-    return
-end
-
 function test_register_eval_non_jump()
     model = Model()
     @variable(model, x)


### PR DESCRIPTION
This also changes the order between the two because when one of the two has a default value depending on the other one it's usually the second positional argument.
It also allows to write `NonlinearOperator(func::Function, head::Symbol = Symbol(func))` in the docstring which wouldn't be possible if the order was reversed.
This change only matters when `NonlinearOperator` is called directly and not through `@operator`.
It seems to me that when `NonlinearOperator` is called directly, you would want the symbol to be the function name 99% of the time so having this default value makes sense. It's also the default in the `@operator` macro so it's consistent.