### PR TITLE
Fix stdlib compat bounds in Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,15 +21,15 @@ JuMPDimensionalDataExt = "DimensionalData"
 
 [compat]
 DimensionalData = "0.24"
-LinearAlgebra = "1.6"
+LinearAlgebra = "<0.0.1, 1.6"
 MacroTools = "0.5"
 MathOptInterface = "1.19"
 MutableArithmetics = "1.1"
 OrderedCollections = "1"
-Printf = "1.6"
+Printf = "<0.0.1, 1.6"
 PrecompileTools = "1"
-SparseArrays = "1.6"
-Test = "1.6"
+SparseArrays = "<0.0.1, 1.6"
+Test = "<0.0.1, 1.6"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
x-ref https://github.com/infiniteopt/InfiniteOpt.jl/pull/334#issuecomment-1854548988

This works around a bug in Julia v1.6 that causes an issue when `Pkg` operations are run during tests.