### PR TITLE
Prep for v1.15.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuMP"
 uuid = "4076af6c-e467-56ae-b986-b466b2749572"
 repo = "https://github.com/jump-dev/JuMP.jl.git"
-version = "1.14.1"
+version = "1.15.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ embedded in [Julia](https://julialang.org/). You can find out more about us by
 visiting [jump.dev](https://jump.dev).
 
 
-**Latest Release**: [![version](https://juliahub.com/docs/JuMP/DmXqY/1.14.1/version.svg)](https://juliahub.com/ui/Packages/JuMP/DmXqY/1.14.1) (`release-1.0` branch):
+**Latest Release**: [![version](https://juliahub.com/docs/JuMP/DmXqY/1.15.0/version.svg)](https://juliahub.com/ui/Packages/JuMP/DmXqY/1.15.0) (`release-1.0` branch):
   * Installation via the Julia package manager:
     * `import Pkg; Pkg.add("JuMP")`
   * Get help:

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -58,7 +58,7 @@ changes which might be breaking for a very small number of users.
  - Added the new nonlinear interface. This is a very large change. See the
    documentation at [Nonlinear Modeling](@ref) and the (long) discussion in
    [JuMP.jl#3106](https://github.com/jump-dev/JuMP.jl/pull/3106). Related PRs
-   are (#3468) (#3472) (#3475) (#3483) (#3487)
+   are (#3468) (#3472) (#3475) (#3483) (#3487) (#3488)
 
 ### Fixed
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,51 @@ CurrentModule = JuMP
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version 1.15.0 (unreleased)
+
+This is a large minor release because it adds an entirely new data structure and
+API path for working with nonlinear programs. The previous nonlinear interface
+remains unchanged and is documented at [Nonlinear Modeling (Legacy)](@ref). The
+new interface is a treated as a non-breaking feature addition and is documented
+at [Nonlinear Modeling](@ref).
+
+### Breaking
+
+The syntax inside JuMP macros is parsed using a different code path, even for
+linear and quadratic expressions. In all cases, the new code should return
+equivalent expressions, but there are three changes to be aware of when updating:
+
+ - The printed form of the expression may change, for example from `x * y` to
+   `y * x`. This can cause tests which test the `String` representation of a
+   model to fail.
+ - Because of the different order of operations, some coefficients may change
+   due to floating point round-off error.
+ - Because of the different order of operations, and particularly when working
+   with a JuMP extension, you may encounter a `MethodError` due to a missing or
+   ambiguous method. These errors are due to previously existing bugs that were
+   not triggered by the previous parsing code. If you encouter such an error,
+   please open a GitHub issue.
+
+### Added
+
+ - Added [`triangle_vec`](@ref) which simplifies adding [`MOI.LogDetConeTriangle`](@ref)
+   and [`MOI.RootDetConeTriangle`](@ref) constraints (#3456)
+ - Added new nonlinear interface (#3106) (#3468) (#3472) (#3475)
+
+### Fixed
+
+ - Fixed uses of `@nospecialize` which cause precompilation failures in Julia
+   v1.6.0 and v1.6.1. (#3464)
+ - Fixed adding a container of [`Parameter`](@ref) (#3473)
+
+### Other
+
+ - Added GAMS to solver documentation (#3357)
+ - Updated various tutorials (#3459) (#3460) (#3462) (#3463) (#3465)
+ - Added [Two-stage stochastic programs](@ref) tutorial (#3466)
+ - Added better error messages for unsupported operations in `LinearAlgebra` (#3476)
+ - Updated to the latest version of Documenter (#3484)
+
 ## Version 1.14.1 (September 2, 2023)
 
 ### Fixed

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -67,6 +67,9 @@ changes which might be breaking for a very small number of users.
  - Fixed adding a container of [`Parameter`](@ref) (#3473)
  - Fixed return type of `x^0` and `x^1` to no longer return `QuadExpr` (see note
    in `Breaking` section above) (#3474)
+ - Fixed error messages in [`LowerBoundRef`](@ref), [`UpperBoundRef`](@ref),
+   [`FixRef`](@ref), [`IntegerRef`](@ref), [`BinaryRef`](@ref),
+   [`ParameterRef`](@ref) and related functions (#3494)
 
 ### Other
 
@@ -75,7 +78,7 @@ changes which might be breaking for a very small number of users.
  - Added [The network multi-commodity flow problem](@ref) tutorial (#3491)
  - Added [Two-stage stochastic programs](@ref) tutorial (#3466)
  - Added better error messages for unsupported operations in `LinearAlgebra` (#3476)
- - Updated to the latest version of Documenter (#3484)
+ - Updated to the latest version of Documenter (#3484) (#3495)
 
 ## Version 1.14.1 (September 2, 2023)
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -58,7 +58,7 @@ changes which might be breaking for a very small number of users.
  - Added the new nonlinear interface. This is a very large change. See the
    documentation at [Nonlinear Modeling](@ref) and the (long) discussion in
    [JuMP.jl#3106](https://github.com/jump-dev/JuMP.jl/pull/3106). Related PRs
-   are (#3468) (#3472) (#3475) (#3483) (#3487) (#3488) (#3489) (#3504)
+   are (#3468) (#3472) (#3475) (#3483) (#3487) (#3488) (#3489) (#3504) (#3509)
 
 ### Fixed
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,7 +18,7 @@ at [Nonlinear Modeling](@ref).
 ### Breaking
 
 Although the new nonlinear interface is a feature addition, there are two
-changes which might be breaking for a small number of users.
+changes which might be breaking for a very small number of users.
 
  - The syntax inside JuMP macros is parsed using a different code path, even for
    linear and quadratic expressions. We made this change to unify how we parse
@@ -34,15 +34,15 @@ changes which might be breaking for a small number of users.
       `MethodError` due to a missing or ambiguous method. These errors are due
       to previously existing bugs that were not triggered by the previous
       parsing code. If you encounter such an error, please open a GitHub issue.
- - The methods for `Base.^(x::VariableRef, n::Integer)` and
-   `Base.^(x::AffExpr, n::Integer)` have changed. Previously, these methods
+ - The methods for `Base.:^(x::VariableRef, n::Integer)` and
+   `Base.:^(x::AffExpr, n::Integer)` have changed. Previously, these methods
    supported only `n = 0, 1, 2` and they always returned a [`QuadExpr`](@ref),
    even for the case when `n = 0` or `n = 1`. Now:
      - `x^0` returns `one(T)`, where `T` is the [`value_type`](@ref) of the
        model (defaults to `Float64`)
      - `x^1` returns `x`
      - `x^2` returns a [`QuadExpr`](@ref)
-     - `x^n` where `n > 2` returns a [`NonlinearExpr`](@ref).
+     - `x^n` where `!(0 <= n <= 2)` returns a [`NonlinearExpr`](@ref).
    We made this change to support nonlinear expressions and to align the
    mathematical definition of the operation with their return type. (Previously,
    users were surprised that `x^1` returned a [`QuadExpr`](@ref).) As a
@@ -55,7 +55,10 @@ changes which might be breaking for a small number of users.
 
  - Added [`triangle_vec`](@ref) which simplifies adding [`MOI.LogDetConeTriangle`](@ref)
    and [`MOI.RootDetConeTriangle`](@ref) constraints (#3456)
- - Added new nonlinear interface (#3106) (#3468) (#3472) (#3475)
+ - Added the new nonlinear interface. This is a very large change. See the
+   documentation at [Nonlinear Modeling](@ref) and the (long) discussion in
+   [JuMP.jl#3106](https://github.com/jump-dev/JuMP.jl/pull/3106). Related PRs
+   are (#3468) (#3472) (#3475) (#3483) (#3487)
 
 ### Fixed
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,7 +7,7 @@ CurrentModule = JuMP
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Version 1.15.0 (unreleased)
+## Version 1.15.0 (September 15, 2023)
 
 This is a large minor release because it adds an entirely new data structure and
 API path for working with nonlinear programs. The previous nonlinear interface
@@ -58,7 +58,7 @@ changes which might be breaking for a very small number of users.
  - Added the new nonlinear interface. This is a very large change. See the
    documentation at [Nonlinear Modeling](@ref) and the (long) discussion in
    [JuMP.jl#3106](https://github.com/jump-dev/JuMP.jl/pull/3106). Related PRs
-   are (#3468) (#3472) (#3475) (#3483) (#3487) (#3488)
+   are (#3468) (#3472) (#3475) (#3483) (#3487) (#3488) (#3489)
 
 ### Fixed
 
@@ -71,7 +71,8 @@ changes which might be breaking for a very small number of users.
 ### Other
 
  - Added GAMS to solver documentation (#3357)
- - Updated various tutorials (#3459) (#3460) (#3462) (#3463) (#3465)
+ - Updated various tutorials (#3459) (#3460) (#3462) (#3463) (#3465) (#3490) (#3492)
+ - Added [The network multi-commodity flow problem](@ref) tutorial (#3491)
  - Added [Two-stage stochastic programs](@ref) tutorial (#3466)
  - Added better error messages for unsupported operations in `LinearAlgebra` (#3476)
  - Updated to the latest version of Documenter (#3484)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -70,6 +70,7 @@ changes which might be breaking for a very small number of users.
  - Fixed error messages in [`LowerBoundRef`](@ref), [`UpperBoundRef`](@ref),
    [`FixRef`](@ref), [`IntegerRef`](@ref), [`BinaryRef`](@ref),
    [`ParameterRef`](@ref) and related functions (#3494)
+ - Fixed type inference of empty containers in JuMP macros (#3500)
 
 ### Other
 
@@ -80,6 +81,7 @@ changes which might be breaking for a very small number of users.
  - Added [Two-stage stochastic programs](@ref) tutorial (#3466)
  - Added better error messages for unsupported operations in `LinearAlgebra` (#3476)
  - Updated to the latest version of Documenter (#3484) (#3495) (#3497)
+ - Updated GitHub action versions (#3507)
 
 ## Version 1.14.1 (September 2, 2023)
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -58,7 +58,7 @@ changes which might be breaking for a very small number of users.
  - Added the new nonlinear interface. This is a very large change. See the
    documentation at [Nonlinear Modeling](@ref) and the (long) discussion in
    [JuMP.jl#3106](https://github.com/jump-dev/JuMP.jl/pull/3106). Related PRs
-   are (#3468) (#3472) (#3475) (#3483) (#3487) (#3488) (#3489)
+   are (#3468) (#3472) (#3475) (#3483) (#3487) (#3488) (#3489) (#3504)
 
 ### Fixed
 
@@ -75,10 +75,11 @@ changes which might be breaking for a very small number of users.
 
  - Added GAMS to solver documentation (#3357)
  - Updated various tutorials (#3459) (#3460) (#3462) (#3463) (#3465) (#3490) (#3492)
+   (#3503)
  - Added [The network multi-commodity flow problem](@ref) tutorial (#3491)
  - Added [Two-stage stochastic programs](@ref) tutorial (#3466)
  - Added better error messages for unsupported operations in `LinearAlgebra` (#3476)
- - Updated to the latest version of Documenter (#3484) (#3495)
+ - Updated to the latest version of Documenter (#3484) (#3495) (#3497)
 
 ## Version 1.14.1 (September 2, 2023)
 


### PR DESCRIPTION
Changelog preview: https://jump.dev/JuMP.jl/previews/PR3485/release_notes/

## TODO

 - [x] Add a note for https://github.com/jump-dev/JuMP.jl/pull/3474#issuecomment-1704504740
 - [x] https://github.com/jump-dev/JuMP.jl/pull/3483
 - [x] #3488 
 - [x] #3490 
 - [x] #3491
 - [x] #3492 
 - [x] #3489 
 - [x] #3494
 - [x] #3495
 - [x] #3497
 - [x] #3500
 - [x] #3503
 - [x] #3504
 - [ ] #3506 
 - [x] #3507
 - [x] #3509

## Pre-release

 - [x] Check that the pinned packages in `docs/Project.toml` are updated. We pin
       the versions so that changes in the solvers (changes in printing, small
       numeric changes) do not break the printing of the JuMP docs in arbitrary
       commits.
 - [x] Check that the `rev` fields in `docs/packages.toml` are updated. We pin
       the versions of solvers and extensions to ensure that changes to their
       READMEs do not break the JuMP docs in arbitrary commits, and to ensure
       that the versions are compatible with the latest JuMP and
       MathOptInterface releases.
 - [x] Update `docs/src/changelog.md`
 - [x] https://github.com/jump-dev/JuMP.jl/actions/runs/6178384899
 - [x] Change the version number in `Project.toml`
 - [x] Update the links in README.md
 - [x] The commit messages in this PR do not contain `[ci skip]`

## The release

 - [ ] After merging this pull request, comment `[at]JuliaRegistrator register` in
       the GitHub commit. This should automatically publish a new version to the
       Julia registry, as well as create a tag, and rebuild the documentation
       for this tag.

       These steps can take quite a bit of time (1 hour or more), so don't be
       surprised if the new documentation takes a while to appear. In addition,
       the links in the README will be broken until JuliaHub fetches the new
       version on their servers.

## Post-release

 - [ ] Once the tag is created, update the relevant `release-` branch. The latest
       release branch at the time of writing is `release-1.0` (we haven't
       back-ported any patches that needed to create a `release-1.Y` branch). To
       to update the release branch with the v1.10.0 tag, do:
       ```
       git checkout release-1.0
       git pull
       git merge v1.10.0
       git push
       ```