### PR TITLE
DNM: Add unsafe_(g|s)et_backend_attribute

### DIFF
--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -1372,6 +1372,16 @@ function test_get_backend_attribute_caching_optimizer()
     return
 end
 
+function test_set_backend_attribute_caching_optimizer()
+    mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
+    model = Model(() -> MOIU.MockOptimizer(mock))
+    # Call sett first, to check that we attach the CachingOptimizer
+    unsafe_set_backend_attribute(model, MOI.Name(), "foo")
+    @test get_attribute(model, MOI.Name()) == ""
+    @test unsafe_get_backend_attribute(model, MOI.Name()) == "foo"
+    return
+end
+
 function test_get_backend_attribute_direct()
     mock = MOIU.UniversalFallback(MOIU.Model{Float64}())
     model = direct_model(MOIU.MockOptimizer(mock))

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -1342,15 +1342,33 @@ function test_get_backend_attribute_caching_optimizer()
     model = Model(() -> MOIU.MockOptimizer(mock))
     @variable(model, x)
     @constraint(model, c, x <= 1)
+    # ModelAttribute
     attr = ModelAttribute3684()
     @test get_attribute(model, attr) === nothing
-    @test get_backend_attribute(model, attr) == "m3684"
+    @test unsafe_get_backend_attribute(model, attr) == "m3684"
+    @test get_attribute(model, MOI.Name()) == ""
+    @test unsafe_get_backend_attribute(model, MOI.Name()) == ""
+    unsafe_set_backend_attribute(model, MOI.Name(), "foo")
+    @test get_attribute(model, MOI.Name()) == ""
+    @test unsafe_get_backend_attribute(model, MOI.Name()) == "foo"
+    # VariableAttribute
     attr = VariableAttribute3684()
     @test get_attribute(x, attr) === nothing
-    @test startswith(get_backend_attribute(x, attr), "x3684-")
+    @test startswith(unsafe_get_backend_attribute(x, attr), "x3684-")
+    @test get_attribute(x, MOI.VariableName()) == "x"
+    @test unsafe_get_backend_attribute(x, MOI.VariableName()) == "x"
+    unsafe_set_backend_attribute(x, MOI.VariableName(), "foo")
+    @test get_attribute(x, MOI.VariableName()) == "x"
+    @test unsafe_get_backend_attribute(x, MOI.VariableName()) == "foo"
+    # ConnstraintAttribute
     attr = ConstraintAttribute3684()
     @test get_attribute(c, attr) === nothing
-    @test startswith(get_backend_attribute(c, attr), "c3684-")
+    @test startswith(unsafe_get_backend_attribute(c, attr), "c3684-")
+    @test get_attribute(c, MOI.ConstraintName()) == "c"
+    @test unsafe_get_backend_attribute(c, MOI.ConstraintName()) == "c"
+    unsafe_set_backend_attribute(c, MOI.ConstraintName(), "foo")
+    @test get_attribute(c, MOI.ConstraintName()) == "c"
+    @test unsafe_get_backend_attribute(c, MOI.ConstraintName()) == "foo"
     return
 end
 
@@ -1359,15 +1377,33 @@ function test_get_backend_attribute_direct()
     model = direct_model(MOIU.MockOptimizer(mock))
     @variable(model, x)
     @constraint(model, c, x <= 1)
+    # ModelAttribute
     attr = ModelAttribute3684()
     @test get_attribute(model, attr) === "m3684"
-    @test get_backend_attribute(model, attr) == "m3684"
+    @test unsafe_get_backend_attribute(model, attr) == "m3684"
+    @test get_attribute(model, MOI.Name()) == ""
+    @test unsafe_get_backend_attribute(model, MOI.Name()) == ""
+    unsafe_set_backend_attribute(model, MOI.Name(), "foo")
+    @test get_attribute(model, MOI.Name()) == "foo"
+    @test unsafe_get_backend_attribute(model, MOI.Name()) == "foo"
+    # VariableAttribute
     attr = VariableAttribute3684()
     @test startswith(get_attribute(x, attr), "x3684-")
