### PR TITLE
Add := operator for Boolean satisfiability problems

### DIFF
--- a/docs/src/developers/extensions.md
+++ b/docs/src/developers/extensions.md
@@ -200,11 +200,11 @@ julia> model = Model(); @variable(model, x);
 
 julia> function JuMP.parse_constraint_head(
            _error::Function,
-           ::Val{:(:=)},
+           ::Val{:≡},
            lhs,
            rhs,
        )
-           println("Rewriting := as ==")
+           println("Rewriting ≡ as ==")
            new_lhs, parse_code = MutableArithmetics.rewrite(lhs)
            build_code = :(
                build_constraint($(_error), $(new_lhs), MOI.EqualTo($(rhs)))
@@ -212,8 +212,8 @@ julia> function JuMP.parse_constraint_head(
            return false, parse_code, build_code
        end
 
-julia> @constraint(model, x + x := 1.0)
-Rewriting := as ==
+julia> @constraint(model, x + x ≡ 1.0)
+Rewriting ≡ as ==
 2 x = 1
 ```
 

--- a/docs/src/developers/extensions.md
+++ b/docs/src/developers/extensions.md
@@ -200,11 +200,11 @@ julia> model = Model(); @variable(model, x);
 
 julia> function JuMP.parse_constraint_head(
            _error::Function,
-           ::Val{:≝},
+           ::Val{:≔},
            lhs,
            rhs,
        )
-           println("Rewriting ≝ as ==")
+           println("Rewriting ≔ as ==")
            new_lhs, parse_code = MutableArithmetics.rewrite(lhs)
            build_code = :(
                build_constraint($(_error), $(new_lhs), MOI.EqualTo($(rhs)))
@@ -212,8 +212,8 @@ julia> function JuMP.parse_constraint_head(
            return false, parse_code, build_code
        end
 
-julia> @constraint(model, x + x ≝ 1.0)
-Rewriting ≝ as ==
+julia> @constraint(model, x + x ≔ 1.0)
+Rewriting ≔ as ==
 2 x = 1
 ```
 

--- a/docs/src/developers/extensions.md
+++ b/docs/src/developers/extensions.md
@@ -200,11 +200,11 @@ julia> model = Model(); @variable(model, x);
 
 julia> function JuMP.parse_constraint_head(
            _error::Function,
-           ::Val{:≡},
+           ::Val{:≝},
            lhs,
            rhs,
        )
-           println("Rewriting ≡ as ==")
+           println("Rewriting ≝ as ==")
            new_lhs, parse_code = MutableArithmetics.rewrite(lhs)
            build_code = :(
                build_constraint($(_error), $(new_lhs), MOI.EqualTo($(rhs)))
@@ -212,8 +212,8 @@ julia> function JuMP.parse_constraint_head(
            return false, parse_code, build_code
        end
 
-julia> @constraint(model, x + x ≡ 1.0)
-Rewriting ≡ as ==
+julia> @constraint(model, x + x ≝ 1.0)
+Rewriting ≝ as ==
 2 x = 1
 ```
 

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -1534,3 +1534,50 @@ julia> q = [5, 6]
 julia> @constraint(model, M * y + q ⟂ y)
 [y[1] + 2 y[2] + 5, 3 y[1] + 4 y[2] + 6, y[1], y[2]] ∈ MathOptInterface.Complements(4)
 ```
+
+## Boolean constraints
+
+Add a Boolean constraint (a [`MOI.EqualTo{Bool}`](@ref) set) using the `:=`
+operator with a `Bool` right-hand side term:
+
+```jldoctest
+julia> model = GenericModel{Bool}();
+
+julia> @variable(model, x[1:2]);
+
+julia> @constraint(model, x[1] || x[2] := true)
+x[1] || x[2] = true
+
+julia> @constraint(model, x[1] && x[2] := false)
+x[1] && x[2] = false
+
+julia> model
+A JuMP Model
+Feasibility problem with:
+Variables: 2
+`GenericNonlinearExpr{GenericVariableRef{Bool}}`-in-`MathOptInterface.EqualTo{Bool}`: 2 constraints
+Model mode: AUTOMATIC
+CachingOptimizer state: NO_OPTIMIZER
+Solver name: No optimizer attached.
+Names registered in the model: x
+```
+
+Boolean constraints should not be added using the `==` operator because JuMP
+will rewrite the constraint as `lhs - rhs = 0`, and because constraints like
+`a == b == c` require parentheses to diambiguate between `(a == b) == c` and
+`a == (b == c)`. In constrast, `a == b := c` is equivalent to `(a == b) := c`:
+
+```jldoctest
+julia> model = Model();
+
+julia> @variable(model, x[1:2]);
+
+julia> rhs = false
+false
+
+julia> @constraint(model, (x[1] == x[2]) == rhs)
+(x[1] == x[2]) - 0.0 = 0
+
+julia> @constraint(model, x[1] == x[2] := rhs)
+x[1] == x[2] = false
+```

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -1564,8 +1564,8 @@ Names registered in the model: x
 
 Boolean constraints should not be added using the `==` operator because JuMP
 will rewrite the constraint as `lhs - rhs = 0`, and because constraints like
-`a == b == c` require parentheses to diambiguate between `(a == b) == c` and
-`a == (b == c)`. In constrast, `a == b := c` is equivalent to `(a == b) := c`:
+`a == b == c` require parentheses to disambiguate between `(a == b) == c` and
+`a == (b == c)`. In contrast, `a == b := c` is equivalent to `(a == b) := c`:
 
 ```jldoctest
 julia> model = Model();

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -1543,13 +1543,7 @@ function relax_with_penalty!(
     return relax_with_penalty!(model, Dict(); default = default)
 end
 
-
-function parse_constraint_head(
-    error_fn::Function,
-    ::Val{:(:=)},
-    lhs,
-    rhs,
-)
+function parse_constraint_head(error_fn::Function, ::Val{:(:=)}, lhs, rhs)
     new_lhs, parse_code_lhs = _rewrite_expression(lhs)
     new_rhs, parse_code_rhs = _rewrite_expression(rhs)
     parse_code = quote
@@ -1562,10 +1556,7 @@ function parse_constraint_head(
         elseif $new_lhs isa Bool
             ScalarConstraint($new_rhs, MOI.EqualTo($new_lhs))
         else
-            ScalarConstraint(
-                op_equal_to($new_lhs, $new_rhs),
-                MOI.EqualTo(true),
-            )
+            ScalarConstraint(op_equal_to($new_lhs, $new_rhs), MOI.EqualTo(true))
         end
     end
     return false, parse_code, build_code

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -1549,25 +1549,22 @@ end
 
 model_convert(::AbstractModel, set::_DoNotConvertSet) = set
 
-function moi_set(constraint::ScalarConstraint{F,<:_DoNotConvertSet}) where {F}
-    return constraint.set.set
-end
+moi_set(c::ScalarConstraint{F,<:_DoNotConvertSet}) where {F} = c.set.set
 
-function _build_boolean_equal_to(::Function, lhs, rhs)
-    set = _DoNotConvertSet(MOI.EqualTo(true))
-    return ScalarConstraint(op_equal_to(lhs, rhs), set)
-end
-
-function _build_boolean_equal_to(::Function, lhs::Bool, rhs)
-    return ScalarConstraint(rhs, _DoNotConvertSet(MOI.EqualTo(lhs)))
-end
-
-function _build_boolean_equal_to(::Function, lhs, rhs::Bool)
+function _build_boolean_equal_to(::Function, lhs::AbstractJuMPScalar, rhs::Bool)
     return ScalarConstraint(lhs, _DoNotConvertSet(MOI.EqualTo(rhs)))
 end
 
-function _build_boolean_equal_to(error_fn::Function, lhs::Bool, rhs::Bool)
-    return error_fn("cannot add the trivial constraint `$lhs := $rhs`")
+function _build_boolean_equal_to(error_fn::Function, ::AbstractJuMPScalar, rhs)
+    return error_fn(
+        "cannot add the `:=` constraint. The right-hand side must be a `Bool`",
+    )
+end
+
+function _build_boolean_equal_to(error_fn::Function, lhs, ::Any)
+    return error_fn(
+        "cannot add the `:=` constraint with left-hand side of type `::$(typeof(lhs))`",
+    )
 end
 
 function parse_constraint_head(error_fn::Function, ::Val{:(:=)}, lhs, rhs)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1160,10 +1160,6 @@ function model_convert(model::AbstractModel, set::MOI.AbstractScalarSet)
     return set
 end
 
-function model_convert(model::GenericModel{Bool}, set::MOI.EqualTo{Bool})
-    return set
-end
-
 function model_convert(model::AbstractModel, α::Number)
     T = value_type(typeof(model))
     V = variable_ref_type(model)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1160,6 +1160,10 @@ function model_convert(model::AbstractModel, set::MOI.AbstractScalarSet)
     return set
 end
 
+function model_convert(model::GenericModel{Bool}, set::MOI.EqualTo{Bool})
+    return set
+end
+
 function model_convert(model::AbstractModel, α::Number)
     T = value_type(typeof(model))
     V = variable_ref_type(model)

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -1721,14 +1721,11 @@ function test_triangle_vec()
     return
 end
 
-function test_def_equal_to_operator()
-    model = GenericModel{Bool}()
+function _test_def_equal_to_operator_T(::Type{T}) where {T}
+    model = GenericModel{T}()
     @variable(model, x[1:3])
     # x[1] := x[2]
-    c = @constraint(model, x[1] := x[2])
-    o = constraint_object(c)
-    @test isequal_canonical(o.func, op_equal_to(x[1], x[2]))
-    @test o.set == MOI.EqualTo(true)
+    @test_throws ErrorException @constraint(model, x[1] := x[2])
     # x[1] == x[2] := false
     c = @constraint(model, x[1] == x[2] := false)
     o = constraint_object(c)
@@ -1752,48 +1749,17 @@ function test_def_equal_to_operator()
     @test o.set == MOI.EqualTo(y)
     # y := x[1] || x[2]
     y = true
-    c = @constraint(model, y := x[1] || x[2])
-    o = constraint_object(c)
-    @test isequal_canonical(o.func, op_or(x[1], x[2]))
-    @test o.set == MOI.EqualTo(y)
+    @test_throws ErrorException @constraint(model, y := x[1] || x[2])
     return
 end
 
 function test_def_equal_to_operator_float()
-    model = Model()
-    @variable(model, x[1:3])
-    # x[1] := x[2]
-    c = @constraint(model, x[1] := x[2])
-    o = constraint_object(c)
-    @test isequal_canonical(o.func, op_equal_to(x[1], x[2]))
-    @test o.set == MOI.EqualTo(true)
-    # x[1] == x[2] := false
-    c = @constraint(model, x[1] == x[2] := false)
-    o = constraint_object(c)
-    @test isequal_canonical(o.func, op_equal_to(x[1], x[2]))
-    @test o.set == MOI.EqualTo(false)
-    # x[1] && x[2] := false
-    c = @constraint(model, x[1] && x[2] := false)
-    o = constraint_object(c)
-    @test isequal_canonical(o.func, op_and(x[1], x[2]))
-    @test o.set == MOI.EqualTo(false)
-    # x[1] && x[2] := true
-    c = @constraint(model, x[1] && x[2] := true)
-    o = constraint_object(c)
-    @test isequal_canonical(o.func, op_and(x[1], x[2]))
-    @test o.set == MOI.EqualTo(true)
-    # x[1] || x[2] := y
-    y = true
-    c = @constraint(model, x[1] || x[2] := y)
-    o = constraint_object(c)
-    @test isequal_canonical(o.func, op_or(x[1], x[2]))
-    @test o.set == MOI.EqualTo(true)
-    # y := x[1] || x[2]
-    y = true
-    c = @constraint(model, y := x[1] || x[2])
-    o = constraint_object(c)
-    @test isequal_canonical(o.func, op_or(x[1], x[2]))
-    @test o.set == MOI.EqualTo(true)
+    _test_def_equal_to_operator_T(Float64)
+    return
+end
+
+function test_def_equal_to_operator_bool()
+    _test_def_equal_to_operator_T(Bool)
     return
 end
 

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -1721,4 +1721,80 @@ function test_triangle_vec()
     return
 end
 
+function test_def_equal_to_operator()
+    model = GenericModel{Bool}()
+    @variable(model, x[1:3])
+    # x[1] := x[2]
+    c = @constraint(model, x[1] := x[2])
+    o = constraint_object(c)
+    @test isequal_canonical(o.func, op_equal_to(x[1], x[2]))
+    @test o.set == MOI.EqualTo(true)
+    # x[1] == x[2] := false
+    c = @constraint(model, x[1] == x[2] := false)
+    o = constraint_object(c)
+    @test isequal_canonical(o.func, op_equal_to(x[1], x[2]))
+    @test o.set == MOI.EqualTo(false)
+    # x[1] && x[2] := false
+    c = @constraint(model, x[1] && x[2] := false)
+    o = constraint_object(c)
+    @test isequal_canonical(o.func, op_and(x[1], x[2]))
+    @test o.set == MOI.EqualTo(false)
+    # x[1] && x[2] := true
+    c = @constraint(model, x[1] && x[2] := true)
+    o = constraint_object(c)
+    @test isequal_canonical(o.func, op_and(x[1], x[2]))
+    @test o.set == MOI.EqualTo(true)
+    # x[1] || x[2] := y
+    y = true
+    c = @constraint(model, x[1] || x[2] := y)
+    o = constraint_object(c)
+    @test isequal_canonical(o.func, op_or(x[1], x[2]))
+    @test o.set == MOI.EqualTo(y)
+    # y := x[1] || x[2]
+    y = true
+    c = @constraint(model, y := x[1] || x[2])
+    o = constraint_object(c)
+    @test isequal_canonical(o.func, op_or(x[1], x[2]))
+    @test o.set == MOI.EqualTo(y)
+    return
+end
+
+function test_def_equal_to_operator_float()
+    model = Model()
+    @variable(model, x[1:3])
+    # x[1] := x[2]
+    c = @constraint(model, x[1] := x[2])
+    o = constraint_object(c)
+    @test isequal_canonical(o.func, op_equal_to(x[1], x[2]))
+    @test o.set == MOI.EqualTo(1.0)
+    # x[1] == x[2] := false
+    c = @constraint(model, x[1] == x[2] := false)
+    o = constraint_object(c)
+    @test isequal_canonical(o.func, op_equal_to(x[1], x[2]))
+    @test o.set == MOI.EqualTo(0.0)
+    # x[1] && x[2] := false
+    c = @constraint(model, x[1] && x[2] := false)
+    o = constraint_object(c)
+    @test isequal_canonical(o.func, op_and(x[1], x[2]))
+    @test o.set == MOI.EqualTo(0.0)
+    # x[1] && x[2] := true
+    c = @constraint(model, x[1] && x[2] := true)
+    o = constraint_object(c)
+    @test isequal_canonical(o.func, op_and(x[1], x[2]))
+    @test o.set == MOI.EqualTo(1.0)
+    # x[1] || x[2] := y
+    y = true
+    c = @constraint(model, x[1] || x[2] := y)
+    o = constraint_object(c)
+    @test isequal_canonical(o.func, op_or(x[1], x[2]))
+    @test o.set == MOI.EqualTo(1.0)
+    # y := x[1] || x[2]
+    y = true
+    c = @constraint(model, y := x[1] || x[2])
+    o = constraint_object(c)
+    @test isequal_canonical(o.func, op_or(x[1], x[2]))
+    @test o.set == MOI.EqualTo(1.0)
+    return
+end
+
 end

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -1766,34 +1766,34 @@ function test_def_equal_to_operator_float()
     c = @constraint(model, x[1] := x[2])
     o = constraint_object(c)
     @test isequal_canonical(o.func, op_equal_to(x[1], x[2]))
-    @test o.set == MOI.EqualTo(1.0)
+    @test o.set == MOI.EqualTo(true)
     # x[1] == x[2] := false
     c = @constraint(model, x[1] == x[2] := false)
     o = constraint_object(c)
     @test isequal_canonical(o.func, op_equal_to(x[1], x[2]))
-    @test o.set == MOI.EqualTo(0.0)
+    @test o.set == MOI.EqualTo(false)
     # x[1] && x[2] := false
     c = @constraint(model, x[1] && x[2] := false)
     o = constraint_object(c)
     @test isequal_canonical(o.func, op_and(x[1], x[2]))
-    @test o.set == MOI.EqualTo(0.0)
+    @test o.set == MOI.EqualTo(false)
     # x[1] && x[2] := true
     c = @constraint(model, x[1] && x[2] := true)
     o = constraint_object(c)
     @test isequal_canonical(o.func, op_and(x[1], x[2]))
-    @test o.set == MOI.EqualTo(1.0)
+    @test o.set == MOI.EqualTo(true)
     # x[1] || x[2] := y
     y = true
     c = @constraint(model, x[1] || x[2] := y)
     o = constraint_object(c)
     @test isequal_canonical(o.func, op_or(x[1], x[2]))
-    @test o.set == MOI.EqualTo(1.0)
+    @test o.set == MOI.EqualTo(true)
     # y := x[1] || x[2]
     y = true
     c = @constraint(model, y := x[1] || x[2])
     o = constraint_object(c)
     @test isequal_canonical(o.func, op_or(x[1], x[2]))
-    @test o.set == MOI.EqualTo(1.0)
+    @test o.set == MOI.EqualTo(true)
     return
 end
 

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -89,7 +89,7 @@ end
 
 struct CustomType end
 
-function JuMP.parse_constraint_head(_error::Function, ::Val{:(:=)}, lhs, rhs)
+function JuMP.parse_constraint_head(_error::Function, ::Val{:≡}, lhs, rhs)
     return false, :(), :(build_constraint($_error, $(esc(lhs)), $(esc(rhs))))
 end
 
@@ -326,7 +326,7 @@ function test_extension_custom_expression_test(
 )
     model = ModelType()
     @variable(model, x)
-    @constraint(model, con_ref, x := CustomType())
+    @constraint(model, con_ref, x ≡ CustomType())
     con = constraint_object(con_ref)
     @test jump_function(con) == x
     @test moi_set(con) isa CustomSet

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -89,7 +89,7 @@ end
 
 struct CustomType end
 
-function JuMP.parse_constraint_head(_error::Function, ::Val{:≝}, lhs, rhs)
+function JuMP.parse_constraint_head(_error::Function, ::Val{:≔}, lhs, rhs)
     return false, :(), :(build_constraint($_error, $(esc(lhs)), $(esc(rhs))))
 end
 
@@ -326,7 +326,7 @@ function test_extension_custom_expression_test(
 )
     model = ModelType()
     @variable(model, x)
-    @constraint(model, con_ref, x ≝ CustomType())
+    @constraint(model, con_ref, x ≔ CustomType())
     con = constraint_object(con_ref)
     @test jump_function(con) == x
     @test moi_set(con) isa CustomSet

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -89,7 +89,7 @@ end
 
 struct CustomType end
 
-function JuMP.parse_constraint_head(_error::Function, ::Val{:≡}, lhs, rhs)
+function JuMP.parse_constraint_head(_error::Function, ::Val{:≝}, lhs, rhs)
     return false, :(), :(build_constraint($_error, $(esc(lhs)), $(esc(rhs))))
 end
 
@@ -326,7 +326,7 @@ function test_extension_custom_expression_test(
 )
     model = ModelType()
     @variable(model, x)
-    @constraint(model, con_ref, x ≡ CustomType())
+    @constraint(model, con_ref, x ≝ CustomType())
     con = constraint_object(con_ref)
     @test jump_function(con) == x
     @test moi_set(con) isa CustomSet


### PR DESCRIPTION
x-ref #2227

This is one improvement suggested by today's call, motivated by the fact that `==` has lower precedence than `&&` and `||`, so `x || y == true` parses as `x || (y == true)`. The new syntax, `x || y := true` parses as `(x || y) := true`.

The key difference of `:=` compared with `==` is that `==` uses `lhs - rhs in EqualTo(false)`, whereas `:=` lowers to the NonlinearExpr` `(lhs == rhs) in EqualTo(true)`. Thus, it should pretty much only be used for Boolean problems that support ScalarNonlinearFunction.

cc @chriscoey thoughts?

See the examples in `test/test_constraint.jl`

TODO: 

 - [x] Documentation