### PR TITLE
Add start_value, lower_bound, and upper_bound support for GenericAffExpr

### DIFF
--- a/docs/src/manual/variables.md
+++ b/docs/src/manual/variables.md
@@ -1214,25 +1214,6 @@ julia> @variable(model, x[1:2, 1:2] in SkewSymmetricMatrixSpace())
     `model`; the remaining elements in `x` are linear transformations of the
     single variable.
 
-Because the returned matrix `x` is `Matrix{AffExpr}`, you cannot use
-variable-related functions on its elements:
-```jldoctest skewsymmetric
-julia> set_lower_bound(x[1, 2], 0.0)
-ERROR: MethodError: no method matching set_lower_bound(::AffExpr, ::Float64)
-[...]
-```
-
-Instead, you can convert an upper-triangular elements to a variable as follows:
-```jldoctest skewsymmetric
-julia> to_variable(x::AffExpr) = first(keys(x.terms))
-to_variable (generic function with 1 method)
-
-julia> to_variable(x[1, 2])
-x[1,2]
-
-julia> set_lower_bound(to_variable(x[1, 2]), 0.0)
-```
-
 ### Example: Hermitian positive semidefinite variables
 
 Declare a matrix of JuMP variables to be Hermitian positive semidefinite using

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -824,7 +824,7 @@ function _eval_as_variable(f::F, x::GenericAffExpr, args...) where {F}
             "Cannot call $f with $x because it is not a real-valued affine " *
             "expression of one variable.",
         )
-    elseif !isone(first(keys(x.terms)))
+    elseif !isone(first(values(x.terms)))
         error(
             "Cannot call $f with $x because it is not a real-valued affine " *
             "expression of one variable with a coefficient of `+1`.",

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -821,31 +821,18 @@ forward the method if and only if `x` is convertable to a `GenericVariableRef`.
 function _eval_as_variable(f::F, x::GenericAffExpr, args...) where {F}
     if length(x.terms) != 1
         error(
-            "Cannot call $f with $x because it is not a real-valued affine " *
-            "expression of one variable.",
+            "Cannot call $f with $x because it is not an affine expression " *
+            "of one variable.",
         )
     end
     variable, coefficient = first(x.terms)
     if !isone(coefficient)
         error(
-            "Cannot call $f with $x because it is not a real-valued affine " *
-            "expression of one variable with a coefficient of `+1`.",
+            "Cannot call $f with $x because the variable has a coefficient " *
+            "that is different to `+1`.",
         )
     end
     return f(variable, args...)
-end
-
-function _eval_as_variable(
-    f::F,
-    x::GenericAffExpr{T},
-    args...,
-) where {F,T<:Complex}
-    return error(
-        "Cannot call $f with $x because it is not a real-valued affine " *
-        "expression of one variable with a coefficient of `+1`. Use " *
-        "`real(x)` or `imag(x)` to obtain the real and imaginary part and " *
-        "pass that instead.",
-    )
 end
 
 # start_value(::GenericAffExpr)

--- a/src/aff_expr.jl
+++ b/src/aff_expr.jl
@@ -824,13 +824,15 @@ function _eval_as_variable(f::F, x::GenericAffExpr, args...) where {F}
             "Cannot call $f with $x because it is not a real-valued affine " *
             "expression of one variable.",
         )
-    elseif !isone(first(values(x.terms)))
+    end
+    variable, coefficient = first(x.terms)
+    if !isone(coefficient)
         error(
             "Cannot call $f with $x because it is not a real-valued affine " *
             "expression of one variable with a coefficient of `+1`.",
         )
     end
