### PR TITLE
Add support for Hermitian PSD for conic inequality

### DIFF
--- a/src/macros/@constraint.jl
+++ b/src/macros/@constraint.jl
@@ -674,6 +674,12 @@ function _functionize(
     return LinearAlgebra.Symmetric(_functionize(v.data))
 end
 
+function _functionize(
+    v::LinearAlgebra.Hermitian{V},
+) where {V<:AbstractVariableRef}
+    return LinearAlgebra.Hermitian(_functionize(v.data))
+end
+
 _functionize(x) = x
 
 _functionize(::_MA.Zero) = false

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -774,6 +774,7 @@ function build_constraint(
         MOI.AbstractSymmetricMatrixSetTriangle,
         MOI.AbstractSymmetricMatrixSetSquare,
         PSDCone,
+        HermitianPSDCone,
     },
 )
     return build_constraint(error_fn, f, extra)
@@ -787,6 +788,7 @@ function build_constraint(
         MOI.AbstractSymmetricMatrixSetTriangle,
         MOI.AbstractSymmetricMatrixSetSquare,
         PSDCone,
+        HermitianPSDCone,
     },
 )
     new_f = _MA.operate!!(*, -1, f)

--- a/test/test_complex.jl
+++ b/test/test_complex.jl
@@ -257,6 +257,23 @@ function test_complex_hermitian_constraint()
     return
 end
 
+function test_complex_hermitian_inequality_constraint()
+    model = Model()
+    @variable(model, x[1:2, 1:2])
+    H = LinearAlgebra.Hermitian(x)
+    @test vectorize(H, HermitianMatrixShape(2)) ==
+          [x[1, 1], x[1, 2], x[2, 2], 0.0]
+    @constraint(model, c, H >= 0, HermitianPSDCone())
+    @test constraint_object(c).func == [x[1, 1], x[1, 2], x[2, 2], 0.0]
+    @test function_string(MIME("text/plain"), constraint_object(c)) ==
+          "[x[1,1]  x[1,2];\n x[1,2]  x[2,2]]"
+    @constraint(model, c2, 0 <= H, HermitianPSDCone())
+    @test constraint_object(c2).func == [x[1, 1], x[1, 2], x[2, 2], 0.0]
+    @test function_string(MIME("text/plain"), constraint_object(c2)) ==
+          "[x[1,1]  x[1,2];\n x[1,2]  x[2,2]]"
+    return
+end
+
 function test_isreal()
     model = Model()
     @variable(model, x[1:2])


### PR DESCRIPTION
Before this PR
```julia
@variable(model, x)
julia> @constraint(model, LinearAlgebra.Hermitian([1 x; x 1])>=0, HermitianPSDCone())
ERROR: At REPL[23]:1: `@constraint(model, LinearAlgebra.Hermitian([1 x; x 1]) >= 0, HermitianPSDCone())`: Unrecognized constraint building format. Tried to invoke `build_constraint(error, AffExpr[1 x; x 1], MathOptInterface.GreaterThan{Bool}(false), HermitianPSDCone())`, but no such method exists. This is due to specifying an unrecognized function, constraint set, and/or extra positional/keyword arguments.

If you're trying to create a JuMP extension, you need to implement `build_constraint` to accomodate these arguments.
Stacktrace:
 [1] error(::String, ::String)
   @ Base ./error.jl:44
 [2] (::JuMP.Containers.var"#error_fn#98"{String})(str::String)
   @ JuMP.Containers ~/.julia/dev/JuMP/src/Containers/macro.jl:325
 [3] build_constraint(error_fn::JuMP.Containers.var"#error_fn#98"{…}, func::Hermitian{…}, set::MathOptInterface.GreaterThan{…}, args::HermitianPSDCone; kwargs::@Kwargs{})
   @ JuMP ~/.julia/dev/JuMP/src/macros/@constraint.jl:781
 [4] build_constraint(error_fn::Function, func::Hermitian{…}, set::MathOptInterface.GreaterThan{…}, args::HermitianPSDCone)
   @ JuMP ~/.julia/dev/JuMP/src/macros/@constraint.jl:776
 [5] #build_constraint#81
   @ ~/.julia/dev/JuMP/src/macros/@constraint.jl:726 [inlined]
 [6] build_constraint(error_fn::Function, f::Hermitian{AffExpr, Matrix{AffExpr}}, set::Nonnegatives, args::HermitianPSDCone)
   @ JuMP ~/.julia/dev/JuMP/src/macros/@constraint.jl:719
```