### PR TITLE
Fix invalid call to InexactError in MA.scaling

### DIFF
--- a/src/mutable_arithmetics.jl
+++ b/src/mutable_arithmetics.jl
@@ -141,14 +141,14 @@ end
 # `scaling` to convert them back to numbers.
 function _MA.scaling(aff::GenericAffExpr{C}) where {C}
     if !isempty(aff.terms)
-        throw(InexactError("Cannot convert `$aff` to `$C`."))
+        throw(InexactError(Symbol("MutableArithmetics.scaling"), C, aff))
     end
     return _MA.scaling(aff.constant)
 end
 
 function _MA.scaling(quad::GenericQuadExpr{C}) where {C}
     if !isempty(quad.terms)
-        throw(InexactError("Cannot convert `$quad` to `$C`."))
+        throw(InexactError(Symbol("MutableArithmetics.scaling"), C, quad))
     end
     return _MA.scaling(quad.aff)
 end

--- a/test/test_mutable_arithmetics.jl
+++ b/test/test_mutable_arithmetics.jl
@@ -185,4 +185,12 @@ function test_extension_different_variables(
     return
 end
 
+function test_scaling_errors()
+    model = Model()
+    @variable(model, x)
+    @test_throws InexactError JuMP._MA.scaling(x + 1.0)
+    @test_throws InexactError JuMP._MA.scaling(x^2 + 1.0)
+    return
+end
+
 end


### PR DESCRIPTION
This is another JET catch.