-    return f(first(keys(x.terms)), args...)
+    return f(variable, args...)
 end
 
 function _eval_as_variable(

--- a/test/test_expr.jl
+++ b/test/test_expr.jl
@@ -461,6 +461,15 @@ function test_aff_expr_complex_lower_bound()
     return
 end
 
+function test_aff_expr_complex_lower_bound_negative()
+    model = Model()
+    @variable(model, -3 <= x <= 4)
+    y = (1 - 2im) * x
+    @test has_lower_bound(y)
+    @test lower_bound(y) == -3.0 - 8im
+    return
+end
+
 function test_aff_expr_complex_upper_bound()
     model = Model()
     @variable(model, x in ComplexPlane())
@@ -536,6 +545,21 @@ function test_aff_expr_complex_errors()
             "exactly one variable",
         ),
         set_start_value(x[1, 1], 1 + 2im),
+    )
+    y = 2 * x[1, 1]
+    @test_throws(
+        ErrorException(
+            "Cannot set the lower bound of `$y` because it does not contain " *
+            "exactly one variable with a coefficient of `+1` or `-1`",
+        ),
+        set_lower_bound(y, 1 + 2im),
+    )
+    @test_throws(
+        ErrorException(
+            "Cannot set the upper bound of `$y` because it does not contain " *
+            "exactly one variable with a coefficient of `+1` or `-1`",
+        ),
+        set_upper_bound(y, 1 + 2im),
     )
     return
 end

--- a/test/test_expr.jl
+++ b/test/test_expr.jl
@@ -484,7 +484,7 @@ function test_aff_expr_complex_hermitian_lower_bound()
     model = Model()
     @variable(model, x[1:2, 1:2] in HermitianPSDCone())
     @test !any(has_lower_bound.(x))
-    A = [1 (2 + 3im); (2 - 3im) 4]
+    A = [1 (2+3im); (2-3im) 4]
     set_lower_bound.(x, A)
     @test all(has_lower_bound.(x))
     @test lower_bound.(x) == A
@@ -495,7 +495,7 @@ function test_aff_expr_complex_hermitian_upper_bound()
     model = Model()
     @variable(model, x[1:2, 1:2] in HermitianPSDCone())
     @test !any(has_upper_bound.(x))
-    A = [1 (2 + 3im); (2 - 3im) 4]
+    A = [1 (2+3im); (2-3im) 4]
     set_upper_bound.(x, A)
     @test all(has_upper_bound.(x))
     @test upper_bound.(x) == A
@@ -506,7 +506,7 @@ function test_aff_expr_complex_hermitian_start_value()
     model = Model()
     @variable(model, x[1:2, 1:2] in HermitianPSDCone())
     @test !any(has_upper_bound.(x))
-    A = [1 (2 + 3im); (2 - 3im) 4]
+    A = [1 (2+3im); (2-3im) 4]
     @test all(start_value.(x) .=== nothing)
     set_start_value.(x, A)
     @test start_value.(x) == A

--- a/test/test_expr.jl
+++ b/test/test_expr.jl
@@ -487,29 +487,31 @@ function test_aff_expr_complex_start_value()
     return
 end
 
-function test_aff_expr_complex_error()
+function test_aff_expr_complex_HermitianPSDCone()
     model = Model()
     @variable(model, x[1:2, 1:2] in HermitianPSDCone())
