### PR TITLE
DNM: Fix and test support for Σ, ∑,and ∏

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -684,6 +684,12 @@ function _rewrite_to_jump_logic(x)
             return Expr(:call, op_greater_than_or_equal_to, x.args[2:end]...)
         elseif x.args[1] == :(==)
             return Expr(:call, op_equal_to, x.args[2:end]...)
+        elseif x.args[1] == :Σ
+            return Expr(:call, sum, x.args[2:end]...)
+        elseif x.args[1] == :∑
+            return Expr(:call, sum, x.args[2:end]...)
+        elseif x.args[1] == :∏
+            return Expr(:call, prod, x.args[2:end]...)
         end
     elseif Meta.isexpr(x, :||)
         return Expr(:call, op_or, x.args...)

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -2131,4 +2131,28 @@ function test_issue_3514()
     return
 end
 
+function test_macro_unicode_sum()
+    model = Model()
+    @variable(model, x[1:2])
+    @test isequal_canonical(@expression(model, ∑(x[i] for i in 1:2)), sum(x))
+    @test isequal_canonical(@expression(model, ∑(x)), sum(x))
+    return
+end
+
+function test_macro_unicode_sigma()
+    model = Model()
+    @variable(model, x[1:2])
+    @test isequal_canonical(@expression(model, Σ(x[i] for i in 1:2)), sum(x))
+    @test isequal_canonical(@expression(model, Σ(x)), sum(x))
+    return
+end
+
+function test_macro_unicode_prod()
+    model = Model()
+    @variable(model, x[1:2])
+    @test isequal_canonical(@expression(model, ∏(x[i] for i in 1:2)), prod(x))
+    @test isequal_canonical(@expression(model, ∏(x)), prod(x))
+    return
+end
+
 end  # module


### PR DESCRIPTION
Closes #3533 

We've always supported Σ, ∑,and ∏, but these weren't tested, and the only worked for generators, not with a single itterable argument.