### PR TITLE
Fix list-style for bibliographies in dark mode

### DIFF
--- a/docs/src/assets/citations.css
+++ b/docs/src/assets/citations.css
@@ -9,7 +9,7 @@
 .citation ul {
  padding: 0 0 2.25em 0;
  margin: 0;
- list-style: none;}
+ list-style: none !important;}
 .citation ul li {
  text-indent: -2.25em;
  margin: 0.33em 0.5em 0.5em 2.25em;}


### PR DESCRIPTION
Cf. https://github.com/JuliaDocs/DocumenterCitations.jl/pull/70

You'd still have to follow up with modifying any existing `citations.css` in your `gh-pages`.

Closes #3704