### PR TITLE
Fix escaping of base_name arguments in macros

### DIFF
--- a/src/Containers/macro.jl
+++ b/src/Containers/macro.jl
@@ -425,13 +425,10 @@ function build_name_expr(
     kwargs::Dict{Symbol,Any},
 )
     base_name = get(kwargs, :base_name, string(something(name, "")))
-    if base_name isa Expr
-        base_name = esc(base_name)
-    end
     if isempty(index_vars) || base_name == ""
-        return base_name
+        return esc(base_name)
     end
-    expr = Expr(:call, :string, base_name, "[")
+    expr = Expr(:call, :string, esc(base_name), "[")
     for index in index_vars
         # Converting the arguments to strings before concatenating is faster:
         # https://github.com/JuliaLang/julia/issues/29550.

--- a/src/Containers/macro.jl
+++ b/src/Containers/macro.jl
@@ -425,10 +425,13 @@ function build_name_expr(
     kwargs::Dict{Symbol,Any},
 )
     base_name = get(kwargs, :base_name, string(something(name, "")))
-    if isempty(index_vars) || base_name == ""
-        return esc(base_name)
+    if !(base_name isa String)
+        base_name = esc(base_name)
     end
-    expr = Expr(:call, :string, esc(base_name), "[")
+    if isempty(index_vars) || base_name == ""
+        return base_name
+    end
+    expr = Expr(:call, :string, base_name, "[")
     for index in index_vars
         # Converting the arguments to strings before concatenating is faster:
         # https://github.com/JuliaLang/julia/issues/29550.

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -2167,4 +2167,22 @@ function test_expression_container_kwarg()
     return
 end
 
+function test_base_name_escape()
+    model = Model()
+    x = @variable(model)
+    @test name(x) == ""
+    x = @variable(model, [1:2])
+    @test name.(x) == ["", ""]
+    x = @variable(model, base_name = "x")
+    @test name(x) == "x"
+    x = @variable(model, [1:2], base_name = "x")
+    @test name.(x) == ["x[1]", "x[2]"]
+    y = "abc"
+    x = @variable(model, base_name = y)
+    @test name(x) == "abc"
+    x = @variable(model, [1:2], base_name = y)
+    @test name.(x) == ["abc[1]", "abc[2]"]
+    return
+end
+
 end  # module


### PR DESCRIPTION
x-ref https://github.com/jump-dev/JuMP.jl/pull/3629#issuecomment-1856679309