### PR TITLE
Add errors for Matrix ± AbstractJuMPScalar

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -460,9 +460,9 @@ function Base.:+(A::AbstractMatrix, x::AbstractJuMPScalar)
     )
 end
 
-Base.:+(x::AbstractJuMPScalar, A::Matrix) = A + x
+Base.:+(x::AbstractJuMPScalar, A::AbstractMatrix) = A + x
 
-function Base.:-(A::Matrix, x::AbstractJuMPScalar)
+function Base.:-(A::AbstractMatrix, x::AbstractJuMPScalar)
     return error(
         "Subtraction between a Matrix and a JuMP variable is not supported: instead of `A - x`, " *
         "do `A .- x` for element-wise subtraction, or if you are modifying the diagonal entries of the matrix " *
@@ -470,4 +470,4 @@ function Base.:-(A::Matrix, x::AbstractJuMPScalar)
     )
 end
 
-Base.:-(x::AbstractJuMPScalar, A::Matrix) = A - x
+Base.:-(x::AbstractJuMPScalar, A::AbstractMatrix) = A - x

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -456,7 +456,7 @@ function Base.:+(A::Matrix, x::AbstractJuMPScalar)
     return error(
         "Addition between a Matrix and a JuMP variable is not supported: instead of `A + x`, " *
         "prefer `A .+ x` for element-wise addition, or if you are modifying the diagonal entries of the matrix " *
-        "do `A + x * LinearAlgebra.I(n)`, where `n` is the diagonal length."
+        "do `A + x * LinearAlgebra.I(n)`, where `n` is the diagonal length.",
     )
 end
 
@@ -466,7 +466,7 @@ function Base.:-(A::Matrix, x::AbstractJuMPScalar)
     return error(
         "Subtraction between a Matrix and a JuMP variable is not supported: instead of `A - x`, " *
         "prefer `A .- x` for element-wise subtraction, or if you are modifying the diagonal entries of the matrix " *
-        "do `A - x * LinearAlgebra.I(n)`, where `n` is the diagonal length."
+        "do `A - x * LinearAlgebra.I(n)`, where `n` is the diagonal length.",
     )
 end
 

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -452,7 +452,7 @@ function LinearAlgebra.issymmetric(x::Matrix{T}) where {T<:_JuMPTypes}
     return true
 end
 
