### PR TITLE
Fix various JET errors

### DIFF
--- a/src/copy.jl
+++ b/src/copy.jl
@@ -323,11 +323,12 @@ function Base.deepcopy(::GenericModel)
 end
 
 function MOI.copy_to(dest::MOI.ModelLike, src::GenericModel)
-    if nonlinear_model(src) !== nothing
+    nlp = nonlinear_model(src)
+    if nlp !== nothing
         # Re-set the NLP block in-case things have changed since last
         # solve.
         evaluator = MOI.Nonlinear.Evaluator(
-            nonlinear_model(src),
+            nlp,
             MOI.Nonlinear.SparseReverseMode(),
             index.(all_variables(src)),
         )

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -584,7 +584,7 @@ end
 
 function jump_function(model::GenericModel, expr::MOI.Nonlinear.Expression)
     V = variable_ref_type(typeof(model))
-    nlp = nonlinear_model(model)
+    nlp = nonlinear_model(model)::MOI.Nonlinear.Model
     parsed = Vector{Any}(undef, length(expr.nodes))
     adj = MOI.Nonlinear.adjacency_matrix(expr.nodes)
     rowvals = SparseArrays.rowvals(adj)

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -577,7 +577,7 @@ end
 moi_function_type(::Type{<:GenericNonlinearExpr}) = MOI.ScalarNonlinearFunction
 
 function constraint_object(c::NonlinearConstraintRef)
-    nlp = nonlinear_model(c.model)
+    nlp = nonlinear_model(c.model)::MOI.Nonlinear.Model
     data = nlp.constraints[index(c)]
     return ScalarConstraint(jump_function(c.model, data.expression), data.set)
 end

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -118,8 +118,9 @@ function set_objective_function(model::GenericModel, func::MOI.AbstractFunction)
     MOI.set(model, attr, func)
     # Nonlinear objectives override regular objectives, so if there was a
     # nonlinear objective set, we must clear it.
-    if nonlinear_model(model) !== nothing
-        MOI.Nonlinear.set_objective(nonlinear_model(model), nothing)
+    nlp = nonlinear_model(model)
+    if nlp !== nothing
+        MOI.Nonlinear.set_objective(nlp, nothing)
     end
     return
 end

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -414,7 +414,8 @@ function optimize!(
 )
     # The nlp_model is not kept in sync, so re-set it here.
     # TODO: Consider how to handle incremental solves.
-    if nonlinear_model(model) !== nothing
+    nlp = nonlinear_model(model)
+    if nlp !== nothing
         if _uses_new_nonlinear_interface(model)
             error(
                 "Cannot optimize a model which contains the features from " *
@@ -424,7 +425,7 @@ function optimize!(
             )
         end
         evaluator = MOI.Nonlinear.Evaluator(
-            nonlinear_model(model),
+            nlp,
             _differentiation_backend,
             index.(all_variables(model)),
         )

--- a/src/print.jl
+++ b/src/print.jl
@@ -399,7 +399,8 @@ function nonlinear_constraint_string(
     mode::MIME,
     c::MOI.Nonlinear.ConstraintIndex,
 )
-    constraint = nonlinear_model(model)[c]
+    nlp = nonlinear_model(model)::MOI.Nonlinear.Model
+    constraint = nlp[c]
     body = nonlinear_expr_string(model, mode, constraint.expression)
     lhs = _set_lhs(constraint.set)
     rhs = _set_rhs(constraint.set)
@@ -442,7 +443,8 @@ function nonlinear_expr_string(
     mode::MIME,
     c::MOI.Nonlinear.Expression,
 )
-    expr = MOI.Nonlinear.convert_to_expr(nonlinear_model(model), c)
+    nlp = nonlinear_model(model)::MOI.Nonlinear.Model
+    expr = MOI.Nonlinear.convert_to_expr(nlp, c)
     # Walk terms, and replace
     #    MOI.VariableIndex => VariableRef
     #    MOI.Nonlinear.ExpressionIndex => _NonlinearExpressionIO
@@ -588,7 +590,7 @@ function function_string(mode::MIME"text/latex", v::AbstractVariableRef)
     # Convert any x[args] to x_{args} so that indices on x print as subscripts.
     m = match(r"^(.*)\[(.+)\]$", var_name)
     if m !== nothing
-        var_name = m[1] * "_{" * m[2] * "}"
+        return string(m[1]::AbstractString, "_{", m[2]::AbstractString, "}")
     end
     return var_name
 end
@@ -655,7 +657,7 @@ function function_string(mode, q::GenericQuadExpr)
 end
 
 function function_string(mode, vector::Vector{<:AbstractJuMPScalar})
-    return "[" * join(function_string.(Ref(mode), vector), ", ") * "]"
+    return string("[", join(function_string.(Ref(mode), vector), ", "), "]")
 end
 
 function function_string(
@@ -702,7 +704,8 @@ function function_string(mode, constraint::AbstractConstraint)
 end
 
 function function_string(mode::MIME, p::NonlinearExpression)
-    expr = nonlinear_model(p.model)[index(p)]
+    nlp = nonlinear_model(p.model)::MOI.Nonlinear.Model
+    expr = nlp[index(p)]
     s = nonlinear_expr_string(p.model, mode, expr)
     return "subexpression[$(p.index)]: " * s
 end


### PR DESCRIPTION
There are bunch of issues stemming from MOI: https://github.com/jump-dev/MathOptInterface.jl/issues/2268.

In most cases, these change nothing at runtime, but they do make things friendlier for the compiler.

A common case is:
```julia
_init_NLP(model)
MOI.Nonlinear.register_operator(model.nlp_model, op, dimension, f)
```
where `model.nlp_model::Union{Nothing,MOI.Nonlinear.Model}`.

_We_ know that after the call to `_init_NLP` it will never be `Nothing`, but the compiler cannot (currently) prove that, and so anything trying to do static compilation will look for the method `MOI.Nonlinear.register_operator(::Nothing, ...)` which doesn't exist.

We could technically ignore them, but fixing even the minor issues in JET lets us more explicitly find and track actual bugs like https://github.com/jump-dev/JuMP.jl/pull/3518, which would otherwise get lost in the noise of 10's or 100's of errors.