### PR TITLE
Prep for v1.14.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuMP"
 uuid = "4076af6c-e467-56ae-b986-b466b2749572"
 repo = "https://github.com/jump-dev/JuMP.jl.git"
-version = "1.14.0"
+version = "1.14.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ embedded in [Julia](https://julialang.org/). You can find out more about us by
 visiting [jump.dev](https://jump.dev).
 
 
-**Latest Release**: [![version](https://juliahub.com/docs/JuMP/DmXqY/1.14.0/version.svg)](https://juliahub.com/ui/Packages/JuMP/DmXqY/1.14.0) (`release-1.0` branch):
+**Latest Release**: [![version](https://juliahub.com/docs/JuMP/DmXqY/1.14.1/version.svg)](https://juliahub.com/ui/Packages/JuMP/DmXqY/1.14.1) (`release-1.0` branch):
   * Installation via the Julia package manager:
     * `import Pkg; Pkg.add("JuMP")`
   * Get help:

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,12 @@ CurrentModule = JuMP
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version 1.14.1 (September 2, 2023)
+
+### Fixed
+
+ - Fix links in Documentation (#3478)
+
 ## Version 1.14.0 (August 27, 2023)
 
 ### Added


### PR DESCRIPTION
Already tagged on the `release-0.14` branch. This PR just cherry-picks the commit onto `master`.