### PR TITLE
Tidy macros/@variable.jl

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -654,13 +654,31 @@ function _wrap_let(model, code)
     return code
 end
 
-function _get_kwarg_value(kwargs, key::Symbol; default = nothing)
-    for kwarg in kwargs
+function _get_kwarg_value(
+    error_fn,
+    kwargs,
+    key::Symbol;
+    default = nothing,
+    escape::Bool = true
+)
+    index, count = 0, 0
+    for (i, kwarg) in enumerate(kwargs)
         if kwarg.args[1] == key
-            return esc(kwarg.args[2])
+            count += 1
+            index = i
         end
     end
-    return default
+    if count == 0
+        return default
+    elseif count == 1
+        if escape
+            return esc(kwargs[index].args[2])
+        else
+            return kwargs[index].args[2]
+        end
+    else
+        error_fn("`$key` keyword argument was given $count times.")
+    end
 end
 
 include("macros/@objective.jl")

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -659,7 +659,7 @@ function _get_kwarg_value(
     kwargs,
     key::Symbol;
     default = nothing,
-    escape::Bool = true
+    escape::Bool = true,
 )
     index, count = 0, 0
     for (i, kwarg) in enumerate(kwargs)

--- a/src/macros/@constraint.jl
+++ b/src/macros/@constraint.jl
@@ -124,11 +124,13 @@ macro constraint(input_args...)
     _add_positional_args(build_call, extra)
     _add_kw_args(build_call, kwargs; exclude = [:base_name, :set_string_name])
     base_name = _get_kwarg_value(
+        error_fn,
         kwargs,
         :base_name;
         default = string(something(Containers._get_name(c), "")),
     )
     set_name_flag = _get_kwarg_value(
+        error_fn,
         kwargs,
         :set_string_name;
         default = :(set_string_names_on_creation($model)),

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -90,15 +90,7 @@ function _set_integer_or_error(error_fn::Function, info::_VariableInfoExpr)
     return
 end
 
-function _is_info_keyword(kw::Expr)
-    return kw.args[1] in [:lower_bound, :upper_bound, :start, :binary, :integer]
-end
-
-# :(start = 0)     -> (:start, 0)
-# :(start = i + 1) -> (:start, :($(Expr(:escape, :(i + 1)))))
-function _keywordify(kw::Expr)
-    return (kw.args[1], _esc_non_constant(kw.args[2]))
-end
+const _INFO_KWARGS = [:lower_bound, :upper_bound, :start, :binary, :integer]
 
 function _VariableInfoExpr(;
     lower_bound = NaN,


### PR DESCRIPTION
Part of #3513 

This one takes a bit to get your head around because we shouldn't map `set` if it is `@variable(model, x[1:2, 1:2], set = PSDCone())` but we should if it depends on the indices.