### PR TITLE
[docs] add EAGO to packages.toml

### DIFF
--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -13,3 +13,6 @@ TokenIgnores =          \
 ; TODO(odow): remove at some point
 [docs/src/packages/Clarabel.md]
 Google.Latin = NO
+
+[docs/src/packages/EAGO.md]
+Google.Periods = NO

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -127,7 +127,7 @@
     rev = "v0.5.1"
 [EAGO]
     user = "PSORLab"
-    rev = "bea34bd61d686721b25dd2a68fbe64325a56a28e"
+    rev = "8bba4cf6d9ef1602b4cfe3ea31b847f21ce25837"
     filename = "docs/src/jump/README.md"
 [GAMS]
     user = "GAMS-dev"

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -129,7 +129,6 @@
     user = "PSORLab"
     rev = "bea34bd61d686721b25dd2a68fbe64325a56a28e"
     filename = "docs/src/jump/README.md"
-    has_html = true
 [GAMS]
     user = "GAMS-dev"
     rev = "c5dee9f929e9d2f4433ae09fa92b8d872c9c43e0"

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -127,7 +127,7 @@
     rev = "v0.5.1"
 [EAGO]
     user = "PSORLab"
-    rev = "75b09a9287a3264e2da1e003f0deb8278661c529"
+    rev = "bea34bd61d686721b25dd2a68fbe64325a56a28e"
     filename = "docs/src/jump/README.md"
     has_html = true
 [GAMS]

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -125,9 +125,9 @@
 [DAQP]
     user = "darnstrom"
     rev = "v0.5.1"
-# [EAGO]
-#     user = "PSORLab"
-#     rev = "v0.8.1"
+[EAGO]
+    user = "PSORLab"
+    rev = "v0.8.1"
 [GAMS]
     user = "GAMS-dev"
     rev = "c5dee9f929e9d2f4433ae09fa92b8d872c9c43e0"

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -128,6 +128,7 @@
 [EAGO]
     user = "PSORLab"
     rev = "v0.8.1"
+    has_html = true
 [GAMS]
     user = "GAMS-dev"
     rev = "c5dee9f929e9d2f4433ae09fa92b8d872c9c43e0"

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -128,6 +128,7 @@
 [EAGO]
     user = "PSORLab"
     rev = "75b09a9287a3264e2da1e003f0deb8278661c529"
+    filename = "docs/src/jump/README.md"
     has_html = true
 [GAMS]
     user = "GAMS-dev"

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -127,7 +127,7 @@
     rev = "v0.5.1"
 [EAGO]
     user = "PSORLab"
-    rev = "v0.8.1"
+    rev = "75b09a9287a3264e2da1e003f0deb8278661c529"
     has_html = true
 [GAMS]
     user = "GAMS-dev"

--- a/docs/styles/Vocab/JuMP-Vocab/accept.txt
+++ b/docs/styles/Vocab/JuMP-Vocab/accept.txt
@@ -240,6 +240,7 @@ Tillmann
 Ulungu
 Vandenberghe
 Vielma
+Watson, H.A.J.
 Wechsung
 Wei
 Wollenberg

--- a/docs/styles/Vocab/JuMP-Vocab/accept.txt
+++ b/docs/styles/Vocab/JuMP-Vocab/accept.txt
@@ -51,6 +51,7 @@ unexported
 [Uu]ntyped
 
 % JuMP-related vocab
+arithmetics
 [Bb]ilevel
 [Cc]anonicaliz(e|ation|ing)
 [Cc]ombinatorics
@@ -58,6 +59,7 @@ convexification
 DAE(?s)
 [Dd]et
 [Ee]xtremal
+factorable
 functionize
 geomean
 hypergraph
@@ -71,12 +73,14 @@ minimizers
 nl|NL
 [Nn]onconvex
 [Nn]on(posi|nega)tiv(e|es|ity)
+[Nn]onsmooth
 [Oo]ptigraph(?s)
 [Oo]ptinode(?s)
 [Oo]ptiedge(?s)
 overfitting
 parameteriz(ing|ation)
 perp
+priori
 POVM
 [Pp]recompil(ation|(e(?d)))
 [Pp]resolve
@@ -118,6 +122,7 @@ cosmo
 Couenne
 Divio
 Dualization
+EAGO
 [Ee]mbotech
 [Ee]cos
 JSONSchema
@@ -161,6 +166,8 @@ Biegler
 Borchers
 Bukhsh
 Cao
+Chachuat
+Chebyshev
 Cholesky
 Coey
 Dantzig
@@ -204,6 +211,7 @@ Mathieu
 Maurer
 Mehdi
 Michal
+Mitsos
 Mittelman
 Montoison
 Motzkin
@@ -223,6 +231,7 @@ Soodeh
 Steuer
 Stigler
 Stingl
+Stuber
 Sungho
 Taccari
 Tanneau
@@ -231,6 +240,7 @@ Tillmann
 Ulungu
 Vandenberghe
 Vielma
+Wechsung
 Wei
 Wollenberg
 Yankai


### PR DESCRIPTION
cc @DimitriAlston 

It'll take a while for the docs to run, but once they're finished this preview link will work:

https://jump.dev/JuMP.jl/previews/PR3561/packages/EAGO

We need to fix some typos, and add some more words to the allow-list (https://github.com/jump-dev/JuMP.jl/blob/master/docs/styles/Vocab/JuMP-Vocab/accept.txt).

The bigger problem is going to be the formatting and links. Documenter's Markdown is not the same as GitHub, so things will render differently. I'll take a look once the preview has built. But another alternative is to provide a simplified file just for the JuMP documentation.

This is what InfiniteOpt has done:

https://github.com/jump-dev/JuMP.jl/blob/c831cc6dad564b380b86c3bf0a74877f66d46773/docs/packages.toml#L141

https://github.com/infiniteopt/InfiniteOpt.jl/blob/master/docs/jump/README.md