-    @test startswith(get_backend_attribute(x, attr), "x3684-")
+    @test startswith(unsafe_get_backend_attribute(x, attr), "x3684-")
+    @test get_attribute(x, MOI.VariableName()) == "x"
+    @test unsafe_get_backend_attribute(x, MOI.VariableName()) == "x"
+    unsafe_set_backend_attribute(x, MOI.VariableName(), "foo")
+    @test get_attribute(x, MOI.VariableName()) == "foo"
+    @test unsafe_get_backend_attribute(x, MOI.VariableName()) == "foo"
+    # ConnstraintAttribute
     attr = ConstraintAttribute3684()
     @test startswith(get_attribute(c, attr), "c3684-")
-    @test startswith(get_backend_attribute(c, attr), "c3684-")
+    @test startswith(unsafe_get_backend_attribute(c, attr), "c3684-")
+    @test get_attribute(c, MOI.ConstraintName()) == "c"
+    @test unsafe_get_backend_attribute(c, MOI.ConstraintName()) == "c"
+    unsafe_set_backend_attribute(c, MOI.ConstraintName(), "foo")
+    @test get_attribute(c, MOI.ConstraintName()) == "foo"
+    @test unsafe_get_backend_attribute(c, MOI.ConstraintName()) == "foo"
     return
 end
 
@@ -1375,18 +1411,21 @@ function test_get_backend_attribute_no_optimizer()
     model = Model()
     @variable(model, x)
     @constraint(model, c, x <= 1)
-    attr = ModelAttribute3684()
-    @test get_attribute(model, attr) === nothing
-    err = ErrorException(
+    get_err = ErrorException(
         "Cannot get backend attribute because no optimizer is attached",
     )
-    @test_throws err get_backend_attribute(model, attr)
+    set_err = ErrorException(
+        "Cannot set backend attribute because no optimizer is attached",
+    )
+    attr = ModelAttribute3684()
+    @test_throws get_err unsafe_get_backend_attribute(model, attr)
+    @test_throws set_err unsafe_set_backend_attribute(model, attr, "a")
     attr = VariableAttribute3684()
-    @test get_attribute(x, attr) === nothing
-    @test_throws err get_backend_attribute(x, attr)
+    @test_throws get_err unsafe_get_backend_attribute(x, attr)
+    @test_throws set_err unsafe_set_backend_attribute(x, attr, "a")
     attr = ConstraintAttribute3684()
-    @test get_attribute(c, attr) === nothing
-    @test_throws err get_backend_attribute(c, attr)
+    @test_throws get_err unsafe_get_backend_attribute(c, attr)
+    @test_throws set_err unsafe_set_backend_attribute(c, attr, "a")
     return
 end
 


### PR DESCRIPTION
Closes https://github.com/jump-dev/JuMP.jl/issues/3684

The issue is asking for something like this to work, which skips the safety checks like
https://github.com/jump-dev/JuMP.jl/blob/4be967cc9ecad56218929914308b7d4fbcd79678/src/optimizer_interface.jl#L740-L748

```Julia
using JuMP, Gurobi
model = Model(Gurobi.Optimizer)
@variable(model, x >= 1.5)
@constraint(model, c, 2x + 1 <= 10)
@objective(model, Min, 1-x)
unsafe_get_backend_attribute(model, Gurobi.ModelAttribute("IsMIP"))
unsafe_get_backend_attribute.(model, Gurobi.VariableAttribute("LB"), x)
unsafe_get_backend_attribute(model, Gurobi.ConstraintAttribute("RHS"), c)
```

The other option is something like:

```julia
    get_attribute(model::GenericModel, attr::MOI.AbstractModelAttribute; force_backend::Bool = false)
    get_attribute(x::GenericVariableRef, attr::MOI.AbstractVariableAttribute; force_backend::Bool = false)
    get_attribute(cr::ConstraintRef, attr::MOI.AbstractConstraintAttribute; force_backend::Bool = false)
```

## TODO

Waiting for consensus on

 a) whether we should add this
 b) naming

 - [x] Documentation