### PR TITLE
Add Manopt to list of solvers

### DIFF
--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -16,3 +16,8 @@ Google.Latin = NO
 
 [docs/src/packages/EAGO.md]
 Google.Periods = NO
+
+[docs/src/packages/Manopt.md]
+Google.EmDash = NO
+Google.EnDash = NO
+Google.Exclamation = NO

--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -18,6 +18,4 @@ Google.Latin = NO
 Google.Periods = NO
 
 [docs/src/packages/Manopt.md]
-Google.EmDash = NO
-Google.EnDash = NO
 Google.Exclamation = NO

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -153,7 +153,7 @@
     has_html = true
 [Manopt]
     user = "JuliaManifolds"
-    rev = "v0.4.42"
+    rev = "c1fc4a5bc8361a20eaa0bcf48aba36fa16089766"
     filename = "Readme.md"
 [NEOSServer]
     user = "odow"

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -154,7 +154,7 @@
 [Manopt]
     user = "JuliaManifolds"
     rev = "v0.4.42"
-    filename = "Readme.me"
+    filename = "Readme.md"
 [NEOSServer]
     user = "odow"
     rev = "v1.1.0"

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -151,6 +151,9 @@
     user = "MadNLP"
     rev = "389561354a774441cd5e6b3aa5fffee102ed222e"
     has_html = true
+[Manopt]
+    user = "JuliaManifolds"
+    rev = "v0.4.42"
 [NEOSServer]
     user = "odow"
     rev = "v1.1.0"

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -154,6 +154,7 @@
 [Manopt]
     user = "JuliaManifolds"
     rev = "v0.4.42"
+    filename = "Readme.me"
 [NEOSServer]
     user = "odow"
     rev = "v1.1.0"

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -126,6 +126,7 @@ The link in the `Solver` column is the corresponding Julia package.
 | [Juniper.jl](https://github.com/lanl-ansi/Juniper.jl)                          |                                                                                  |        | MIT      | (MI)SOCP, (MI)NLP         |
 | [Loraine.jl](https://github.com/kocvara/Loraine.jl)                            |                                                                                  |        | MIT      | LP, SDP                   |
 | [MadNLP.jl](https://github.com/sshin23/MadNLP.jl)                              |                                                                                  |        | MIT      | LP, QP, NLP               |
+| [Manopt.jl](https://github.com/JuliaManifolds/Manopt.jl)                       |                                                                                  |        | MIT      | NLP                       |
 | [MiniZinc](https://www.minizinc.org/)                                          | [MiniZinc.jl](https://github.com/jump-dev/MiniZinc.jl)                           | Manual | MPL-2    | CP-SAT                    |
 | [Minotaur](https://github.com/coin-or/minotaur)                                | [AmplNLWriter.jl](https://github.com/jump-dev/AmplNLWriter.jl)                   | Manual | BSD-like | (MI)NLP                   |
 | [MOSEK](https://www.mosek.com/)                                                | [MosekTools.jl](https://github.com/jump-dev/MosekTools.jl)                       | Manual | Comm.    | (MI)LP, (MI)SOCP, SDP     |

--- a/docs/styles/Vocab/JuMP-Vocab/accept.txt
+++ b/docs/styles/Vocab/JuMP-Vocab/accept.txt
@@ -139,7 +139,7 @@ Jax
 JSONSchema
 Knitro
 KNITRO
-Manopt
+[Mm]anopt
 MATLAB
 MOI
 Mosek

--- a/docs/styles/Vocab/JuMP-Vocab/accept.txt
+++ b/docs/styles/Vocab/JuMP-Vocab/accept.txt
@@ -102,6 +102,7 @@ unregister
 warmstart
 
 % Proper nouns
+Adagrad
 AMPL
 Appveyor
 Artelys
@@ -125,7 +126,8 @@ Dualization
 EAGO
 [Ee]mbotech
 [Ee]cos
-JSONSchema
+Geomstats
+Geoopt
 GLPK
 Gurobi
 GUROBI
@@ -133,8 +135,11 @@ GZip
 Hypatia
 Ipopt
 IPOPT
+Jax
+JSONSchema
 Knitro
 KNITRO
+Manopt
 MATLAB
 MOI
 Mosek
@@ -149,6 +154,7 @@ Penopt
 Plasmo
 puzzlor
 RAPOSa
+Riemopt
 SDPAFamily
 SDPNAL
 Umfpack
@@ -220,6 +226,7 @@ Nemirovski
 Pacaud
 Peng
 Rebennack
+Riemannian
 [Rr]osenbrock
 Schermer
 Schur


### PR DESCRIPTION
cc @kellertuer @mateuszbaran

## Basic

 - [x] Check that the solver is a registered Julia package
 - [x] Check that the solver supports the long-term support release of Julia
 - [x] Check that the solver has a MathOptInterface wrapper
 - [x] Check that the tests call `MOI.Test.runtests`. Some test excludes are
       permissible, but the reason for skipping a particular test should be
       documented.
 - [x] Check that the README and/or documentation provides an example of how to
       use the solver with JuMP: https://manoptjl.org/stable/extensions.html#JuMP.jl

## Documentation

 - [x] Add a new row to the table in `docs/src/installation.md`

## Optional

 - [x] Add package metadata to `docs/packages.toml`