### PR TITLE
[docs] clarify indicator constraints must use variables for LHS

### DIFF
--- a/docs/src/developers/extensions.md
+++ b/docs/src/developers/extensions.md
@@ -251,7 +251,7 @@ Rewriting my_equal_to to ==
 
 !!! tip
     When parsing a constraint you can recurse into sub-constraint (for example, the
-    `{expr}` in `z => {x <= 1}`) by calling [`parse_constraint`](@ref).
+    `{expr}` in `z --> {x <= 1}`) by calling [`parse_constraint`](@ref).
 
 To prevent JuMP from promoting the set to the same value type as the model, use
 [`SkipModelConvertScalarSetWrapper`](@ref).

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -1366,16 +1366,20 @@ y
 julia> @variable(model, a, Bin)
 a
 
-julia> @constraint(model, a => {x + y <= 1})
-a => {x + y ≤ 1}
+julia> @constraint(model, a --> {x + y <= 1})
+a --> {x + y ≤ 1}
 ```
 
 If the constraint must hold when `a` is zero, add `!` or `¬` before the binary
 variable;
 ```jldoctest indicator
-julia> @constraint(model, !a => {x + y <= 1})
-!a => {x + y ≤ 1}
+julia> @constraint(model, !a --> {x + y <= 1})
+!a --> {x + y ≤ 1}
 ```
+
+!!! warning
+    You cannot use an expression for the left-hand side of an indicator
+    constraint.
 
 ## Semidefinite constraints
 

--- a/docs/src/tutorials/linear/tips_and_tricks.jl
+++ b/docs/src/tutorials/linear/tips_and_tricks.jl
@@ -205,14 +205,14 @@ M = 100
 model = Model();
 @variable(model, x[1:2])
 @variable(model, z, Bin)
-@constraint(model, z => {sum(x) <= 1})
+@constraint(model, z --> {sum(x) <= 1})
 
 # **Example** $x_1 + x_2 \leq 1$ if $z = 0$.
 
 model = Model();
 @variable(model, x[1:2])
 @variable(model, z, Bin)
-@constraint(model, !z => {sum(x) <= 1})
+@constraint(model, !z --> {sum(x) <= 1})
 
 # ### Trick 2
 

--- a/src/indicator.jl
+++ b/src/indicator.jl
@@ -88,5 +88,5 @@ function constraint_string(
     end
     con = ScalarConstraint(constraint.func[2], constraint.set.set)
     con_str = constraint_string(print_mode, con)
-    return var_str * " => {" * con_str * "}"
+    return var_str * " --> {" * con_str * "}"
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -407,6 +407,10 @@ JuMP currently supports the following `expr` objects:
  * `lhs ⟂ rhs`
  * `lhs in rhs`
  * `lhs ∈ rhs`
+ * `z --> {constraint}`
+ * `!z --> {constraint}`
+ * `z <--> {constraint}`
+ * `!z <--> {constraint}`
  * `z => {constraint}`
  * `!z => {constraint}`
 as well as all broadcasted variants.

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -553,7 +553,7 @@ function test_extension_printing_indicator_constraints(
     @variable(model, y)
     ind_constr = @constraint(model, !x => {y <= 1})
 
-    io_test(MIME("text/plain"), ind_constr, "!x => {y $le 1}")
+    io_test(MIME("text/plain"), ind_constr, "!x --> {y $le 1}")
     # TODO: Test in IJulia mode.
     return
 end


### PR DESCRIPTION
x-ref https://github.com/scipopt/SCIP.jl/issues/282#issuecomment-1826189600

cc @LebedevRI