### PR TITLE
Use let model=model in variable macro to improve type stability

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1334,7 +1334,13 @@ function _constraint_macro(
 
     creation_code =
         Containers.container_code(idxvars, indices, code, requested_container)
-
+    # Wrap the entire code block in a let statement to make the model act as
+    # a type stable local variable.
+    creation_code = quote
+        let $model = $model
+            $creation_code
+        end
+    end
     if anonvar
         # Anonymous constraint, no need to register it in the model-level
         # dictionary nor to assign it to a variable in the user scope.
@@ -1939,6 +1945,13 @@ macro expression(args...)
     end
     code =
         Containers.container_code(idxvars, indices, code, requested_container)
+    # Wrap the entire code block in a let statement to make the model act as
+    # a type stable local variable.
+    creation_code = quote
+        let $m = $m
+            $creation_code
+        end
+    end
     # don't do anything with the model, but check that it's valid anyway
     if anonvar
         macro_code = code

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1947,9 +1947,9 @@ macro expression(args...)
         Containers.container_code(idxvars, indices, code, requested_container)
     # Wrap the entire code block in a let statement to make the model act as
     # a type stable local variable.
-    creation_code = quote
+    code = quote
         let $m = $m
-            $creation_code
+            $code
         end
     end
     # don't do anything with the model, but check that it's valid anyway

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -3016,7 +3016,13 @@ macro variable(args...)
             requested_container,
         )
     end
-
+    # Wrap the entire code block in a let statement to make the model act as
+    # a type stable local variable.
+    creation_code = quote
+        let $model = $model
+            $creation_code
+        end
+    end
     if anonvar
         # Anonymous variable, no need to register it in the model-level
         # dictionary nor to assign it to a variable in the user scope.

--- a/test/test_hygiene.jl
+++ b/test/test_hygiene.jl
@@ -57,4 +57,10 @@ Test.@test ex[3] == 6
 Test.@test i == 10
 Test.@test j == 10
 
+# Test that `model` is inferred correctly inside macros, despite being a
+# non-const global.
+model = JuMP.Model()
+JuMP.@variable(model, x[1:0])
+Test.@test x == JuMP.VariableRef[]
+
 end

--- a/test/test_hygiene.jl
+++ b/test/test_hygiene.jl
@@ -59,8 +59,8 @@ Test.@test j == 10
 
 # Test that `model` is inferred correctly inside macros, despite being a
 # non-const global.
-model = JuMP.Model()
-JuMP.@variable(model, x[1:0])
+m = JuMP.Model()
+JuMP.@variable(m, x[1:0])
 Test.@test x == JuMP.VariableRef[]
 
 end

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -2038,8 +2038,8 @@ end
 # knowing the type of `model`.
 function test_wrap_let_non_symbol_models()
     module_name = @eval module $(gensym())
-        using JuMP, Test
-        data = (; model = Model())
+    using JuMP, Test
+    data = (; model = Model())
     end
     @eval module_name begin
         @variable(data.model, x)
@@ -2051,7 +2051,8 @@ function test_wrap_let_non_symbol_models()
         @constraint(data.model, c[i = 1:2], i * expr[i] <= i)
         @test c isa Vector{<:ConstraintRef}
         @variable(data.model, bad_var[1:0])
-        @test bad_var isa Vector{Any}
+        @test bad_var isa Vector{<:Any}
+        @test !(bad_var isa Vector{VariableRef})  # Cannot prove type
         @expression(data.model, bad_expr[i = 1:0], x + i)
         @test bad_expr isa Vector{Any}
     end
@@ -2062,8 +2063,8 @@ end
 # knowing the type of `model`.
 function test_wrap_let_symbol_models()
     module_name = @eval module $(gensym())
-        using JuMP, Test
-        model = Model()
+    using JuMP, Test
+    model = Model()
     end
     @eval module_name begin
         @variable(model, x)


### PR DESCRIPTION
Closes #3499

We probably need something similar in the other macros as well.

This is quite hard to test, because wrapping things in a function fixes the problem...