### PR TITLE
Fix LinearAlgebra.hermitian(::AbstractJuMPScalar, ::Symbol)

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -1055,7 +1055,11 @@ Base.eltype(::Type{T}) where {T<:AbstractJuMPScalar} = T
 LinearAlgebra.symmetric_type(::Type{T}) where {T<:AbstractJuMPScalar} = T
 LinearAlgebra.hermitian_type(::Type{T}) where {T<:AbstractJuMPScalar} = T
 LinearAlgebra.symmetric(scalar::AbstractJuMPScalar, ::Symbol) = scalar
-LinearAlgebra.hermitian(scalar::AbstractJuMPScalar, ::Symbol) = adjoint(scalar)
+
+function LinearAlgebra.hermitian(x::F, ::Symbol) where {F<:AbstractJuMPScalar}
+    return convert(F, real(x))
+end
+
 LinearAlgebra.adjoint(scalar::AbstractJuMPScalar) = conj(scalar)
 
 Base.iterate(x::AbstractJuMPScalar) = (x, true)

--- a/test/test_complex.jl
+++ b/test/test_complex.jl
@@ -312,9 +312,9 @@ end
 
 function test_hermitian_jump_scalar()
     model = Model()
-    @variable(model, X[1:2,1:2] in HermitianPSDCone())
+    @variable(model, x[1:2, 1:2] in HermitianPSDCone())
     Y = im * x.data
-    Z = [0 real(x[1,2])*im-imag(x[1,2]); -real(x[1,2])*im-imag(x[1,2]) 0]
+    Z = [0 real(x[1, 2])*im-imag(x[1, 2]); -real(x[1, 2])*im-imag(x[1, 2]) 0]
     @test !isequal_canonical(Y, Z)
     @test isequal_canonical(
         LinearAlgebra.Hermitian(Y),

--- a/test/test_complex.jl
+++ b/test/test_complex.jl
@@ -310,4 +310,17 @@ function test_hermitian_generic_number_type()
     return
 end
 
+function test_hermitian_jump_scalar()
+    model = Model()
+    @variable(model, X[1:2,1:2] in HermitianPSDCone())
+    Y = im * x.data
+    Z = [0 real(x[1,2])*im-imag(x[1,2]); -real(x[1,2])*im-imag(x[1,2]) 0]
+    @test !isequal_canonical(Y, Z)
+    @test isequal_canonical(
+        LinearAlgebra.Hermitian(Y),
+        LinearAlgebra.Hermitian(Z),
+    )
+    return
+end
+
 end  # TestComplexNumberSupport


### PR DESCRIPTION
Closes #3692

Docstrinng is:
```julia
help?> LinearAlgebra.hermitian
  hermitian(A, uplo=:U)

  Construct a hermitian view of A. If A is a matrix, uplo controls whether the upper (if uplo = :U)
  or lower (if uplo = :L) triangle of A is used to implicitly fill the other one. If A is a Number,
  its real part is returned converted back to the input type.

  If a hermitian view of a matrix is to be constructed of which the elements are neither matrices
  nor numbers, an appropriate method of hermitian has to be implemented. In that case,
  hermitian_type has to be implemented, too.
```

The important sentence is: `If A is a Number, its real part is returned converted back to the input type.`