### PR TITLE
[breaking] throw error if Containers.SparseAxisArray used in constraint function

### DIFF
--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -2358,4 +2358,19 @@ function test_op_or_short_circuit()
     return
 end
 
+function test_sparseaxisarray_constraint_zeros()
+    A = [[1, 2, 10], [2, 3, 30]]
+    model = Model()
+    @variable(model, x[i in 1:2, j in A[i]])
+    @test_throws_runtime(
+        ErrorException,
+        @constraint(model, x[1, :] == 0),
+    )
+    @test_throws_runtime(
+        ErrorException,
+        @constraint(model, x[1, :] in SecondOrderCone()),
+    )
+    return
+end
+
 end  # module

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -2362,13 +2362,24 @@ function test_sparseaxisarray_constraint_zeros()
     A = [[1, 2, 10], [2, 3, 30]]
     model = Model()
     @variable(model, x[i in 1:2, j in A[i]])
+    msg = JuMP._build_sparse_axis_array_error_msg()
     @test_throws_runtime(
-        ErrorException,
+        ErrorException("In `@constraint(model, x[1, :] == 0)`: $msg"),
         @constraint(model, x[1, :] == 0),
     )
     @test_throws_runtime(
-        ErrorException,
+        ErrorException(
+            "In `@constraint(model, x[1, :] in SecondOrderCone())`: $msg",
+        ),
         @constraint(model, x[1, :] in SecondOrderCone()),
+    )
+    @test_throws_runtime(
+        ErrorException("In `@constraint(model, x[1, :] in SOS1())`: $msg"),
+        @constraint(model, x[1, :] in SOS1()),
+    )
+    @test_throws_runtime(
+        ErrorException("In @constraint(model, x[1, :] in SOS2())`: $msg"),
+        @constraint(model, x[1, :] in SOS2()),
     )
     return
 end

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -2378,7 +2378,7 @@ function test_sparseaxisarray_constraint_zeros()
         @constraint(model, x[1, :] in SOS1()),
     )
     @test_throws_runtime(
-        ErrorException("In @constraint(model, x[1, :] in SOS2())`: $msg"),
+        ErrorException("In `@constraint(model, x[1, :] in SOS2())`: $msg"),
         @constraint(model, x[1, :] in SOS2()),
     )
     return


### PR DESCRIPTION
Closes https://github.com/jump-dev/JuMP.jl/issues/3678

This PR is the nuclear option of throwing an error. Technically, this is breaking change, but it blocks a high risk of incorrect usage.

We should look at the tests and `extension-tests.yml` before deciding to merge this: https://github.com/jump-dev/JuMP.jl/actions/runs/7924586714

We could make this less breaking by adding methods like:
```julia
function build_constraint(
    ::Function,
    f::Containers.SparseAxisArray{<:Union{Number,AbstractJuMPScalar},1},
    s::MOI.Nonnegatives,
)
    return VectorConstraint(f, s)
end

function build_constraint(
    ::Function,
    f::Containers.SparseAxisArray{<:Union{Number,AbstractJuMPScalar},1},
    s::MOI.Nonpositives,
)
    return VectorConstraint(f, s)
end

function build_constraint(
    ::Function,
    f::Containers.SparseAxisArray{<:Union{Number,AbstractJuMPScalar},1},
    s::MOI.Zeros,
)
    return VectorConstraint(f, s)
end
```

but even then, things like the constraint dual might be in the "wrong" order.