### PR TITLE
Fix typo in the objective of the TSP lazy constraints example.

### DIFF
--- a/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
+++ b/docs/src/tutorials/algorithms/tsp_lazy_constraints.jl
@@ -59,7 +59,7 @@ import Plots
 # The objective is to minimize the length of the tour (due to the assumed
 # symmetry, the second sum only contains $i<j$):
 # ```math
-# \text{min\ } \sum_{i \in V}  \sum_{j \in V, i < j} d_{ij} x_{ij}.
+# \text{min } \sum_{i \in V}  \sum_{j \in V, i < j} d_{ij} x_{ij}.
 # ```
 
 # Note that it is also possible to use the following objective function instead:


### PR DESCRIPTION
An extra backslash was added in the text.