### PR TITLE
[docs] standardize on '## Example' headers instead of plural

### DIFF
--- a/docs/src/developers/style.md
+++ b/docs/src/developers/style.md
@@ -581,7 +581,7 @@ Optional: add a slightly longer paragraph describing the function.
 
  - List any notes that the user should be aware of
 
-## Examples
+## Example
 
 ```jldoctest
 julia> 1 + 1

--- a/docs/src/tutorials/getting_started/design_patterns_for_larger_models.jl
+++ b/docs/src/tutorials/getting_started/design_patterns_for_larger_models.jl
@@ -559,7 +559,7 @@ Solve the knapsack problem and return the optimal primal solution
  * Otherwise, `nothing`, indicating that the problem does not have an optimal
    solution.
 
-## Examples
+## Example
 
 ```julia
 solution = solve_knapsack(

--- a/src/Containers/macro.jl
+++ b/src/Containers/macro.jl
@@ -436,7 +436,7 @@ is the dictionary returned by [`parse_macro_arguments`](@ref).
 This assumes that the key in `kwargs` used to over-ride the name choice is
 `:base_name`.
 
-## Examples
+## Example
 
 ```jldoctest
 julia> Containers.build_name_expr(:x, [:i, :j], Dict{Symbol,Any}())

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -1476,7 +1476,7 @@ to pass the set un-changed to the solver.
     This struct is intended for use internally by JuMP extensions. You should not
     need to use it in regular JuMP code.
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -561,7 +561,7 @@ Returns the reference of the variable with name attribute `name` or `Nothing` if
 no variable has this name attribute. Throws an error if several variables have
 `name` as their name attribute.
 
-## Examples
+## Example
 
 ```jldoctest objective_function; filter = r"Stacktrace:.*"s
 julia> model = Model();
@@ -677,7 +677,7 @@ queried with [`lower_bound`](@ref).
 See also [`LowerBoundRef`](@ref), [`lower_bound`](@ref),
 [`set_lower_bound`](@ref), [`delete_lower_bound`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -713,7 +713,7 @@ bound constraint.
 See also [`LowerBoundRef`](@ref), [`has_lower_bound`](@ref),
 [`lower_bound`](@ref), [`delete_lower_bound`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -768,7 +768,7 @@ Errors if one does not exist.
 See also [`has_lower_bound`](@ref), [`lower_bound`](@ref),
 [`set_lower_bound`](@ref), [`delete_lower_bound`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -794,7 +794,7 @@ Delete the lower bound constraint of a variable.
 See also [`LowerBoundRef`](@ref), [`has_lower_bound`](@ref),
 [`lower_bound`](@ref), [`set_lower_bound`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -823,7 +823,7 @@ Return the lower bound of a variable. Error if one does not exist.
 See also [`LowerBoundRef`](@ref), [`has_lower_bound`](@ref),
 [`set_lower_bound`](@ref), [`delete_lower_bound`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -850,7 +850,7 @@ queried with [`upper_bound`](@ref).
 See also [`UpperBoundRef`](@ref), [`upper_bound`](@ref),
 [`set_upper_bound`](@ref), [`delete_upper_bound`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -884,7 +884,7 @@ constraint.
 See also [`UpperBoundRef`](@ref), [`has_upper_bound`](@ref),
 [`upper_bound`](@ref), [`delete_upper_bound`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -939,7 +939,7 @@ Errors if one does not exist.
 See also [`has_upper_bound`](@ref), [`upper_bound`](@ref),
 [`set_upper_bound`](@ref), [`delete_upper_bound`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -967,7 +967,7 @@ Errors if one does not exist.
 See also [`UpperBoundRef`](@ref), [`has_upper_bound`](@ref),
 [`upper_bound`](@ref), [`set_upper_bound`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -998,7 +998,7 @@ Error if one does not exist.
 See also [`UpperBoundRef`](@ref), [`has_upper_bound`](@ref),
 [`set_upper_bound`](@ref), [`delete_upper_bound`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -1024,7 +1024,7 @@ queried with [`fix_value`](@ref).
 
 See also [`FixRef`](@ref), [`fix_value`](@ref), [`fix`](@ref), [`unfix`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -1066,7 +1066,7 @@ after a call to [`unfix`](@ref).
 See also [`FixRef`](@ref), [`is_fixed`](@ref), [`fix_value`](@ref),
 [`unfix`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -1149,7 +1149,7 @@ Error if one does not exist.
 See also [`FixRef`](@ref), [`is_fixed`](@ref), [`fix_value`](@ref),
 [`fix`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -1179,7 +1179,7 @@ Error if one does not exist.
 
 See also [`FixRef`](@ref), [`is_fixed`](@ref), [`fix`](@ref), [`unfix`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -1205,7 +1205,7 @@ Errors if one does not exist.
 See also [`is_fixed`](@ref), [`fix_value`](@ref), [`fix`](@ref),
 [`unfix`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -1232,7 +1232,7 @@ Return `true` if `v` is constrained to be integer.
 
 See also [`IntegerRef`](@ref), [`set_integer`](@ref), [`unset_integer`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -1267,7 +1267,7 @@ Add an integrality constraint on the variable `variable_ref`.
 
 See also [`IntegerRef`](@ref), [`is_integer`](@ref), [`unset_integer`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -1312,7 +1312,7 @@ Errors if one does not exist.
 
 See also [`IntegerRef`](@ref), [`is_integer`](@ref), [`set_integer`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -1342,7 +1342,7 @@ Errors if one does not exist.
 
 See also [`is_integer`](@ref), [`set_integer`](@ref), [`unset_integer`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -1369,7 +1369,7 @@ Return `true` if `v` is constrained to be binary.
 
 See also [`BinaryRef`](@ref), [`set_binary`](@ref), [`unset_binary`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -1400,7 +1400,7 @@ Add a constraint on the variable `v` that it must take values in the set
 
 See also [`BinaryRef`](@ref), [`is_binary`](@ref), [`unset_binary`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -1443,7 +1443,7 @@ Remove the binary constraint on the variable `variable_ref`.
 
 See also [`BinaryRef`](@ref), [`is_binary`](@ref), [`set_binary`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -1472,7 +1472,7 @@ Errors if one does not exist.
 
 See also [`is_binary`](@ref), [`set_binary`](@ref), [`unset_binary`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -1503,7 +1503,7 @@ Errors if one does not exist.
 See also [`is_parameter`](@ref), [`set_parameter_value`](@ref),
 [`parameter_value`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -1542,7 +1542,7 @@ Return `true` if `x` is constrained to be a parameter.
 See also [`ParameterRef`](@ref), [`set_parameter_value`](@ref),
 [`parameter_value`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -1574,7 +1574,7 @@ Errors if `x` is not a parameter.
 See also [`ParameterRef`](@ref), [`is_parameter`](@ref),
 [`parameter_value`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();
@@ -1610,7 +1610,7 @@ Errors if `x` is not a parameter.
 See also [`ParameterRef`](@ref), [`is_parameter`](@ref),
 [`set_parameter_value`](@ref).
 
-## Examples
+## Example
 
 ```jldoctest
 julia> model = Model();

--- a/test/perf/JuMPBenchmarks.jl
+++ b/test/perf/JuMPBenchmarks.jl
@@ -523,7 +523,7 @@ Run a script to benchmark various aspects of JuMP.
 
 Pass `-r N` to run each benchmark function `N` times.
 
-### Examples
+### Example
 
 ```
 \$ julia test/perf/JuMPBenchmarks.jl -r 2
@@ -537,7 +537,7 @@ instead.
  * If `--compare` is not given, save a new benchmark dataset to `file`.
  * If `--compare`, compare aginst the data in `file`.
 
-### Examples
+### Example
 
 ```
 \$ julia test/perf/JuMPBenchmarks.jl -f my_benchmark_run
@@ -552,7 +552,7 @@ start Julia at the command line. This uses the Project.toml located at
 `/docs/src/Project.toml`, which assumes you have dev'd JuMP to it as
 appropriate.
 
-### Examples
+### Example
 
 ```
 \$ julia test/perf/JuMPBenchmarks.jl -j /Users/oscar/julia1.6


### PR DESCRIPTION
This is me being pedantic. But we had 135 `## Example` blocks and 35 `## Examples` blocks, so the singular wins.