### PR TITLE
Add the MINLP solver MAiNGO to the documentation

### DIFF
--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -20,6 +20,9 @@ Google.Periods = NO
 [docs/src/packages/Manopt.md]
 Google.Exclamation = NO
 
+[docs/src/packages/MAiNGO.md]
+Vale.Spelling = NO
+
 [docs/src/packages/Optim.md]
 Google.EmDash = NO
 

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -159,7 +159,7 @@
     has_html = true
 [MAiNGO]
     user = "MAiNGO-github"
-    rev  = "07d3831f3b9714979b017716313bbb3a7231a451"
+    rev  = "b6ea68189558558e44195c1f87c00d9f5038cf0d"
 [Manopt]
     user = "JuliaManifolds"
     rev = "v0.4.51"

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -157,6 +157,9 @@
     user = "MadNLP"
     rev = "389561354a774441cd5e6b3aa5fffee102ed222e"
     has_html = true
+[MAiNGO]
+    user = "MAiNGO-github"
+    rev  = "07d3831f3b9714979b017716313bbb3a7231a451"
 [Manopt]
     user = "JuliaManifolds"
     rev = "v0.4.51"

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -126,6 +126,7 @@ The link in the `Solver` column is the corresponding Julia package.
 | [Juniper.jl](https://github.com/lanl-ansi/Juniper.jl)                          |                                                                                  |        | MIT      | (MI)SOCP, (MI)NLP         |
 | [Loraine.jl](https://github.com/kocvara/Loraine.jl)                            |                                                                                  |        | MIT      | LP, SDP                   |
 | [MadNLP.jl](https://github.com/sshin23/MadNLP.jl)                              |                                                                                  |        | MIT      | LP, QP, NLP               |
+| [MAiNGO](https://git.rwth-aachen.de/avt-svt/public/maingo)                     | [MAiNGO.jl](https://github.com/MAiNGO-github/MAiNGO.jl)                          |        | EPL 2.0  |(MI)NLP                    |
 | [Manopt.jl](https://github.com/JuliaManifolds/Manopt.jl)                       |                                                                                  |        | MIT      | NLP                       |
 | [MiniZinc](https://www.minizinc.org/)                                          | [MiniZinc.jl](https://github.com/jump-dev/MiniZinc.jl)                           | Manual | MPL-2    | CP-SAT                    |
 | [Minotaur](https://github.com/coin-or/minotaur)                                | [AmplNLWriter.jl](https://github.com/jump-dev/AmplNLWriter.jl)                   | Manual | BSD-like | (MI)NLP                   |


### PR DESCRIPTION
We have recently built a wrapper around our open-source global MINLP solver MAiNGO, which is is written in C++.
The wrapper initially took a lot of inspiration from the Baron.jl repository.

Looking at the [checklist](https://jump.dev/JuMP.jl/stable/developers/checklists/#Adding-a-new-solver-to-the-documentation), the conditions for including the solver in the documentation should be fulfilled.

We would be very excited to be included in the list of compatible solvers.

https://github.com/MAiNGO-github/MAiNGO.jl

## Basic

 - [x] Check that the solver is a registered Julia package
 - [x] Check that the solver supports the long-term support release of Julia
 - [x] Check that the solver has a MathOptInterface wrapper
 - [x] Check that the tests call `MOI.Test.runtests`. Some test excludes are
       permissible, but the reason for skipping a particular test should be
       documented.
 - [x] Check that the README and/or documentation provides an example of how to
       use the solver with JuMP

## Documentation

 - [x] Add a new row to the table in `docs/src/installation.md`

## Optional

 - [x] Add package metadata to `docs/packages.toml`