### PR TITLE
Fix modifying user-expressions in macros

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -231,7 +231,7 @@ A helper function so that we can change how we rewrite expressions in a single
 place and have it cascade to all locations in the JuMP macros that rewrite
 expressions.
 """
-function _rewrite_expression(expr)
+function _rewrite_expression(expr::Expr)
     new_expr = MacroTools.postwalk(_rewrite_to_jump_logic, expr)
     new_aff, parse_aff = _MA.rewrite(new_expr; move_factors_into_sums = false)
     ret = gensym()
@@ -240,6 +240,17 @@ function _rewrite_expression(expr)
         $ret = $flatten!($new_aff)
     end
     return ret, code
+end
+
+"""
+    _rewrite_expression(expr)
+
+If `expr` is not an `Expr`, then rewriting it won't do anything. We just need to
+copy if it is mutable so that future operations do not modify the user's data.
+"""
+function _rewrite_expression(expr)
+    ret = gensym()
+    return ret, :($ret = $_MA.copy_if_mutable($(esc(expr))))
 end
 
 """

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -2223,4 +2223,15 @@ function test_constraint_broadcast_in_set()
     return
 end
 
+function test_macro_modify_user_data()
+    model = Model()
+    @variable(model, x)
+    @expression(model, e, x + 5)
+    @constraint(model, -10 <= e <= 10)
+    @test isequal_canonical(e, x + 5)
+    @constraint(model, e in MOI.LessThan(1.0))
+    @test isequal_canonical(e, x + 5)
+    return
+end
+
 end  # module


### PR DESCRIPTION
Closes #3638 

Looks like this was caused by the new `MA.rewrite( ; move_factors_into_sums = false)` code path in https://github.com/jump-dev/JuMP.jl/pull/3106

```julia
julia> JuMP._MA.rewrite(:(e))
(Symbol("##308"), :(var"##308" = begin
          #= /Users/oscar/.julia/packages/MutableArithmetics/NIXlP/src/rewrite.jl:325 =#
          let
              #= /Users/oscar/.julia/packages/MutableArithmetics/NIXlP/src/rewrite.jl:326 =#
              begin
                  var"##310" = MutableArithmetics.Zero()
                  var"##309" = (MutableArithmetics.operate!!)(MutableArithmetics.add_mul, var"##310", $(Expr(:escape, :e)))
              end
              #= /Users/oscar/.julia/packages/MutableArithmetics/NIXlP/src/rewrite.jl:327 =#
              var"##309"
          end
      end))

julia> JuMP._MA.rewrite(:(e); move_factors_into_sums = false)
(Symbol("##311"), :(var"##311" = begin
          #= /Users/oscar/.julia/packages/MutableArithmetics/NIXlP/src/rewrite.jl:325 =#
          let
              #= /Users/oscar/.julia/packages/MutableArithmetics/NIXlP/src/rewrite.jl:326 =#
              begin
                  #= /Users/oscar/.julia/packages/MutableArithmetics/NIXlP/src/rewrite.jl:321 =#
              end
              #= /Users/oscar/.julia/packages/MutableArithmetics/NIXlP/src/rewrite.jl:327 =#
              $(Expr(:escape, :e))
          end
      end))
```

Note how the latter does not create a copy of the expression.