### PR TITLE
Bump compat of DimensionalData

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 JuMPDimensionalDataExt = "DimensionalData"
 
 [compat]
-DimensionalData = "0.24"
+DimensionalData = "0.24, 0.25"
 LinearAlgebra = "<0.0.1, 1.6"
 MacroTools = "0.5"
 MathOptInterface = "1.25.2"

--- a/docs/src/developers/checklists.md
+++ b/docs/src/developers/checklists.md
@@ -23,6 +23,8 @@ done in the same commit, or separately. The last commit should have the message
        READMEs do not break the JuMP docs in arbitrary commits, and to ensure
        that the versions are compatible with the latest JuMP and
        MathOptInterface releases.
+ - [ ] Check compat of `DimensionalData` in `Project.toml`
+ - [ ] Check compat of `MacroTools` in `Project.toml`
  - [ ] Update `docs/src/changelog.md`
  - [ ] Run https://github.com/jump-dev/JuMP.jl/actions/workflows/extension-tests.yml
        using a `workflow_dispatch` trigger to check for any changes in JuMP that


### PR DESCRIPTION
So it actually took all of 2 months after merging https://github.com/jump-dev/JuMP.jl/pull/3413#issuecomment-1603425251 for a breaking release to happen.

x-ref https://discourse.julialang.org/t/jump-dimensionaldata-compatibility/109736

cc @Ethan-russell