### PR TITLE
Convert constraint starting values

### DIFF
--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -119,12 +119,13 @@ function set_dual_start_value(
     },
     value,
 )
+    model = owner_model(con_ref)
     vectorized_value = vectorize(value, dual_shape(con_ref.shape))
     MOI.set(
-        owner_model(con_ref),
+        model,
         MOI.ConstraintDualStart(),
         con_ref,
-        vectorized_value,
+        model_convert(model, vectorized_value),
     )
     return
 end
@@ -174,11 +175,12 @@ function set_start_value(
     },
     value,
 )
+    model = owner_model(con_ref)
     MOI.set(
-        owner_model(con_ref),
+        model,
         MOI.ConstraintPrimalStart(),
         con_ref,
-        vectorize(value, con_ref.shape),
+        model_convert(model, vectorize(value, con_ref.shape)),
     )
     return
 end

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -156,7 +156,7 @@ function set_dual_start_value(
     value,
 )
     v = _convert_if_something(_value_type(con_ref), value)
-    MOI.set(owner_model(model), MOI.ConstraintDualStart(), con_ref, v)
+    MOI.set(owner_model(con_ref), MOI.ConstraintDualStart(), con_ref, v)
     return
 end
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -87,22 +87,12 @@ end
 
 function _set_converted(
     attr::MOI.AbstractConstraintAttribute,
-    con_ref::ConstraintRef{
-        <:AbstractModel,
-        <:MOI.ConstraintIndex{
-            F,
-        },
-    },
+    con_ref::ConstraintRef{<:AbstractModel,<:MOI.ConstraintIndex{F}},
     value,
 ) where {F<:MOI.AbstractFunction}
     model = owner_model(con_ref)
     V = MOI.Utilities.value_type(value_type(typeof(model)), F)
-    MOI.set(
-        model,
-        attr,
-        con_ref,
-        _convert_if_something(V, value),
-    )
+    MOI.set(model, attr, con_ref, _convert_if_something(V, value))
     return
 end
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -95,7 +95,7 @@ end
 _value_type(::Any, ::Any) = Any
 
 function _value_type(::ConstraintRef{M,<:MOI.ConstraintIndex{F}}) where {M,F}
-    return _value_type(M,F)
+    return _value_type(M, F)
 end
 
 # Returns the value of MOI.ConstraintDualStart in a type-stable way

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -912,6 +912,7 @@ function test_dual_start()
     con = @constraint(model, 2x <= 1)
     @test dual_start_value(con) === nothing
     set_dual_start_value(con, 2)
+    @test MOI.get(model, MOI.ConstraintDualStart(), con) isa Float64
     @test dual_start_value(con) == 2.0
     set_dual_start_value(con, nothing)
     @test dual_start_value(con) === nothing
@@ -925,6 +926,9 @@ function test_dual_start_vector()
     @test dual_start_value(con_vec) === nothing
     set_dual_start_value(con_vec, [1.0, 3.0])
     @test dual_start_value(con_vec) == [1.0, 3.0]
+    set_dual_start_value(con_vec, [1, 3])
+    @test MOI.get(model, MOI.ConstraintDualStart(), con_vec) isa Vector{Float64}
+    @test dual_start_value(con_vec) == [1, 3]
     set_dual_start_value(con_vec, nothing)
     @test dual_start_value(con_vec) === nothing
     return
@@ -936,6 +940,7 @@ function test_primal_start()
     con = @constraint(model, 2x <= 1)
     @test start_value(con) === nothing
     set_start_value(con, 2)
+    @test MOI.get(model, MOI.ConstraintPrimalStart(), con) isa Float64
     @test start_value(con) == 2.0
     set_start_value(con, nothing)
     @test start_value(con) === nothing
@@ -949,6 +954,10 @@ function test_primal_start_vector()
     @test start_value(con_vec) === nothing
     set_start_value(con_vec, [1.0, 3.0])
     @test start_value(con_vec) == [1.0, 3.0]
+    set_start_value(con_vec, [1, 3])
+    attr = MOI.ConstraintPrimalStart()
+    @test MOI.get(model, attr, con_vec) isa Vector{Float64}
+    @test start_value(con_vec) == [1, 3]
     set_start_value(con_vec, nothing)
     @test start_value(con_vec) === nothing
     return


### PR DESCRIPTION
When writing [this post](https://discourse.julialang.org/t/warm-start-using-dualization-with-jump-and-cosmo/106006/6?u=blegat), I found out when when starting integer dual starting values, COSMO was failing here:
https://github.com/oxfordcontrol/COSMO.jl/blob/dd6a6fdbda91231e4c3a108d072389e50a5003ac/src/interface.jl#L167
because `y0` does not have the right element type.
As we are doing the conversion for variable starting values, I thought we might need to do it for constraints as well:
https://github.com/jump-dev/JuMP.jl/blob/b13812d9f7cb5c0c3fa781c3e60400279a2d8907/src/variables.jl#L1685
Now, we might want to use `MOI.Utilities.value_type` as the value type of the function may not be the value type of the variables.
