### PR TITLE
Allow MOI.ModelLike as the optimizer instead of MOI.AbstractOptimizer

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -84,7 +84,7 @@ value_type(::Type{<:AbstractModel}) = Float64
 mutable struct GenericModel{T<:Real} <: AbstractModel
     # In MANUAL and AUTOMATIC modes, CachingOptimizer.
     # In DIRECT mode, will hold an AbstractOptimizer.
-    moi_backend::MOI.AbstractOptimizer
+    moi_backend::MOI.ModelLike
     # List of shapes of constraints that are not `ScalarShape` or `VectorShape`.
     shapes::Dict{MOI.ConstraintIndex,AbstractShape}
     # List of bridges to add in addition to the ones added in

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -444,6 +444,12 @@ function optimize!(
     if mode(model) != DIRECT && MOIU.state(backend(model)) == MOIU.NO_OPTIMIZER
         throw(NoOptimizer())
     end
+    if !(unsafe_backend(model) isa MOI.AbstractOptimizer)
+        error(
+            "Cannot call `optimize!` because the provided optimizer is not " *
+            "a subtype of `MOI.AbstractOptimizer`.",
+        )
+    end
     try
         MOI.optimize!(backend(model))
     catch err

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -444,10 +444,12 @@ function optimize!(
     if mode(model) != DIRECT && MOIU.state(backend(model)) == MOIU.NO_OPTIMIZER
         throw(NoOptimizer())
     end
-    if !(unsafe_backend(model) isa MOI.AbstractOptimizer)
+    optimizer = unsafe_backend(model)
+    if !(optimizer isa MOI.AbstractOptimizer)
         error(
             "Cannot call `optimize!` because the provided optimizer is not " *
-            "a subtype of `MOI.AbstractOptimizer`.",
+            "a subtype of `MOI.AbstractOptimizer`.\n\nThe optimizer is:\n\n" *
+            sprint(show, optimizer) * "\n",
         )
     end
     try

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -449,7 +449,8 @@ function optimize!(
         error(
             "Cannot call `optimize!` because the provided optimizer is not " *
             "a subtype of `MOI.AbstractOptimizer`.\n\nThe optimizer is:\n\n" *
-            sprint(show, optimizer) * "\n",
+            sprint(show, optimizer) *
+            "\n",
         )
     end
     try

--- a/src/print.jl
+++ b/src/print.jl
@@ -273,7 +273,12 @@ function show_backend_summary(io::IO, model::GenericModel)
         println(io, "CachingOptimizer state: ", MOIU.state(backend(model)))
     end
     # The last print shouldn't have a new line
-    print(io, "Solver name: ", solver_name(model))
+    name = try
+        solver_name(model)
+    catch
+        "unknown"
+    end
+    print(io, "Solver name: ", name)
     return
 end
 

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -1233,7 +1233,13 @@ function test_caching_mps_model()
     model = Model(MOI.FileFormats.MPS.Model)
     @test occursin("unknown", sprint(show, model))
     @variable(model, x >= 0)
-    @test_throws MethodError optimize!(model)
+    @test_throws(
+        ErrorException(
+            "Cannot call `optimize!` because the provided optimizer is not " *
+            "a subtype of `MOI.AbstractOptimizer`.",
+        ),
+        optimize!(model),
+    )
     return
 end
 

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -1236,7 +1236,8 @@ function test_caching_mps_model()
     @test_throws(
         ErrorException(
             "Cannot call `optimize!` because the provided optimizer is not " *
-            "a subtype of `MOI.AbstractOptimizer`.",
+            "a subtype of `MOI.AbstractOptimizer`.\n\nThe optimizer is:\n\n" *
+            "A Mathematical Programming System (MPS) model\n",
         ),
         optimize!(model),
     )

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -1216,4 +1216,25 @@ function test_show_variable_not_owned()
     return
 end
 
+function test_direct_mps_model()
+    model = direct_model(MOI.FileFormats.MPS.Model())
+    @test occursin("unknown", sprint(show, model))
+    @variable(model, x >= 0)
+    io = IOBuffer()
+    write(io, backend(model))
+    seekstart(io)
+    data = String(take!(io))
+    @test startswith(data, "NAME")
+    @test endswith(data, "ENDATA")
+    return
+end
+
+function test_caching_mps_model()
+    model = Model(MOI.FileFormats.MPS.Model)
+    @test occursin("unknown", sprint(show, model))
+    @variable(model, x >= 0)
+    @test_throws MethodError optimize!(model)
+    return
+end
+
 end  # module TestModels

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -1225,7 +1225,7 @@ function test_direct_mps_model()
     seekstart(io)
     data = String(take!(io))
     @test startswith(data, "NAME")
-    @test endswith(data, "ENDATA")
+    @test endswith(data, "ENDATA\n")
     return
 end
 


### PR DESCRIPTION
Closes https://github.com/jump-dev/MathOptInterface.jl/issues/2417

The only downside is this:
```Julia
julia> model = Model(MOI.FileFormats.MPS.Model)
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: EMPTY_OPTIMIZER
Solver name: unknown

julia> @variable(model, x >= 0)
x

julia> optimize!(model)
ERROR: MethodError: no method matching optimize!(::MathOptInterface.Utilities.GenericModel{…})

Closest candidates are:
  optimize!(::Any, ::Any)
   @ MathOptInterface ~/.julia/packages/MathOptInterface/3JqTJ/src/MathOptInterface.jl:82
  optimize!(::MathOptInterface.Bridges.AbstractBridgeOptimizer)
   @ MathOptInterface ~/.julia/packages/MathOptInterface/3JqTJ/src/Bridges/bridge_optimizer.jl:378
  optimize!(::MathOptInterface.Utilities.CachingOptimizer)
   @ MathOptInterface ~/.julia/packages/MathOptInterface/3JqTJ/src/Utilities/cachingoptimizer.jl:302
  ...

Stacktrace:
 [1] optimize!(b::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.GenericModel{…}})
```
It violates the MethodError principle because we're throwing an error deep in the stack.

Should we check whether the backend is an optimizer?
```Julia
julia> model = Model(MOI.FileFormats.MPS.Model)
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: EMPTY_OPTIMIZER
Solver name: unknown

julia> unsafe_backend(model)
A Mathematical Programming System (MPS) model

julia> unsafe_backend(model) isa MOI.AbstractOptimizer
false
```