### PR TITLE
Rename test_throws_strip and test_macro_throws for clarity

### DIFF
--- a/test/test_complement.jl
+++ b/test/test_complement.jl
@@ -34,7 +34,7 @@ end
 function test_scalar_error_x_F()
     model = Model()
     @variable(model, x >= 0)
-    @test_throws_strip(
+    @test_throws_runtime(
         ErrorException(
             "In `@constraint(model, x ⟂ 2x - 1)`: second term must be a " *
             "variable.",
@@ -47,7 +47,7 @@ end
 function test_scalar_error_F_F()
     model = Model()
     @variable(model, x >= 0)
-    @test_throws_strip(
+    @test_throws_runtime(
         ErrorException(
             "In `@constraint(model, x + 1 ⟂ 2x - 1)`: second term must " *
             "be a variable.",
@@ -60,7 +60,7 @@ end
 function test_scalar_error_0_F()
     model = Model()
     @variable(model, x >= 0)
-    @test_throws_strip(
+    @test_throws_runtime(
         ErrorException(
             "In `@constraint(model, 0 ⟂ 2x - 1)`: second term must be a " *
             "variable.",
@@ -94,7 +94,7 @@ end
 function test_vector_error_length_mismatch()
     model = Model()
     @variable(model, x[1:2] >= 0)
-    @test_throws_strip(
+    @test_throws_runtime(
         ErrorException(
             "In `@constraint(model, x ⟂ [x[1]])`: size of mapping does " *
             "not match size of variables: (2,) != (1,).",
@@ -107,7 +107,7 @@ end
 function test_vector_error_x_F()
     model = Model()
     @variable(model, x[1:2] >= 0)
-    @test_throws_strip(
+    @test_throws_runtime(
         ErrorException(
             "In `@constraint(model, x ⟂ 2x .- 1)`: second term must be an " *
             "array of variables.",
@@ -119,7 +119,7 @@ end
 function test_vector_error_F_F()
     model = Model()
     @variable(model, x[1:2] >= 0)
-    @test_throws_strip(
+    @test_throws_runtime(
         ErrorException(
             "In `@constraint(model, x .+ 1 ⟂ 2x .- 1)`: second term must " *
             "be an array of variables.",
@@ -133,7 +133,7 @@ function test_vector_error_0_F()
     model = Model()
     @variable(model, x[1:2] >= 0)
     y = [1.2, -1.3]
-    @test_throws_strip(
+    @test_throws_runtime(
         ErrorException(
             "In `@constraint(model, y ⟂ 2x .- 1)`: second term must " *
             "be an array of variables.",

--- a/test/test_complex.jl
+++ b/test/test_complex.jl
@@ -280,7 +280,7 @@ function test_HermitianPSDCone_general_matrix_error()
     Y = X + LinearAlgebra.I(2) * t
     @test LinearAlgebra.ishermitian(Y)
     @test !(Y isa LinearAlgebra.Hermitian)
-    @test_throws_strip(
+    @test_throws_runtime(
         ErrorException(
             "In `@constraint(model, Y in HermitianPSDCone())`: " *
             "Unable to add matrix in HermitianPSDCone because the matrix is " *

--- a/test/test_nlp.jl
+++ b/test/test_nlp.jl
@@ -399,11 +399,11 @@ end
 function test_parse_unsupported_generator()
     model = Model()
     @variable(model, x[1:2])
-    @test_macro_throws(
+    @test_throws_parsetime(
         ErrorException("Unsupported generator `:min`"),
         @NLexpression(model, min(x[i] for i in 1:2)),
     )
-    @test_macro_throws(
+    @test_throws_parsetime(
         ErrorException("Unsupported generator `:max`"),
         @NLexpression(model, max(x[i] for i in 1:2)),
     )
@@ -482,7 +482,7 @@ function test_error_on_begin_end()
         "`begin...end` blocks are not supported in nonlinear macros. The " *
         "nonlinear expression must be a single statement.",
     )
-    @test_macro_throws(err, @NLobjective(model, Max, begin
+    @test_throws_parsetime(err, @NLobjective(model, Max, begin
         sin(x) + 1
     end))
     return
@@ -498,7 +498,7 @@ end
 function test_error_on_getfield_in_expression()
     model = Model()
     @variable(model, x[1:2])
-    @test_macro_throws(
+    @test_throws_parsetime(
         ErrorException,
         @NLexpression(model, sum(foo.bar(i) * x[i] for i in 1:2))
     )

--- a/test/test_reified.jl
+++ b/test/test_reified.jl
@@ -56,7 +56,7 @@ function test_reified_inconsistent()
     @variable(model, x)
     @variable(model, z, Bin)
     expr = :(z <--> {x .== 1})
-    @test_macro_throws(
+    @test_throws_parsetime(
         ErrorException(
             "In `@constraint(model, $expr)`: " *
             "vectorized constraints cannot be used with reification.",
@@ -71,7 +71,7 @@ function test_reified_no_curly_bracket()
     @variable(model, x)
     @variable(model, z, Bin)
     expr = :(z <--> x == 1)
-    @test_macro_throws(
+    @test_throws_parsetime(
         ErrorException(
             "In `@constraint(model, $expr)`: " *
             "Invalid right-hand side `x == 1` of reified constraint. " *

--- a/test/test_variable.jl
+++ b/test/test_variable.jl
@@ -155,8 +155,8 @@ function test_extension_variable_interval(
     _has_bounds(bothb3, 0.0, 1.0)
     @variable(model, 1 ≥ bothb4 ≥ 0)
     _has_bounds(bothb4, 0.0, 1.0)
-    @test_macro_throws ErrorException @variable(model, 1 ≥ bothb5 ≤ 0)
-    @test_macro_throws ErrorException @variable(model, 1 ≤ bothb6 ≥ 0)
+    @test_throws_parsetime ErrorException @variable(model, 1 ≥ bothb5 ≤ 0)
+    @test_throws_parsetime ErrorException @variable(model, 1 ≤ bothb6 ≥ 0)
     return
 end
 
@@ -597,7 +597,7 @@ function test_extension_variables_constrained_on_creation_errors(
     VariableRefType = VariableRef,
 )
     model = ModelType()
-    @test_macro_throws(
+    @test_throws_parsetime(
         ErrorException(
             "In `@variable(model, x[1:2] in SecondOrderCone(), set = PSDCone())`: " *
             "Cannot use set keyword because the variable is already " *
@@ -605,7 +605,7 @@ function test_extension_variables_constrained_on_creation_errors(
         ),
         @variable(model, x[1:2] in SecondOrderCone(), set = PSDCone()),
     )
-    @test_macro_throws(
+    @test_throws_parsetime(
         ErrorException(
             "In `@variable(model, x[1:2] in SecondOrderCone(), PSD)`: " *
             "Cannot pass `PSD` as a positional argument because the variable " *
@@ -613,7 +613,7 @@ function test_extension_variables_constrained_on_creation_errors(
         ),
         @variable(model, x[1:2] in SecondOrderCone(), PSD),
     )
-    @test_macro_throws(
+    @test_throws_parsetime(
         ErrorException(
             "In `@variable(model, x[1:2, 1:2], PSD, Symmetric)`: " *
             "Cannot pass `Symmetric` as a positional argument because the " *
@@ -621,7 +621,7 @@ function test_extension_variables_constrained_on_creation_errors(
         ),
         @variable(model, x[1:2, 1:2], PSD, Symmetric),
     )
-    @test_macro_throws(
+    @test_throws_parsetime(
         ErrorException(
             "In `@variable(model, x[1:2], set = SecondOrderCone(), set = PSDCone())`: " *
             "the keyword argument `set` was given multiple times.",


### PR DESCRIPTION
Using the right one of these _always_ catches me out. Let's use actually explanatory names so we know the difference between them.