### PR TITLE
[docs] mention extensions in relevant tutorials

### DIFF
--- a/docs/src/tutorials/nonlinear/nested_problems.jl
+++ b/docs/src/tutorials/nonlinear/nested_problems.jl
@@ -33,7 +33,7 @@
 # see the [User-defined Hessians](@ref) tutorial.
 
 # !!! info
-#     The JuMP extension [BilevelJuMP.jl](@ref) can also be used to model and
+#     The JuMP extension [BilevelJuMP.jl](./../packages/BilevelJuMP) can also be used to model and
 #     solve bilevel optimization problems.
 
 # This tutorial uses the following packages:

--- a/docs/src/tutorials/nonlinear/nested_problems.jl
+++ b/docs/src/tutorials/nonlinear/nested_problems.jl
@@ -32,6 +32,10 @@
 # For a simpler example of writing a user-defined operator,
 # see the [User-defined Hessians](@ref) tutorial.
 
+# !!! info
+#     The JuMP extension [BilevelJuMP.jl](@ref) can also be used to model and
+#     solve bilevel optimization problems.
+
 # This tutorial uses the following packages:
 
 using JuMP

--- a/docs/src/tutorials/nonlinear/nested_problems.jl
+++ b/docs/src/tutorials/nonlinear/nested_problems.jl
@@ -33,7 +33,7 @@
 # see the [User-defined Hessians](@ref) tutorial.
 
 # !!! info
-#     The JuMP extension [BilevelJuMP.jl](./../packages/BilevelJuMP) can also be used to model and
+#     The JuMP extension [BilevelJuMP.jl](../../packages/BilevelJuMP.md) can also be used to model and
 #     solve bilevel optimization problems.
 
 # This tutorial uses the following packages:

--- a/docs/src/tutorials/nonlinear/rocket_control.jl
+++ b/docs/src/tutorials/nonlinear/rocket_control.jl
@@ -13,7 +13,7 @@
 # The example is an optimal control problem of a nonlinear rocket.
 
 # !!! info
-#     The JuMP extension [InfiniteOpt.jl](../../../packages/InfiniteOpt) can also be
+#     The JuMP extension [InfiniteOpt.jl](../../packages/InfiniteOpt) can also be
 #     used to model and solve optimal control problems.
 
 # This tutorial uses the following packages:

--- a/docs/src/tutorials/nonlinear/rocket_control.jl
+++ b/docs/src/tutorials/nonlinear/rocket_control.jl
@@ -13,7 +13,7 @@
 # The example is an optimal control problem of a nonlinear rocket.
 
 # !!! info
-#     The JuMP extension [InfiniteOpt.jl](../../packages/InfiniteOpt) can also be
+#     The JuMP extension [InfiniteOpt.jl](./../../packages/InfiniteOpt) can also be
 #     used to model and solve optimal control problems.
 
 # This tutorial uses the following packages:

--- a/docs/src/tutorials/nonlinear/rocket_control.jl
+++ b/docs/src/tutorials/nonlinear/rocket_control.jl
@@ -13,7 +13,7 @@
 # The example is an optimal control problem of a nonlinear rocket.
 
 # !!! info
-#     The JuMP extension [InfiniteOpt.jl](./../../packages/InfiniteOpt) can also be
+#     The JuMP extension [InfiniteOpt.jl](../../packages/InfiniteOpt.md) can also be
 #     used to model and solve optimal control problems.
 
 # This tutorial uses the following packages:

--- a/docs/src/tutorials/nonlinear/rocket_control.jl
+++ b/docs/src/tutorials/nonlinear/rocket_control.jl
@@ -13,7 +13,7 @@
 # The example is an optimal control problem of a nonlinear rocket.
 
 # !!! info
-#     The JuMP extension [InfiniteOpt.jl](/packages/InfiniteOpt) can also be
+#     The JuMP extension [InfiniteOpt.jl](../../../packages/InfiniteOpt) can also be
 #     used to model and solve optimal control problems.
 
 # This tutorial uses the following packages:

