### PR TITLE
Fix documentation.yml GitHub action

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,7 +16,13 @@ jobs:
         with:
           version: '1'
       - name: Install dependencies
-        run: julia --color=yes --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.develop("MathOptInterface"); Pkg.instantiate()'
+        shell: julia --color=yes --project=docs/ {0}
+        run: |
+          using Pkg
+          Pkg.develop(PackageSpec(path=pwd()))
+          Pkg.instantiate()
+          import MathOptInterface
+          Pkg.develop(path=pkgdir(MathOptInterface))
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -21,8 +21,6 @@ jobs:
           using Pkg
           Pkg.develop(PackageSpec(path=pwd()))
           Pkg.instantiate()
-          import MathOptInterface
-          Pkg.develop(path=pkgdir(MathOptInterface))
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -541,6 +541,12 @@ Documenter.DocMeta.setdocmeta!(
 # link checking. Inn production we replace this by running the LaTeX build.
 write(joinpath(@__DIR__, "src", "JuMP.pdf"), "")
 
+# Create remotes for Documenter
+status = sprint(io -> Pkg.status("MathOptInterface"; io = io))
+version = match(r"(v[0-9].[0-9]+.[0-9]+)", status)[1]
+gh_moi = Documenter.Remotes.GitHub("jump-dev", "MathOptInterface.jl")
+remotes = Dict(pkgdir(MOI) => (gh_moi, version))
+
 @time Documenter.makedocs(
     sitename = "JuMP",
     authors = "The JuMP core developers and contributors",
@@ -572,10 +578,7 @@ write(joinpath(@__DIR__, "src", "JuMP.pdf"), "")
     # Skip doctests if --fast provided.
     doctest = _FIX ? :fix : !_FAST,
     pages = vcat(_PAGES, "release_notes.md"),
-    remotes = Dict(
-        dirname(dirname(pathof(MOI))) =>
-            Documenter.Remotes.GitHub("jump-dev", "MathOptInterface.jl"),
-    ),
+    remotes = remotes,
 )
 
 # ==============================================================================


### PR DESCRIPTION
x-ref #3525

Documenter@1 needs MathOptInterface to be `Pkg.develop`'d. I overlooked the fact that the version we use might not be the latest release.