### PR TITLE
Fix broadcasting f-in-set in constraint macro

### DIFF
--- a/src/macros/@constraint.jl
+++ b/src/macros/@constraint.jl
@@ -655,7 +655,7 @@ function parse_constraint_call(
 )
     f, parse_code = _rewrite_expression(func)
     build_call = if vectorized
-        :(build_constraint.($error_fn, _desparsify($f), Ref($(esc(set)))))
+        :(build_constraint.($error_fn, _desparsify($f), $(esc(set))))
     else
         :(build_constraint($error_fn, $f, $(esc(set))))
     end

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -2185,4 +2185,17 @@ function test_base_name_escape()
     return
 end
 
+function test_constraint_broadcast_in_set()
+    model = Model()
+    @variable(model, x[1:2])
+    sets = [MOI.GreaterThan(1.0), MOI.GreaterThan(2.0)]
+    c = @constraint(model, 1.0 * x .∈ sets)
+    @test constraint_object(c[1]).set == MOI.GreaterThan(1.0)
+    @test constraint_object(c[2]).set == MOI.GreaterThan(2.0)
+    c = @constraint(model, 1.0 * x .∈ MOI.ZeroOne())
+    @test constraint_object(c[1]).set == MOI.ZeroOne()
+    @test constraint_object(c[2]).set == MOI.ZeroOne()
+    return
+end
+
 end  # module


### PR DESCRIPTION
x-ref #3629 

So this line was never covered:
https://app.codecov.io/gh/jump-dev/JuMP.jl/commit/419c3344c9a62692e344da745765ac7daec95c01/blob/src/macros.jl#L839

The `Ref` was added here:
https://github.com/jump-dev/JuMP.jl/pull/1438/files#diff-e628f2d30670b1af0cdd9c9c520aaddc44021cd503e169d767ec49c95f189264R288

I guess because we didn't yet have:
https://github.com/jump-dev/MathOptInterface.jl/commit/ed08ee98f5d7ad65bbd1f5414f5b448e0d2dc78c

I think it's because only the `.∈` syntax supports this. You can't `.` the in-fix `in` operator:
```Julia
julia> dump(:(x .in y))
ERROR: syntax: space before "." not allowed in "x ." at REPL[76]:1
Stacktrace:
 [1] top-level scope
   @ none:1

julia> dump(:(x in. y))
ERROR: syntax: invalid identifier name "."
Stacktrace:
 [1] top-level scope
   @ none:1
```