### PR TITLE
[docs] update to GA-4

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -566,7 +566,7 @@ remotes = Dict(pkgdir(MOI) => (gh_moi, version))
     format = Documenter.HTML(;
         # See https://github.com/JuliaDocs/Documenter.jl/issues/868
         prettyurls = get(ENV, "CI", nothing) == "true",
-        analytics = "UA-44252521-1",
+        analytics = "G-0RZ8X3D3D0",
         mathengine = Documenter.MathJax2(),
         collapselevel = 1,
         assets = ["assets/extra_styles.css", "assets/citations.css"],


### PR DESCRIPTION
This won't fix all of the existing HTML files in gh-pages branch. I'll need to fix that manually.

I've tested that this is all we need to do in SDDP.jl https://github.com/odow/SDDP.jl/pull/723

x-ref https://github.com/JuliaDocs/Documenter.jl/issues/2016