### PR TITLE
[docs] tick off macro refactoring from roadmap

### DIFF
--- a/docs/src/developers/roadmap.md
+++ b/docs/src/developers/roadmap.md
@@ -30,7 +30,8 @@ represent broad themes that we see as areas in which JuMP could be improved.
    [https://github.com/jump-dev/JuMP.jl/issues/2099](https://github.com/jump-dev/JuMP.jl/issues/2099)
    JuMP is restricted to problems with scalar-valued objectives. We want to
    extend this to vector-valued problems.
- - Refactor the internal code of JuMP's macros. The code in `src/macros.jl` is
+ - **Done [#3629](https://github.com/jump-dev/JuMP.jl/pull/3629)** Refactor the
+   internal code of JuMP's macros. The code in `src/macros.jl` is
    some of the oldest part of JuMP and is difficult to read, modify, and extend.
    We should overhaul the internals of JuMP's macros---without making
    user-visible breaking changes---to improve their long-term maintainability.

--- a/src/Containers/macro.jl
+++ b/src/Containers/macro.jl
@@ -606,3 +606,25 @@ macro container(input_args...)
     end
     return :($(esc(name)) = $code)
 end
+
+"""
+    _extract_kw_args(args)
+
+!!! warning
+    This function is deprecated. Use [`parse_macro_arguments`](@ref) instead.
+"""
+function _extract_kw_args(args)
+    flat_args, kw_args, requested_container = Any[], Any[], :Auto
+    for arg in args
+        if Meta.isexpr(arg, :(=))
+            if arg.args[1] == :container
+                requested_container = arg.args[2]
+            else
+                push!(kw_args, arg)
+            end
+        else
+            push!(flat_args, arg)
+        end
+    end
+    return flat_args, kw_args, requested_container
+end


### PR DESCRIPTION
Closes #3513

I have made a whole suite of changes recently:

 * #3600
 * #3601
 * #3603
 * #3606 
 * #3607
 * #3610
 * #3611
 * #3612
 * #3613
 * #3614
 * #3615
 * #3616
 * #3617
 * #3619
 * #3620
 * #3631
 * #3632 
 * #3633

Looking at a diff isn't too useful, but here was the code before I started:

https://github.com/jump-dev/JuMP.jl/blob/v1.17.0/src/macros.jl

And here it is now:

https://github.com/jump-dev/JuMP.jl/blob/master/src/macros.jl
https://github.com/jump-dev/JuMP.jl/tree/master/src/macros
https://github.com/jump-dev/JuMP.jl/blob/master/src/Containers/macro.jl

I'm particularly pleased with the now very readable:
https://github.com/jump-dev/JuMP.jl/blob/65d12dc7ca6a0fa726b18656e28e59d089dea333/src/macros/%40expression.jl#L66-L98
when it was
https://github.com/jump-dev/JuMP.jl/blob/419c3344c9a62692e344da745765ac7daec95c01/src/macros.jl#L1923-L1975

For extensions, @pulsipher has been trying this out in InfiniteOpt: https://github.com/infiniteopt/InfiniteOpt.jl/pull/334, and I think it's a big win.

Now is the chance to take a read through and open up any bike shedding, etc.