+    @test start_value(x[1, 1]) === nothing
+    set_lower_bound(x[1, 1], 2.5)
+    @test has_lower_bound(x[1, 1])
+    @test lower_bound(x[1, 1]) == 2.5
     @test_throws(
         ErrorException(
-            "Cannot call $start_value with $(x[1, 1]) because it is not a real-valued affine " *
-            "expression of one variable with a coefficient of `+1`. Use " *
-            "`real(x)` or `imag(x)` to obtain the real and imaginary part and " *
-            "pass that instead.",
+            "Cannot call $start_value with $(x[2, 1]) because it is not an affine " *
+            "expression of one variable.",
         ),
-        start_value(x[1, 1]),
+        start_value(x[2, 1]),
     )
     @test_throws(
         ErrorException(
-            "Cannot call $start_value with $(imag(x[2, 1])) because it is not a real-valued affine " *
-            "expression of one variable with a coefficient of `+1`.",
+            "Cannot call $start_value with $(imag(x[2, 1])) because the " *
+            "variable has a coefficient that is different to `+1`.",
         ),
         start_value(imag(x[2, 1])),
     )
     y = AffExpr(0.0)
     @test_throws(
         ErrorException(
-            "Cannot call $start_value with $y because it is not a real-valued affine " *
+            "Cannot call $start_value with $y because it is not an affine " *
             "expression of one variable.",
         ),
         start_value(y),

--- a/test/test_expr.jl
+++ b/test/test_expr.jl
@@ -451,4 +451,93 @@ function test_quadexpr_owner_model()
     return
 end
 
+function test_aff_expr_complex_lower_bound()
+    model = Model()
+    @variable(model, x in ComplexPlane())
+    @test !has_lower_bound(x)
+    set_lower_bound(x, 1 + 2im)
+    @test has_lower_bound(x)
+    @test lower_bound(x) == 1 + 2im
+    return
+end
+
+function test_aff_expr_complex_upper_bound()
+    model = Model()
+    @variable(model, x in ComplexPlane())
+    @test !has_upper_bound(x)
+    set_upper_bound(x, 3 + 4im)
+    @test has_upper_bound(x)
+    @test upper_bound(x) == 3 + 4im
+    return
+end
+
+function test_aff_expr_complex_start_value()
+    model = Model()
+    @variable(model, x in ComplexPlane())
+    @test start_value(x) === nothing
+    set_start_value(x, 2 + 3im)
+    @test start_value(x) == 2 + 3im
+    return
+end
+
+function test_aff_expr_complex_hermitian_lower_bound()
+    model = Model()
+    @variable(model, x[1:2, 1:2] in HermitianPSDCone())
+    @test !any(has_lower_bound.(x))
+    A = [1 (2 + 3im); (2 - 3im) 4]
+    set_lower_bound.(x, A)
+    @test all(has_lower_bound.(x))
+    @test lower_bound.(x) == A
+    return
+end
+
+function test_aff_expr_complex_hermitian_upper_bound()
+    model = Model()
+    @variable(model, x[1:2, 1:2] in HermitianPSDCone())
+    @test !any(has_upper_bound.(x))
+    A = [1 (2 + 3im); (2 - 3im) 4]
+    set_upper_bound.(x, A)
+    @test all(has_upper_bound.(x))
+    @test upper_bound.(x) == A
+    return
+end
+
+function test_aff_expr_complex_hermitian_start_value()
+    model = Model()
+    @variable(model, x[1:2, 1:2] in HermitianPSDCone())
+    @test !any(has_upper_bound.(x))
+    A = [1 (2 + 3im); (2 - 3im) 4]
+    @test all(start_value.(x) .=== nothing)
+    set_start_value.(x, A)
+    @test start_value.(x) == A
+    return
+end
+
+function test_aff_expr_complex_errors()
+    model = Model()
+    @variable(model, x[1:2, 1:2] in HermitianPSDCone())
+    @test_throws(
+        ErrorException(
+            "Cannot set the lower bound of 0 because it does not contain " *
+            "exactly one variable",
+        ),
+        set_lower_bound(x[1, 1], 1 + 2im),
+    )
+    @test_throws(
+        ErrorException(
+            "Cannot set the upper bound of 0 because it does not contain " *
+            "exactly one variable",
+        ),
+        set_upper_bound(x[1, 1], 1 + 2im),
+    )
+    @test_throws(
+        ErrorException(
+            "Cannot set the start value of 0 because it does not contain " *
+            "exactly one variable",
+        ),
+        set_start_value(x[1, 1], 1 + 2im),
+    )
+    return
+end
+
 end  # TestExpr


### PR DESCRIPTION
Closes #3550 

This PR is up for debate, but our problem is that some usages of `@variable` return expressions of variables, and then common operations like `lower_bound` or `set_start_value` do not work.

In most common cases we _can_ make this work, so we probably should. This would improve the user-experience, particularly for those using `Complex` number support.