### PR TITLE
Throw informative error when parsing reference sets in macros

### DIFF
--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -2254,4 +2254,70 @@ function test_escaping_of_set_kwarg()
     return
 end
 
+function test_error_parsing_reference_sets()
+    model = Model()
+    @variable(model, a)
+    @test_throws_runtime(
+        ErrorException(
+            "In `@variable(model, b[1:a])`: unexpected error parsing reference set: 1:a",
+        ),
+        @variable(model, b[1:a]),
+    )
+    @test_throws_runtime(
+        ErrorException(
+            "In `@variable(model, b[1:2, 1:a])`: unexpected error parsing reference set: 1:a",
+        ),
+        @variable(model, b[1:2, 1:a]),
+    )
+    @test_throws_runtime(
+        ErrorException(
+            "In `@variable(model, b[i = 1:a, 1:i])`: unexpected error parsing reference set: 1:a",
+        ),
+        @variable(model, b[i = 1:a, 1:i]),
+    )
+    @test_throws_runtime(
+        ErrorException(
+            "In `@variable(model, b[i = 1:2, a:i])`: unexpected error parsing reference set: a:i",
+        ),
+        @variable(model, b[i = 1:2, a:i]),
+    )
+    @test_throws_runtime(
+        ErrorException(
+            "In `@variable(model, b[i = 1:2; i < a])`: unexpected error parsing condition: i < a",
+        ),
+        @variable(model, b[i = 1:2; i < a]),
+    )
+    @test_throws_runtime(
+        ErrorException(
+            "In `@expression(model, b[1:a], a + 1)`: unexpected error parsing reference set: 1:a",
+        ),
+        @expression(model, b[1:a], a + 1),
+    )
+    @test_throws_runtime(
+        ErrorException(
+            "In `@expression(model, b[1:2, 1:a], a + 1)`: unexpected error parsing reference set: 1:a",
+        ),
+        @expression(model, b[1:2, 1:a], a + 1),
+    )
+    @test_throws_runtime(
+        ErrorException(
+            "In `@expression(model, b[i = 1:a, 1:i], a + 1)`: unexpected error parsing reference set: 1:a",
+        ),
+        @expression(model, b[i = 1:a, 1:i], a + 1),
+    )
+    @test_throws_runtime(
+        ErrorException(
+            "In `@expression(model, b[i = 1:2, a:i], a + 1)`: unexpected error parsing reference set: a:i",
+        ),
+        @expression(model, b[i = 1:2, a:i], a + 1),
+    )
+    @test_throws_runtime(
+        ErrorException(
+            "In `@expression(model, b[i = 1:2; i < a], a + 1)`: unexpected error parsing condition: i < a",
+        ),
+        @expression(model, b[i = 1:2; i < a], a + 1),
+    )
+    return
+end
+
 end  # module


### PR DESCRIPTION
Closes #3652 

Error from #3652 is now:
```Julia
julia> using JuMP

julia> model = Model()
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: NO_OPTIMIZER
Solver name: No optimizer attached.

julia> @variable(model, a, Int)
a

julia> @variable(model, b[1:a], Int) 
ERROR: At REPL[67]:1: `@variable(model, b[1:a], Int)`: unexpected error parsing reference set: 1:a
Stacktrace:
 [1] error(::String, ::String, ::Expr)
   @ Base ./error.jl:44
 [2] (::JuMP.Containers.var"#error_fn#98"{String})(::String, ::Vararg{Any})
   @ JuMP.Containers ~/.julia/dev/JuMP/src/Containers/macro.jl:315
 [3] macro expansion
   @ ~/.julia/dev/JuMP/src/Containers/macro.jl:92 [inlined]
 [4] macro expansion
   @ ~/.julia/dev/JuMP/src/macros.jl:375 [inlined]
 [5] top-level scope
   @ REPL[67]:1

caused by: MethodError: no method matching (::Colon)(::Int64, ::VariableRef)

Closest candidates are:
  (::Colon)(::T, ::Any, ::T) where T<:Real
   @ Base range.jl:50
  (::Colon)(::A, ::Any, ::C) where {A<:Real, C<:Real}
   @ Base range.jl:10
  (::Colon)(::T, ::Any, ::T) where T
   @ Base range.jl:49
  ...

Stacktrace:
 [1] macro expansion
   @ ~/.julia/dev/JuMP/src/Containers/macro.jl:90 [inlined]
 [2] macro expansion
   @ ~/.julia/dev/JuMP/src/macros.jl:375 [inlined]
 [3] top-level scope
   @ REPL[67]:1
```

cc @LebedevRI