-function Base.:+(A::Matrix, x::AbstractJuMPScalar)
+function Base.:+(A::AbstractMatrix, x::AbstractJuMPScalar)
     return error(
         "Addition between a Matrix and a JuMP variable is not supported: instead of `A + x`, " *
         "do `A .+ x` for element-wise addition, or if you are modifying the diagonal entries of the matrix " *

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -451,3 +451,23 @@ function LinearAlgebra.issymmetric(x::Matrix{T}) where {T<:_JuMPTypes}
     end
     return true
 end
+
+function Base.:+(A::Matrix, x::AbstractJuMPScalar)
+    return error(
+        "Addition between a Matrix and a JuMP variable is not supported: instead of A + x, " *
+        "prefer A .+ x for element-wise addition, or if you are modifying the diagonal entries of the matrix " *
+        "do A + x * LinearAlgebra.I(n), where n is the diagonal length."
+    )
+end
+
+Base.:+(x::AbstractJuMPScalar, A::Matrix) = A + x
+
+function Base.:-(A::Matrix, x::AbstractJuMPScalar)
+    return error(
+        "Subtraction between a Matrix and a JuMP variable is not supported: instead of A - x, " *
+        "prefer A .- x for element-wise subtraction, or if you are modifying the diagonal entries of the matrix " *
+        "do A - x * LinearAlgebra.I(n), where n is the diagonal length."
+    )
+end
+
+Base.:-(x::AbstractJuMPScalar, A::Matrix) = A - x

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -454,9 +454,9 @@ end
 
 function Base.:+(A::Matrix, x::AbstractJuMPScalar)
     return error(
-        "Addition between a Matrix and a JuMP variable is not supported: instead of A + x, " *
-        "prefer A .+ x for element-wise addition, or if you are modifying the diagonal entries of the matrix " *
-        "do A + x * LinearAlgebra.I(n), where n is the diagonal length."
+        "Addition between a Matrix and a JuMP variable is not supported: instead of `A + x`, " *
+        "prefer `A .+ x` for element-wise addition, or if you are modifying the diagonal entries of the matrix " *
+        "do `A + x * LinearAlgebra.I(n)`, where `n` is the diagonal length."
     )
 end
 
@@ -464,9 +464,9 @@ Base.:+(x::AbstractJuMPScalar, A::Matrix) = A + x
 
 function Base.:-(A::Matrix, x::AbstractJuMPScalar)
     return error(
-        "Subtraction between a Matrix and a JuMP variable is not supported: instead of A - x, " *
-        "prefer A .- x for element-wise subtraction, or if you are modifying the diagonal entries of the matrix " *
-        "do A - x * LinearAlgebra.I(n), where n is the diagonal length."
+        "Subtraction between a Matrix and a JuMP variable is not supported: instead of `A - x`, " *
+        "prefer `A .- x` for element-wise subtraction, or if you are modifying the diagonal entries of the matrix " *
+        "do `A - x * LinearAlgebra.I(n)`, where `n` is the diagonal length."
     )
 end
 

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -455,7 +455,7 @@ end
 function Base.:+(A::Matrix, x::AbstractJuMPScalar)
     return error(
         "Addition between a Matrix and a JuMP variable is not supported: instead of `A + x`, " *
-        "prefer `A .+ x` for element-wise addition, or if you are modifying the diagonal entries of the matrix " *
+        "do `A .+ x` for element-wise addition, or if you are modifying the diagonal entries of the matrix " *
         "do `A + x * LinearAlgebra.I(n)`, where `n` is the diagonal length.",
     )
 end
@@ -465,7 +465,7 @@ Base.:+(x::AbstractJuMPScalar, A::Matrix) = A + x
 function Base.:-(A::Matrix, x::AbstractJuMPScalar)
     return error(
         "Subtraction between a Matrix and a JuMP variable is not supported: instead of `A - x`, " *
-        "prefer `A .- x` for element-wise subtraction, or if you are modifying the diagonal entries of the matrix " *
+        "do `A .- x` for element-wise subtraction, or if you are modifying the diagonal entries of the matrix " *
         "do `A - x * LinearAlgebra.I(n)`, where `n` is the diagonal length.",
     )
 end

--- a/test/test_operator.jl
+++ b/test/test_operator.jl
@@ -625,4 +625,43 @@ function test_complex_pow()
     return
 end
 
+function test_matrix_abstractscalar_add()
+    model = Model()
+    @variable(model, x)
+    A = rand(Float64, 2, 2)
+    @test_throws(
+        ErrorException(
+            "Addition between a Matrix and a JuMP variable is not supported: instead of `A + x`, " *
+            "prefer `A .+ x` for element-wise addition, or if you are modifying the diagonal entries of the matrix " *
+            "do `A + x * LinearAlgebra.I(n)`, where `n` is the diagonal length.",
+        ),
+        A + x
+    ),
+    @test_throws(
+        ErrorException(
+            "Addition between a Matrix and a JuMP variable is not supported: instead of `A + x`, " *
+            "prefer `A .+ x` for element-wise addition, or if you are modifying the diagonal entries of the matrix " *
+            "do `A + x * LinearAlgebra.I(n)`, where `n` is the diagonal length.",
+        ),
+        x + A
+    ),
+    @test_throws(
+        ErrorException(
+            "Subtraction between a Matrix and a JuMP variable is not supported: instead of `A - x`, " *
+            "prefer `A .- x` for element-wise subtraction, or if you are modifying the diagonal entries of the matrix " *
+            "do `A - x * LinearAlgebra.I(n)`, where `n` is the diagonal length.",
+        ),
+        A - x
+    ),
+    @test_throws(
+        ErrorException(
+            "Subtraction between a Matrix and a JuMP variable is not supported: instead of `A - x`, " *
+            "prefer `A .- x` for element-wise subtraction, or if you are modifying the diagonal entries of the matrix " *
+            "do `A - x * LinearAlgebra.I(n)`, where `n` is the diagonal length.",
+        ),
+        x - A
+    ),
+    return
+end
+
 end

--- a/test/test_operator.jl
+++ b/test/test_operator.jl
@@ -632,7 +632,7 @@ function test_matrix_abstractscalar_add()
     @test_throws(
         ErrorException(
             "Addition between a Matrix and a JuMP variable is not supported: instead of `A + x`, " *
-            "prefer `A .+ x` for element-wise addition, or if you are modifying the diagonal entries of the matrix " *
+            "do `A .+ x` for element-wise addition, or if you are modifying the diagonal entries of the matrix " *
             "do `A + x * LinearAlgebra.I(n)`, where `n` is the diagonal length.",
         ),
         A + x
@@ -640,7 +640,7 @@ function test_matrix_abstractscalar_add()
     @test_throws(
         ErrorException(
             "Addition between a Matrix and a JuMP variable is not supported: instead of `A + x`, " *
-            "prefer `A .+ x` for element-wise addition, or if you are modifying the diagonal entries of the matrix " *
+            "do `A .+ x` for element-wise addition, or if you are modifying the diagonal entries of the matrix " *
             "do `A + x * LinearAlgebra.I(n)`, where `n` is the diagonal length.",
         ),
         x + A
@@ -648,7 +648,7 @@ function test_matrix_abstractscalar_add()
     @test_throws(
         ErrorException(
             "Subtraction between a Matrix and a JuMP variable is not supported: instead of `A - x`, " *
-            "prefer `A .- x` for element-wise subtraction, or if you are modifying the diagonal entries of the matrix " *
+            "do `A .- x` for element-wise subtraction, or if you are modifying the diagonal entries of the matrix " *
             "do `A - x * LinearAlgebra.I(n)`, where `n` is the diagonal length.",
         ),
         A - x
@@ -656,7 +656,7 @@ function test_matrix_abstractscalar_add()
     @test_throws(
         ErrorException(
             "Subtraction between a Matrix and a JuMP variable is not supported: instead of `A - x`, " *
-            "prefer `A .- x` for element-wise subtraction, or if you are modifying the diagonal entries of the matrix " *
+            "do `A .- x` for element-wise subtraction, or if you are modifying the diagonal entries of the matrix " *
             "do `A - x * LinearAlgebra.I(n)`, where `n` is the diagonal length.",
         ),
         x - A


### PR DESCRIPTION
Give a more informative error when there an operation between a single JuMP variable and a Matrix type object is attempted.

Closes #3553 