--- a/docs/src/tutorials/nonlinear/rocket_control.jl
+++ b/docs/src/tutorials/nonlinear/rocket_control.jl
@@ -12,6 +12,10 @@
 
 # The example is an optimal control problem of a nonlinear rocket.
 
+# !!! info
+#     The JuMP extension [InfiniteOpt.jl](/packages/InfiniteOpt) can also be
+#     used to model and solve optimal control problems.
+
 # This tutorial uses the following packages:
 
 using JuMP

--- a/docs/src/tutorials/nonlinear/space_shuttle_reentry_trajectory.jl
+++ b/docs/src/tutorials/nonlinear/space_shuttle_reentry_trajectory.jl
@@ -32,7 +32,7 @@
 # by John T. Betts.
 
 # !!! info
-#     The JuMP extension [InfiniteOpt.jl](/packages/InfiniteOpt) can also be
+#     The JuMP extension [InfiniteOpt.jl](../../../packages/InfiniteOpt) can also be
 #     used to model and solve optimal control problems.
 
 # !!! tip

--- a/docs/src/tutorials/nonlinear/space_shuttle_reentry_trajectory.jl
+++ b/docs/src/tutorials/nonlinear/space_shuttle_reentry_trajectory.jl
@@ -31,6 +31,10 @@
 # ["Practical Methods for Optimal Control and Estimation Using Nonlinear Programming"](https://epubs.siam.org/doi/book/10.1137/1.9780898718577),
 # by John T. Betts.
 
+# !!! info
+#     The JuMP extension [InfiniteOpt.jl](/packages/InfiniteOpt) can also be
+#     used to model and solve optimal control problems.
+
 # !!! tip
 #     This tutorial is a more-complicated version of the [Rocket Control](@ref) example.
 #     If you are new to solving nonlinear programs in JuMP, you may want to start there instead.

--- a/docs/src/tutorials/nonlinear/space_shuttle_reentry_trajectory.jl
+++ b/docs/src/tutorials/nonlinear/space_shuttle_reentry_trajectory.jl
@@ -32,7 +32,7 @@
 # by John T. Betts.
 
 # !!! info
-#     The JuMP extension [InfiniteOpt.jl](/../../packages/InfiniteOpt) can also be
+#     The JuMP extension [InfiniteOpt.jl](../../packages/InfiniteOpt.md) can also be
 #     used to model and solve optimal control problems.
 
 # !!! tip

--- a/docs/src/tutorials/nonlinear/space_shuttle_reentry_trajectory.jl
+++ b/docs/src/tutorials/nonlinear/space_shuttle_reentry_trajectory.jl
@@ -32,7 +32,7 @@
 # by John T. Betts.
 
 # !!! info
-#     The JuMP extension [InfiniteOpt.jl](../../../packages/InfiniteOpt) can also be
+#     The JuMP extension [InfiniteOpt.jl](../../packages/InfiniteOpt) can also be
 #     used to model and solve optimal control problems.
 
 # !!! tip

--- a/docs/src/tutorials/nonlinear/space_shuttle_reentry_trajectory.jl
+++ b/docs/src/tutorials/nonlinear/space_shuttle_reentry_trajectory.jl
@@ -32,7 +32,7 @@
 # by John T. Betts.
 
 # !!! info
-#     The JuMP extension [InfiniteOpt.jl](../../packages/InfiniteOpt) can also be
+#     The JuMP extension [InfiniteOpt.jl](/../../packages/InfiniteOpt) can also be
 #     used to model and solve optimal control problems.
 
 # !!! tip


### PR DESCRIPTION
x-ref https://github.com/jump-dev/JuMP.jl/pull/3623#issuecomment-1852127896

I think the rule for this is that the extension must be part of the `Extensions` tab of the JuMP docs, and we must link there. That means if we ever remove an extension from the docs, it'll also catch removing these links.