### PR TITLE
Add batched modification methods

### DIFF
--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -784,9 +784,9 @@ function set_normalized_rhs(
     F<:Union{MOI.ScalarAffineFunction{T},MOI.ScalarQuadraticFunction{T}},
 }
     MOI.set(
-        owner_model(first(constraints)),
+        backend(owner_model(first(constraints))),
         MOI.ConstraintSet(),
-        constraints,
+        index.(constraints),
         S.(convert.(T, values)),
     )
     return

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -794,10 +794,10 @@ julia> model = Model();
 julia> @variable(model, x);
 
 julia> @constraint(model, con1, 2x + 1 <= 2)
-con : 2 x ≤ 1
+con1 : 2 x ≤ 1
 
 julia> @constraint(model, con2, 3x + 2 <= 4)
-con : 3 x ≤ 2
+con2 : 3 x ≤ 2
 
 julia> set_normalized_rhs([con1, con2], [4, 5])
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -805,7 +805,7 @@ julia> con1
 con1 : 2 x ≤ 4
 
 julia> con2
-con1 : 3 x ≤ 5
+con2 : 3 x ≤ 5
 ```
 """
 function set_normalized_rhs(

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -773,6 +773,41 @@ function set_normalized_rhs(
     return
 end
 
+"""
+    set_normalized_rhs(
+        constraints::AbstractVector{<:ConstraintRef},
+        values::AbstractVector{<:Number}
+    )
+
+Set the right-hand side terms of all `constraints` to `values`.
+
+Note that prior to this step, JuMP will aggregate all constant terms onto the
+right-hand side of the constraint. For example, given a constraint `2x + 1 <=
+2`, `set_normalized_rhs([con], [4])` will create the constraint `2x <= 4`, not `2x +
+1 <= 4`.
+
+## Example
+
+```jldoctest; filter=r"≤|<="
+julia> model = Model();
+
+julia> @variable(model, x);
+
+julia> @constraint(model, con1, 2x + 1 <= 2)
+con : 2 x ≤ 1
+
+julia> @constraint(model, con2, 3x + 2 <= 4)
+con : 3 x ≤ 2
+
+julia> set_normalized_rhs([con1, con2], [4, 5])
+
+julia> con1
+con1 : 2 x ≤ 4
+
+julia> con2
+con1 : 3 x ≤ 5
+```
+"""
 function set_normalized_rhs(
     constraints::AbstractVector{
         <:ConstraintRef{<:AbstractModel,MOI.ConstraintIndex{F,S}},

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -731,7 +731,7 @@ function add_constraint(
 end
 
 """
-    set_normalized_rhs(constraint::ConstraintRef, value)
+    set_normalized_rhs(constraint::ConstraintRef, value::Number)
 
 Set the right-hand side term of `constraint` to `value`.
 
@@ -758,7 +758,7 @@ con : 2 x ≤ 4
 """
 function set_normalized_rhs(
     con_ref::ConstraintRef{<:AbstractModel,MOI.ConstraintIndex{F,S}},
-    value,
+    value::Number,
 ) where {
     T,
     S<:Union{MOI.LessThan{T},MOI.GreaterThan{T},MOI.EqualTo{T}},
@@ -769,6 +769,25 @@ function set_normalized_rhs(
         MOI.ConstraintSet(),
         con_ref,
         S(convert(T, value)),
+    )
+    return
+end
+
+function set_normalized_rhs(
+    constraints::AbstractVector{
+        <:ConstraintRef{<:AbstractModel,MOI.ConstraintIndex{F,S}},
+    },
+    values::AbstractVector{<:Number},
+) where {
+    T,
+    S<:Union{MOI.LessThan{T},MOI.GreaterThan{T},MOI.EqualTo{T}},
+    F<:Union{MOI.ScalarAffineFunction{T},MOI.ScalarQuadraticFunction{T}},
+}
+    MOI.set(
+        owner_model(first(constraints)),
+        MOI.ConstraintSet(),
+        constraints,
+        S.(convert.(T, values)),
     )
     return
 end

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -685,7 +685,7 @@ julia> @variable(model, x[1:2]);
 julia> @objective(model, Min, x[1]^2 + x[1] * x[2])
 x[1]² + x[1]*x[2]
 
-julia> set_objective_coefficient(model, [x[1], x[1]], [x[1], x[2]], [2, 3])
+julia> set_objective_coefficients(model, [x[1], x[1]], [x[1], x[2]], [2, 3])
 
 julia> objective_function(model)
 2 x[1]² + 3 x[1]*x[2]

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -652,9 +652,9 @@ end
 """
     set_objective_coefficient(
         model::GenericModel{T},
-        variables_1::AbstractVector{<GenericVariableRef{T}},
-        variables_2::AbstractVector{<GenericVariableRef{T}},
-        coefficients::AbstractVector{<Real},
+        variables_1::AbstractVector{<:GenericVariableRef{T}},
+        variables_2::AbstractVector{<:GenericVariableRef{T}},
+        coefficients::AbstractVector{<:Real},
     ) where {T}
 
 Set multiple quadratic objective coefficients associated with `variables_1` and

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -544,10 +544,7 @@ function _set_objective_coefficient(
     coeffs::AbstractVector{<:T},
     ::Type{GenericVariableRef{T}},
 ) where {T}
-    if length(variables) == 0
-        return
-    end
-    new_objective = coeffs' * variables
+    new_objective = LinearAlgebra.dot(coeffs, variables)
     current_obj = objective_function(model)::GenericVariableRef{T}
     if !(current_obj in variables)
         add_to_expression!(new_objective, current_obj)

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -547,9 +547,7 @@ function _set_objective_coefficients(
 ) where {T}
     current_obj = objective_function(model)
     current_obj_index = index(current_obj)
-    if length(variables) == 1 && current_obj_index == index(variables[])
-        set_objective_function(model, coeffs[] * variables[])
-    else
+    if length(variables) > 0
         position = findfirst(x -> index(x) == current_obj_index, variables)
         if position === nothing
             set_objective_function(

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -450,7 +450,10 @@ function set_objective_coefficient(
     coeff::Real,
 ) where {T}
     if _nlp_objective_function(model) !== nothing
-        error("A nonlinear objective is already set in the model")
+        error(
+            "A nonlinear objective created by the legacy `@NLobjective` is " *
+            "set in the model. This does not support modification.",
+        )
     end
     coeff_t = convert(T, coeff)::T
     F = objective_function_type(model)
@@ -527,9 +530,14 @@ function set_objective_coefficient(
     coeffs::AbstractVector{<:Real},
 ) where {T}
     if _nlp_objective_function(model) !== nothing
-        error("A nonlinear objective is already set in the model")
-    elseif length(variables) != length(coeffs)
-        msg = "The number of variables and coefficients must match"
+        error(
+            "A nonlinear objective created by the legacy `@NLobjective` is " *
+            "set in the model. This does not support modification.",
+        )
+    end
+    n, m = length(variables), length(coeffs)
+    if !(n == m)
+        msg = "The number of variables ($n) and coefficients ($m) must match"
         throw(DimensionMismatch(msg))
     end
     F = objective_function_type(model)
@@ -605,7 +613,10 @@ function set_objective_coefficient(
     coeff::Real,
 ) where {T}
     if _nlp_objective_function(model) !== nothing
-        error("A nonlinear objective is already set in the model")
+        error(
+            "A nonlinear objective created by the legacy `@NLobjective` is " *
+            "set in the model. This does not support modification.",
+        )
     end
     coeff_t = convert(T, coeff)::T
     F = moi_function_type(objective_function_type(model))
@@ -685,12 +696,17 @@ function set_objective_coefficient(
     coeffs::AbstractVector{<:Real},
 ) where {T}
     if _nlp_objective_function(model) !== nothing
-        error("A nonlinear objective is already set in the model")
-    elseif !(length(variables_1) == length(variables_2) == length(coeffs))
-        msg = "The number of variables and coefficients must match"
+        error(
+            "A nonlinear objective created by the legacy `@NLobjective` is " *
+            "set in the model. This does not support modification.",
+        )
+    end
+    n1, n2, m = length(variables_1), length(variables_2), length(coeffs)
+    if !(n1 == n2 == m)
+        msg = "The number of variables ($n1, $n2) and coefficients ($m) must match"
         throw(DimensionMismatch(msg))
     end
-    coeffs_t = convert.(T, coeffs)::AbstractVector{<:T}
+    coeffs_t = convert.(T, coeffs)
     F = moi_function_type(objective_function_type(model))
     _set_objective_coefficient(model, variables_1, variables_2, coeffs_t, F)
     model.is_model_dirty = true

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -532,6 +532,13 @@ function set_objective_coefficients(
     if _nlp_objective_function(model) !== nothing
         error("A nonlinear objective is already set in the model")
     end
+    if length(variables) != length(coeffs)
+        throw(
+            DimensionMismatch(
+                "The number of variables and coefficients must match",
+            ),
+        )
+    end
     coeffs_t = convert.(T, coeffs)::AbstractVector{T}
     F = objective_function_type(model)
     _set_objective_coefficients(model, variables, coeffs_t, F)
@@ -701,6 +708,13 @@ function set_objective_coefficients(
 ) where {T}
     if _nlp_objective_function(model) !== nothing
         error("A nonlinear objective is already set in the model")
+    end
+    if !(length(variables_1) == length(variables_2) == length(coeffs))
+        throw(
+            DimensionMismatch(
+                "The number of variables and coefficients must match",
+            ),
+        )
     end
     coeffs_t = convert.(T, coeffs)::AbstractVector{<:T}
     F = moi_function_type(objective_function_type(model))

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -702,13 +702,16 @@ end
 
 function _set_objective_coefficient(
     model::GenericModel{T},
-    variables_1::AbstractVector{<:GenericVariableRef{T}},
-    variables_2::AbstractVector{<:GenericVariableRef{T}},
+    variables_1::AbstractVector{<:V},
+    variables_2::AbstractVector{<:V},
     coeffs::AbstractVector{<:T},
     ::Type{F},
-) where {T,F}
-    new_obj = @expression(model, sum(coeffs .* variables_1 .* variables_2))
+) where {T,F,V<:GenericVariableRef{T}}
+    new_obj = GenericQuadExpr{T,V}()
     add_to_expression!(new_obj, objective_function(model))
+    for (c, x, y) in zip(coeffs, variables_1, variables_2)
+        add_to_expression!(new_obj, c, x, y)
+    end
     set_objective_function(model, new_obj)
     return
 end

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -609,9 +609,9 @@ julia> set_objective_coefficient(model, x[1], x[2], 3)
 
 julia> objective_function(model)
 2 x[1]² + 3 x[1]*x[2]
+```
 
 See also [`set_objective_coefficients`](@ref).
-```
 """
 function set_objective_coefficient(
     model::GenericModel{T},
@@ -691,9 +691,9 @@ julia> set_objective_coefficient(model, [x[1], x[1]], [x[1], x[2]], [2, 3])
 
 julia> objective_function(model)
 2 x[1]² + 3 x[1]*x[2]
+```
 
 See also [`set_objective_coefficient`](@ref).
-```
 """
 function set_objective_coefficients(
     model::GenericModel{T},

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -667,9 +667,9 @@ end
 """
     set_objective_coefficients(
         model::GenericModel{T},
-        variables_1::GenericVariableRef{T},
-        variables_2::GenericVariableRef{T},
-        coefficients::Real,
+        variables_1::AbstractVector{<GenericVariableRef{T}},
+        variables_2::AbstractVector{<GenericVariableRef{T}},
+        coefficients::AbstractVector{<Real},
     ) where {T}
 
 Set multiple quadratic objective coefficients associated with `variables_1` and

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -443,8 +443,6 @@ julia> set_objective_coefficient(model, x, 3)
 julia> objective_function(model)
 3 x + 1
 ```
-
-See also [`set_objective_coefficients`](@ref).
 """
 function set_objective_coefficient(
     model::GenericModel{T},
@@ -494,7 +492,7 @@ function _set_objective_coefficient(
 end
 
 """
-    set_objective_coefficients(
+    set_objective_coefficient(
         model::GenericModel,
         variables::Vector{<:GenericVariableRef},
         coefficients::Vector{<:Real},
@@ -516,15 +514,13 @@ julia> @variable(model, y);
 julia> @objective(model, Min, 3x + 2y + 1)
 3 x + 2 y + 1
 
-julia> set_objective_coefficients(model, [x, y], [5, 4])
+julia> set_objective_coefficient(model, [x, y], [5, 4])
 
 julia> objective_function(model)
 5 x + 4 y + 1
 ```
-
-See also [`set_objective_coefficient`](@ref).
 """
-function set_objective_coefficients(
+function set_objective_coefficient(
     model::GenericModel{T},
     variables::AbstractVector{<:GenericVariableRef{T}},
     coeffs::AbstractVector{<:Real},
@@ -541,12 +537,12 @@ function set_objective_coefficients(
     end
     coeffs_t = convert.(T, coeffs)::AbstractVector{T}
     F = objective_function_type(model)
-    _set_objective_coefficients(model, variables, coeffs_t, F)
+    _set_objective_coefficient(model, variables, coeffs_t, F)
     model.is_model_dirty = true
     return
 end
 
-function _set_objective_coefficients(
+function _set_objective_coefficient(
     model::GenericModel{T},
     variables::AbstractVector{<:GenericVariableRef{T}},
     coeffs::AbstractVector{<:T},
@@ -571,7 +567,7 @@ function _set_objective_coefficients(
     return
 end
 
-function _set_objective_coefficients(
+function _set_objective_coefficient(
     model::GenericModel{T},
     variables::AbstractVector{<:GenericVariableRef{T}},
     coeffs::AbstractVector{<:T},
@@ -615,8 +611,6 @@ julia> set_objective_coefficient(model, x[1], x[2], 3)
 julia> objective_function(model)
 2 x[1]² + 3 x[1]*x[2]
 ```
-
-See also [`set_objective_coefficients`](@ref).
 """
 function set_objective_coefficient(
     model::GenericModel{T},
@@ -670,7 +664,7 @@ function _set_objective_coefficient(
 end
 
 """
-    set_objective_coefficients(
+    set_objective_coefficient(
         model::GenericModel{T},
         variables_1::AbstractVector{<GenericVariableRef{T}},
         variables_2::AbstractVector{<GenericVariableRef{T}},
@@ -692,15 +686,13 @@ julia> @variable(model, x[1:2]);
 julia> @objective(model, Min, x[1]^2 + x[1] * x[2])
 x[1]² + x[1]*x[2]
 
-julia> set_objective_coefficients(model, [x[1], x[1]], [x[1], x[2]], [2, 3])
+julia> set_objective_coefficient(model, [x[1], x[1]], [x[1], x[2]], [2, 3])
 
 julia> objective_function(model)
 2 x[1]² + 3 x[1]*x[2]
 ```
-
-See also [`set_objective_coefficient`](@ref).
 """
-function set_objective_coefficients(
+function set_objective_coefficient(
     model::GenericModel{T},
     variables_1::AbstractVector{<:GenericVariableRef{T}},
     variables_2::AbstractVector{<:GenericVariableRef{T}},
@@ -718,12 +710,12 @@ function set_objective_coefficients(
     end
     coeffs_t = convert.(T, coeffs)::AbstractVector{<:T}
     F = moi_function_type(objective_function_type(model))
-    _set_objective_coefficients(model, variables_1, variables_2, coeffs_t, F)
+    _set_objective_coefficient(model, variables_1, variables_2, coeffs_t, F)
     model.is_model_dirty = true
     return
 end
 
-function _set_objective_coefficients(
+function _set_objective_coefficient(
     model::GenericModel{T},
     variables_1::AbstractVector{<:GenericVariableRef{T}},
     variables_2::AbstractVector{<:GenericVariableRef{T}},
@@ -742,7 +734,7 @@ function _set_objective_coefficients(
     return
 end
 
-function _set_objective_coefficients(
+function _set_objective_coefficient(
     model::GenericModel{T},
     variables_1::AbstractVector{<:GenericVariableRef{T}},
     variables_2::AbstractVector{<:GenericVariableRef{T}},

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -551,7 +551,7 @@ function _set_objective_coefficients(
         set_objective_function(model, coeffs[] * variables[])
     else
         position = findfirst(x -> index(x) == current_obj_index, variables)
-        if positions === nothing
+        if position === nothing
             set_objective_function(
                 model,
                 add_to_expression!(
@@ -566,7 +566,7 @@ function _set_objective_coefficients(
     return
 end
 
-function _set_objective_coefficient(
+function _set_objective_coefficients(
     model::GenericModel{T},
     variables::AbstractVector{<:GenericVariableRef{T}},
     coeffs::AbstractVector{<:T},
@@ -737,8 +737,10 @@ function _set_objective_coefficients(
     coeffs::AbstractVector{<:T},
     ::Type{MOI.ScalarQuadraticFunction{T}},
 ) where {T}
-    if variable_1 == variable_2
-        coeff *= T(2)
+    for i in eachindex(variables_1)
+        if variables_1[i] == variables_2[i]
+            coeffs[i] *= T(2)
+        end
     end
     MOI.modify(
         backend(model),

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -2777,8 +2777,8 @@ function set_normalized_coefficients(
     model = owner_model(first(constraints))
     MOI.modify(
         backend(model),
-        index.(constraint),
-        MOI.ScalarQuadraticCoefficientChanges.(
+        index.(constraints),
+        MOI.ScalarQuadraticCoefficientChange.(
             index.(variables_1),
             index.(variables_2),
             new_values,

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -2595,7 +2595,7 @@ y
 julia> @constraint(model, con, 2x + 3x + 4y <= 2)
 con : 5 x + 4 y ≤ 2
 
-julia> set_normalized_coefficients(con, [x, y], [6, 7])
+julia> set_normalized_coefficients([con, con], [x, y], [6, 7])
 
 julia> con
 con : 6 x + 7 y ≤ 2
@@ -2752,7 +2752,7 @@ julia> @variable(model, x[1:2]);
 julia> @constraint(model, con, 2x[1]^2 + 3 * x[1] * x[2] + x[2] <= 2)
 con : 2 x[1]² + 3 x[1]*x[2] + x[2] ≤ 2
 
-julia> set_normalized_coefficient(con, [x[1], x[1]], [x[1], x[2]], [4, 5])
+julia> set_normalized_coefficient([con, con], [x[1], x[1]], [x[1], x[2]], [4, 5])
 
 julia> con
 con : 4 x[1]² + 5 x[1]*x[2] + x[2] ≤ 2

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -2607,8 +2607,9 @@ function set_normalized_coefficient(
     variables::AbstractVector{<:AbstractVariableRef},
     coeffs::AbstractVector{<:Number},
 ) where {T,F<:Union{MOI.ScalarAffineFunction{T},MOI.ScalarQuadraticFunction{T}}}
-    if !(length(constraints) == length(variables) == length(coeffs))
-        msg = "The number of constraints, variables and coefficients must match"
+    c, n, m = length(constraints), length(variables), length(coeffs)
+    if !(c == n == m)
+        msg = "The number of constraints ($c), variables ($n) and coefficients ($m) must match"
         throw(DimensionMismatch(msg))
     end
     model = owner_model(first(constraints))
@@ -2764,13 +2765,10 @@ function set_normalized_coefficient(
     variables_2::AbstractVector{<:AbstractVariableRef},
     coeffs::AbstractVector{<:Number},
 ) where {T,F<:MOI.ScalarQuadraticFunction{T}}
-    dimension_match =
-        length(constraints) ==
-        length(variables_1) ==
-        length(variables_2) ==
-        length(coeffs)
-    if !dimension_match
-        msg = "The number of constraints, variables and coefficients must match"
+    c, m = length(constraints), length(coeffs)
+    n1, n2 = length(variables_1), length(variables_1)
+    if !(c == n1 == n2 == m)
+        msg = "The number of constraints ($c), variables ($n1, $n2) and coefficients ($m) must match"
         throw(DimensionMismatch(msg))
     end
     new_coeffs = convert.(T, coeffs)

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -2653,8 +2653,6 @@ julia> set_normalized_coefficients(con, x, [(1, 2.0), (2, 5.0)])
 julia> con
 con : [2 x, 5 x] ∈ MathOptInterface.Nonnegatives(2)
 ```
-
-See also [`set_normalized_coefficient`](@ref).
 """
 function set_normalized_coefficients(
     constraint::ConstraintRef{<:AbstractModel,<:MOI.ConstraintIndex{F}},

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -2550,8 +2550,6 @@ julia> set_normalized_coefficient(con, x, 4)
 julia> con
 con : 4 x ≤ 2
 ```
-
-See also [`set_normalized_coefficients`](@ref).
 """
 function set_normalized_coefficient(
     con_ref::ConstraintRef{<:AbstractModel,<:MOI.ConstraintIndex{F}},
@@ -2569,7 +2567,7 @@ function set_normalized_coefficient(
 end
 
 """
-    set_normalized_coefficients(
+    set_normalized_coefficient(
         constraints::AbstractVector{<:ConstraintRef},
         variables::AbstractVector{<:GenericVariableRef},
         values::AbstractVector{<:Number},
@@ -2579,7 +2577,7 @@ Set multiple coefficient of `variables` in the constraints `constraints` to `val
 
 Note that prior to this step, JuMP will aggregate multiple terms containing the
 same variable. For example, given a constraint `2x + 3x <= 2`,
-`set_normalized_coefficients(con, [x], [4])` will create the constraint `4x <= 2`.
+`set_normalized_coefficient(con, [x], [4])` will create the constraint `4x <= 2`.
 
 ## Example
 
@@ -2595,15 +2593,13 @@ y
 julia> @constraint(model, con, 2x + 3x + 4y <= 2)
 con : 5 x + 4 y ≤ 2
 
-julia> set_normalized_coefficients([con, con], [x, y], [6, 7])
+julia> set_normalized_coefficient([con, con], [x, y], [6, 7])
 
 julia> con
 con : 6 x + 7 y ≤ 2
 ```
-
-See also [`set_normalized_coefficients`](@ref).
 """
-function set_normalized_coefficients(
+function set_normalized_coefficient(
     constraints::AbstractVector{
         <:ConstraintRef{<:AbstractModel,<:MOI.ConstraintIndex{F}},
     },
@@ -2707,8 +2703,6 @@ julia> set_normalized_coefficient(con, x[1], x[2], 5)
 julia> con
 con : 4 x[1]² + 5 x[1]*x[2] + x[2] ≤ 2
 ```
-
-See also [`set_normalized_coefficients`](@ref).
 """
 function set_normalized_coefficient(
     constraint::ConstraintRef{<:AbstractModel,<:MOI.ConstraintIndex{F}},
@@ -2735,7 +2729,7 @@ function set_normalized_coefficient(
 end
 
 """
-    set_normalized_coefficients(
+    set_normalized_coefficient(
         constraints::AbstractVector{<:ConstraintRef},
         variables_1:AbstractVector{<:GenericVariableRef},
         variables_2:AbstractVector{<:GenericVariableRef},
@@ -2747,7 +2741,7 @@ the constraints `constraints` to `values`.
 
 Note that prior to this step, JuMP will aggregate multiple terms containing the
 same variable. For example, given a constraint `2x^2 + 3x^2 <= 2`,
-`set_normalized_coefficients(con, [x], [x], [4])` will create the constraint `4x^2 <= 2`.
+`set_normalized_coefficient(con, [x], [x], [4])` will create the constraint `4x^2 <= 2`.
 
 ## Example
 
@@ -2759,15 +2753,13 @@ julia> @variable(model, x[1:2]);
 julia> @constraint(model, con, 2x[1]^2 + 3 * x[1] * x[2] + x[2] <= 2)
 con : 2 x[1]² + 3 x[1]*x[2] + x[2] ≤ 2
 
-julia> set_normalized_coefficients([con, con], [x[1], x[1]], [x[1], x[2]], [4, 5])
+julia> set_normalized_coefficient([con, con], [x[1], x[1]], [x[1], x[2]], [4, 5])
 
 julia> con
 con : 4 x[1]² + 5 x[1]*x[2] + x[2] ≤ 2
 ```
-
-See also [`set_normalized_coefficients`](@ref).
 """
-function set_normalized_coefficients(
+function set_normalized_coefficient(
     constraints::AbstractVector{
         <:ConstraintRef{<:AbstractModel,<:MOI.ConstraintIndex{F}},
     },

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -2573,7 +2573,8 @@ end
         values::AbstractVector{<:Number},
     )
 
-Set multiple coefficient of `variables` in the constraints `constraints` to `values`.
+Set multiple coefficient of `variables` in the constraints `constraints` to
+`values`.
 
 Note that prior to this step, JuMP will aggregate multiple terms containing the
 same variable. For example, given a constraint `2x + 3x <= 2`,
@@ -2607,11 +2608,8 @@ function set_normalized_coefficient(
     coeffs::AbstractVector{<:Number},
 ) where {T,F<:Union{MOI.ScalarAffineFunction{T},MOI.ScalarQuadraticFunction{T}}}
     if !(length(constraints) == length(variables) == length(coeffs))
-        throw(
-            DimensionMismatch(
-                "The number of constraints, variables and coefficients must match",
-            ),
-        )
+        msg = "The number of constraints, variables and coefficients must match"
+        throw(DimensionMismatch(msg))
     end
     model = owner_model(first(constraints))
     MOI.modify(
@@ -2734,12 +2732,13 @@ end
         values::AbstractVector{<:Number},
     )
 
-Set multiple quadratic coefficients associated with `variables_1` and `variables_2` in
-the constraints `constraints` to `values`.
+Set multiple quadratic coefficients associated with `variables_1` and
+`variables_2` in the constraints `constraints` to `values`.
 
 Note that prior to this step, JuMP will aggregate multiple terms containing the
 same variable. For example, given a constraint `2x^2 + 3x^2 <= 2`,
-`set_normalized_coefficient(con, [x], [x], [4])` will create the constraint `4x^2 <= 2`.
+`set_normalized_coefficient(con, [x], [x], [4])` will create the constraint
+`4x^2 <= 2`.
 
 ## Example
 
@@ -2765,21 +2764,18 @@ function set_normalized_coefficient(
     variables_2::AbstractVector{<:AbstractVariableRef},
     coeffs::AbstractVector{<:Number},
 ) where {T,F<:MOI.ScalarQuadraticFunction{T}}
-    if !(
+    dimension_match =
         length(constraints) ==
         length(variables_1) ==
         length(variables_2) ==
         length(coeffs)
-    )
-        throw(
-            DimensionMismatch(
-                "The number of constraints, variables and coefficients must match",
-            ),
-        )
+    if !dimension_match
+        msg = "The number of constraints, variables and coefficients must match"
+        throw(DimensionMismatch(msg))
     end
     new_coeffs = convert.(T, coeffs)
-    for i in eachindex(variables_1)
-        if variables_1[i] == variables_2[i]
+    for (i, x, y) in zip(eachindex(new_coeffs), variables_1, variables_2)
+        if x == y
             new_coeffs[i] *= T(2)
         end
     end

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -2759,7 +2759,7 @@ julia> @variable(model, x[1:2]);
 julia> @constraint(model, con, 2x[1]^2 + 3 * x[1] * x[2] + x[2] <= 2)
 con : 2 x[1]² + 3 x[1]*x[2] + x[2] ≤ 2
 
-julia> set_normalized_coefficient([con, con], [x[1], x[1]], [x[1], x[2]], [4, 5])
+julia> set_normalized_coefficients([con, con], [x[1], x[1]], [x[1], x[2]], [4, 5])
 
 julia> con
 con : 4 x[1]² + 5 x[1]*x[2] + x[2] ≤ 2

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -987,15 +987,15 @@ function test_change_coefficient_batch()
     con_ref = @constraint(model, 2 * x + 3 * y == -1)
     @test normalized_coefficient(con_ref, x) == 2.0
     @test normalized_coefficient(con_ref, y) == 3.0
-    set_normalized_coefficients([con_ref, con_ref], [x, y], [1.0, 4.0])
+    set_normalized_coefficient([con_ref, con_ref], [x, y], [1.0, 4.0])
     @test normalized_coefficient(con_ref, x) == 1.0
     @test normalized_coefficient(con_ref, y) == 4.0
-    set_normalized_coefficients([con_ref, con_ref], [x, y], [3, 4])  # Check type promotion.
+    set_normalized_coefficient([con_ref, con_ref], [x, y], [3, 4])  # Check type promotion.
     @test normalized_coefficient(con_ref, x) == 3.0
     @test normalized_coefficient(con_ref, y) == 4.0
     quad_con = @constraint(model, x^2 == 0)
     @test normalized_coefficient(quad_con, x) == 0.0
-    set_normalized_coefficients([quad_con, quad_con], [x, y], [2, 7])
+    set_normalized_coefficient([quad_con, quad_con], [x, y], [2, 7])
     @test normalized_coefficient(quad_con, x) == 2.0
     @test normalized_coefficient(quad_con, y) == 7.0
     @test isequal_canonical(constraint_object(quad_con).func, x^2 + 2x + 7y)
@@ -1003,7 +1003,7 @@ function test_change_coefficient_batch()
         DimensionMismatch(
             "The number of constraints, variables and coefficients must match",
         ),
-        set_normalized_coefficients([con_ref], [x, y], [4, 5]),
+        set_normalized_coefficient([con_ref], [x, y], [4, 5]),
     )
     return
 end
@@ -1863,14 +1863,14 @@ function test_set_normalized_coefficient_quadratic_batch()
     @constraint(model, con, 2x[1]^2 + 3 * x[1] * x[2] + x[2] <= 2)
     @test normalized_coefficient(con, x[1], x[1]) == 2.0
     @test normalized_coefficient(con, x[1], x[2]) == 3.0
-    set_normalized_coefficients([con, con], [x[1], x[1]], [x[1], x[2]], [4, 5])
+    set_normalized_coefficient([con, con], [x[1], x[1]], [x[1], x[2]], [4, 5])
     @test normalized_coefficient(con, x[1], x[1]) == 4.0
     @test normalized_coefficient(con, x[1], x[2]) == 5.0
     @test_throws(
         DimensionMismatch(
             "The number of constraints, variables and coefficients must match",
         ),
-        set_normalized_coefficients([con], [x[1], x[1]], [x[1], x[2]], [4, 5]),
+        set_normalized_coefficient([con], [x[1], x[1]], [x[1], x[2]], [4, 5]),
     )
     return
 end

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -1030,6 +1030,29 @@ function test_change_rhs()
     return
 end
 
+function test_change_rhs_batch()
+    model = Model()
+    x = @variable(model)
+    con_ref1 = @constraint(model, 2 * x <= 1)
+    con_ref2 = @constraint(model, 3 * x <= 2)
+    @test normalized_rhs(con_ref1) == 1.0
+    @test normalized_rhs(con_ref2) == 2.0
+    set_normalized_rhs([con_ref1, con_ref2], [3.0, 4.0])
+    @test normalized_rhs(con_ref1) == 3.0
+    @test normalized_rhs(con_ref2) == 4.0
+    con_ref1 = @constraint(model, 2 * x - 1 == 1)
+    con_ref2 = @constraint(model, 2 * x - 1 == 2)
+    @test normalized_rhs(con_ref1) == 2.0
+    @test normalized_rhs(con_ref2) == 3.0
+    set_normalized_rhs([con_ref1, con_ref2], [3.0, 4.0])
+    @test normalized_rhs(con_ref1) == 3.0
+    @test normalized_rhs(con_ref2) == 4.0
+    con_ref1 = @constraint(model, 0 <= 2 * x)
+    con_ref2 = @constraint(model, 2 * x <= 1)
+    @test_throws MethodError set_normalized_rhs([con_ref1, con_ref2], [3, 3])
+    return
+end
+
 function test_add_to_function_constant_scalar()
     model = Model()
     x = @variable(model)

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -999,6 +999,12 @@ function test_change_coefficient_batch()
     @test normalized_coefficient(quad_con, x) == 2.0
     @test normalized_coefficient(quad_con, y) == 7.0
     @test isequal_canonical(constraint_object(quad_con).func, x^2 + 2x + 7y)
+    @test_throws(
+        DimensionMismatch(
+            "The number of constraints, variables and coefficients must match",
+        ),
+        set_normalized_coefficients([con_ref], [x, y], [4, 5]),
+    )
     return
 end
 
@@ -1860,6 +1866,12 @@ function test_set_normalized_coefficient_quadratic_batch()
     set_normalized_coefficients([con, con], [x[1], x[1]], [x[1], x[2]], [4, 5])
     @test normalized_coefficient(con, x[1], x[1]) == 4.0
     @test normalized_coefficient(con, x[1], x[2]) == 5.0
+    @test_throws(
+        DimensionMismatch(
+            "The number of constraints, variables and coefficients must match",
+        ),
+        set_normalized_coefficients([con], [x[1], x[1]], [x[1], x[2]], [4, 5]),
+    )
     return
 end
 

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -1001,7 +1001,7 @@ function test_change_coefficient_batch()
     @test isequal_canonical(constraint_object(quad_con).func, x^2 + 2x + 7y)
     @test_throws(
         DimensionMismatch(
-            "The number of constraints, variables and coefficients must match",
+            "The number of constraints (1), variables (2) and coefficients (2) must match",
         ),
         set_normalized_coefficient([con_ref], [x, y], [4, 5]),
     )
@@ -1868,7 +1868,7 @@ function test_set_normalized_coefficient_quadratic_batch()
     @test normalized_coefficient(con, x[1], x[2]) == 5.0
     @test_throws(
         DimensionMismatch(
-            "The number of constraints, variables and coefficients must match",
+            "The number of constraints (1), variables (2, 2) and coefficients (2) must match",
         ),
         set_normalized_coefficient([con], [x[1], x[1]], [x[1], x[2]], [4, 5]),
     )

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -987,15 +987,15 @@ function test_change_coefficient_batch()
     con_ref = @constraint(model, 2 * x + 3 * y == -1)
     @test normalized_coefficient(con_ref, x) == 2.0
     @test normalized_coefficient(con_ref, y) == 3.0
-    set_normalized_coefficients(con_ref, [x, y], [1.0, 4.0])
+    set_normalized_coefficients([con_ref, con_ref], [x, y], [1.0, 4.0])
     @test normalized_coefficient(con_ref, x) == 1.0
     @test normalized_coefficient(con_ref, y) == 4.0
-    set_normalized_coefficients(con_ref, [x, y], [3, 4])  # Check type promotion.
+    set_normalized_coefficients([con_ref, con_ref], [x, y], [3, 4])  # Check type promotion.
     @test normalized_coefficient(con_ref, x) == 3.0
     @test normalized_coefficient(con_ref, y) == 4.0
     quad_con = @constraint(model, x^2 == 0)
     @test normalized_coefficient(quad_con, x) == 0.0
-    set_normalized_coefficients(quad_con, [x, y], [2, 7])
+    set_normalized_coefficients([quad_con, quad_con], [x, y], [2, 7])
     @test normalized_coefficient(quad_con, x) == 2.0
     @test normalized_coefficient(quad_con, y) == 7.0
     @test isequal_canonical(constraint_object(quad_con).func, x^2 + 2x + 7y)
@@ -1047,7 +1047,7 @@ function test_change_rhs_batch()
     set_normalized_rhs([con_ref1, con_ref2], [3.0, 4.0])
     @test normalized_rhs(con_ref1) == 3.0
     @test normalized_rhs(con_ref2) == 4.0
-    con_ref1 = @constraint(model, 0 <= 2 * x)
+    con_ref1 = @constraint(model, 0 >= 2 * x)
     con_ref2 = @constraint(model, 2 * x <= 1)
     @test_throws MethodError set_normalized_rhs([con_ref1, con_ref2], [3, 3])
     return
@@ -1857,7 +1857,7 @@ function test_set_normalized_coefficient_quadratic_batch()
     @constraint(model, con, 2x[1]^2 + 3 * x[1] * x[2] + x[2] <= 2)
     @test normalized_coefficient(con, x[1], x[1]) == 2.0
     @test normalized_coefficient(con, x[1], x[2]) == 3.0
-    set_normalized_coefficient(con, [x[1], x[1]], [x[1], x[2]], [4, 5])
+    set_normalized_coefficients([con, con], [x[1], x[1]], [x[1], x[2]], [4, 5])
     @test normalized_coefficient(con, x[1], x[1]) == 4.0
     @test normalized_coefficient(con, x[1], x[2]) == 5.0
     return

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -987,15 +987,15 @@ function test_change_coefficient_batch()
     con_ref = @constraint(model, 2 * x + 3 * y == -1)
     @test normalized_coefficient(con_ref, x) == 2.0
     @test normalized_coefficient(con_ref, y) == 3.0
-    set_normalized_coefficient(con_ref, [x, y], [1.0, 4.0])
+    set_normalized_coefficients(con_ref, [x, y], [1.0, 4.0])
     @test normalized_coefficient(con_ref, x) == 1.0
     @test normalized_coefficient(con_ref, y) == 4.0
-    set_normalized_coefficient(con_ref, [x, y], [3, 4])  # Check type promotion.
+    set_normalized_coefficients(con_ref, [x, y], [3, 4])  # Check type promotion.
     @test normalized_coefficient(con_ref, x) == 3.0
     @test normalized_coefficient(con_ref, y) == 4.0
     quad_con = @constraint(model, x^2 == 0)
     @test normalized_coefficient(quad_con, x) == 0.0
-    set_normalized_coefficient(quad_con, [x, y], [2, 7])
+    set_normalized_coefficients(quad_con, [x, y], [2, 7])
     @test normalized_coefficient(quad_con, x) == 2.0
     @test normalized_coefficient(quad_con, y) == 7.0
     @test isequal_canonical(constraint_object(quad_con).func, x^2 + 2x + 7y)

--- a/test/test_objective.jl
+++ b/test/test_objective.jl
@@ -55,13 +55,13 @@ function test_objective_coef_batch_update_linear_objective_changes()
     @variable(model, x)
     @variable(model, y)
     @objective(model, Max, x)
-    set_objective_coefficient(model, [x, y], [4.0, 5.0])
+    set_objective_coefficients(model, [x, y], [4.0, 5.0])
     @test isequal_canonical(objective_function(model), 4x + 5y)
     @objective(model, Max, x + y)
-    set_objective_coefficient(model, [x, y], [4.0, 5.0])
+    set_objective_coefficients(model, [x, y], [4.0, 5.0])
     @test isequal_canonical(objective_function(model), 4x + 5y)
     @objective(model, Min, x)
-    set_objective_coefficient(model, [y], [2.0])
+    set_objective_coefficients(model, [y], [2.0])
     @test isequal_canonical(objective_function(model), x + 2.0 * y)
     return
 end
@@ -80,7 +80,7 @@ function test_objective_coef_update_quadratic_objective_batch_changes()
     @variable(model, x)
     @variable(model, y)
     @objective(model, Max, x^2 + x + y)
-    set_objective_coefficient(model, [x, y], [4.0, 5.0])
+    set_objective_coefficients(model, [x, y], [4.0, 5.0])
     @test isequal_canonical(objective_function(model), x^2 + 4x + 5y)
     return
 end
@@ -265,12 +265,12 @@ function test_set_objective_coefficient_quadratic_batch()
     model = Model()
     @variable(model, x[1:2])
     @objective(model, Min, x[1]^2 + x[1] * x[2] + x[1] + 2)
-    set_objective_coefficient(model, [x[1], x[1]], [x[1], x[2]], [2, 3])
+    set_objective_coefficients(model, [x[1], x[1]], [x[1], x[2]], [2, 3])
     @test isequal_canonical(
         objective_function(model),
         2 * x[1]^2 + 3 * x[1] * x[2] + x[1] + 2,
     )
-    set_objective_coefficient(model, [x[2]], [x[1]], [4])
+    set_objective_coefficients(model, [x[2]], [x[1]], [4])
     @test isequal_canonical(
         objective_function(model),
         2 * x[1]^2 + 4 * x[1] * x[2] + x[1] + 2,
@@ -295,7 +295,7 @@ function test_set_objective_coefficient_quadratic_batch_error()
     @NLobjective(model, Min, x[1] * x[2])
     @test_throws(
         ErrorException("A nonlinear objective is already set in the model"),
-        set_objective_coefficient(model, [x[1]], [x[1]], [2]),
+        set_objective_coefficients(model, [x[1]], [x[1]], [2]),
     )
     return
 end
@@ -317,7 +317,7 @@ function test_set_objective_coefficient_quadratic_batch_affine_original()
     model = Model()
     @variable(model, x[1:2])
     @objective(model, Min, x[1] + 2)
-    set_objective_coefficient(model, [x[1], x[1]], [x[1], x[2]], [2, 3])
+    set_objective_coefficients(model, [x[1], x[1]], [x[1], x[2]], [2, 3])
     @test isequal_canonical(
         objective_function(model),
         2 * x[1]^2 + 3 * x[1] * x[2] + x[1] + 2,
@@ -342,7 +342,7 @@ function test_set_objective_coefficient_quadratic_batch_variable_original()
     model = Model()
     @variable(model, x[1:2])
     @objective(model, Min, x[1])
-    set_objective_coefficient(model, [x[1], x[1]], [x[1], x[2]], [2, 3])
+    set_objective_coefficients(model, [x[1], x[1]], [x[1], x[2]], [2, 3])
     @test isequal_canonical(
         objective_function(model),
         2 * x[1]^2 + 3 * x[1] * x[2] + x[1],
@@ -365,7 +365,7 @@ end
 function test_set_objective_coefficient_quadratic_batch_nothing_set()
     model = Model()
     @variable(model, x[1:2])
-    set_objective_coefficient(model, [x[1], x[1]], [x[1], x[2]], [2, 3])
+    set_objective_coefficients(model, [x[1], x[1]], [x[1], x[2]], [2, 3])
     @test isequal_canonical(
         objective_function(model),
         2 * x[1]^2 + 3 * x[1] * x[2],

--- a/test/test_objective.jl
+++ b/test/test_objective.jl
@@ -50,6 +50,28 @@ function test_objective_coef_update_linear_objective_changes()
     return
 end
 
+function test_objective_coef_update_linear_objective_error()
+    model = Model()
+    @variable(model, x[1:2])
+    @NLobjective(model, Min, x[1] * x[2])
+    @test_throws(
+        ErrorException("A nonlinear objective is already set in the model"),
+        set_objective_coefficient(model, x[1], 2),
+    )
+    return
+end
+
+function test_objective_coef_update_linear_objective_batch_error()
+    model = Model()
+    @variable(model, x[1:2])
+    @NLobjective(model, Min, x[1] * x[2])
+    @test_throws(
+        ErrorException("A nonlinear objective is already set in the model"),
+        set_objective_coefficients(model, [x[1], x[2]], [2, 3]),
+    )
+    return
+end
+
 function test_objective_coef_batch_update_linear_objective_changes()
     model = Model()
     @variable(model, x)
@@ -61,8 +83,11 @@ function test_objective_coef_batch_update_linear_objective_changes()
     set_objective_coefficients(model, [x, y], [4.0, 5.0])
     @test isequal_canonical(objective_function(model), 4x + 5y)
     @objective(model, Min, x)
+    set_objective_coefficients(model, [x], [2.0])
+    @test isequal_canonical(objective_function(model), 2x)
+    @objective(model, Min, x)
     set_objective_coefficients(model, [y], [2.0])
-    @test isequal_canonical(objective_function(model), x + 2.0 * y)
+    @test isequal_canonical(objective_function(model), x + 2y)
     return
 end
 

--- a/test/test_objective.jl
+++ b/test/test_objective.jl
@@ -72,6 +72,19 @@ function test_objective_coef_update_linear_objective_batch_error()
     return
 end
 
+function test_objective_coef_update_linear_objective_batch_dimension_error()
+    model = Model()
+    @variable(model, x[1:2])
+    @objective(model, Min, x[1] * x[2])
+    @test_throws(
+        DimensionMismatch(
+            "The number of variables and coefficients must match",
+        ),
+        set_objective_coefficients(model, [x[1], x[2]], [2]),
+    )
+    return
+end
+
 function test_objective_coef_batch_update_linear_objective_changes()
     model = Model()
     @variable(model, x)
@@ -321,6 +334,19 @@ function test_set_objective_coefficient_quadratic_batch_error()
     @test_throws(
         ErrorException("A nonlinear objective is already set in the model"),
         set_objective_coefficients(model, [x[1]], [x[1]], [2]),
+    )
+    return
+end
+
+function test_set_objective_coefficient_quadratic_batch_dimension_error()
+    model = Model()
+    @variable(model, x[1:2])
+    @objective(model, Min, x[1] * x[2])
+    @test_throws(
+        DimensionMismatch(
+            "The number of variables and coefficients must match",
+        ),
+        set_objective_coefficients(model, [x[1]], [x[1]], [2, 3]),
     )
     return
 end

--- a/test/test_objective.jl
+++ b/test/test_objective.jl
@@ -55,7 +55,10 @@ function test_objective_coef_update_linear_objective_error()
     @variable(model, x[1:2])
     @NLobjective(model, Min, x[1] * x[2])
     @test_throws(
-        ErrorException("A nonlinear objective is already set in the model"),
+        ErrorException(
+            "A nonlinear objective created by the legacy `@NLobjective` is " *
+            "set in the model. This does not support modification.",
+        ),
         set_objective_coefficient(model, x[1], 2),
     )
     return
@@ -66,7 +69,10 @@ function test_objective_coef_update_linear_objective_batch_error()
     @variable(model, x[1:2])
     @NLobjective(model, Min, x[1] * x[2])
     @test_throws(
-        ErrorException("A nonlinear objective is already set in the model"),
+        ErrorException(
+            "A nonlinear objective created by the legacy `@NLobjective` is " *
+            "set in the model. This does not support modification.",
+        ),
         set_objective_coefficient(model, [x[1], x[2]], [2, 3]),
     )
     return
@@ -78,7 +84,7 @@ function test_objective_coef_update_linear_objective_batch_dimension_error()
     @objective(model, Min, x[1] * x[2])
     @test_throws(
         DimensionMismatch(
-            "The number of variables and coefficients must match",
+            "The number of variables (2) and coefficients (1) must match",
         ),
         set_objective_coefficient(model, [x[1], x[2]], [2]),
     )
@@ -321,7 +327,10 @@ function test_set_objective_coefficient_quadratic_error()
     @variable(model, x[1:2])
     @NLobjective(model, Min, x[1] * x[2])
     @test_throws(
-        ErrorException("A nonlinear objective is already set in the model"),
+        ErrorException(
+            "A nonlinear objective created by the legacy `@NLobjective` is " *
+            "set in the model. This does not support modification.",
+        ),
         set_objective_coefficient(model, x[1], x[1], 2),
     )
     return
@@ -332,7 +341,10 @@ function test_set_objective_coefficient_quadratic_batch_error()
     @variable(model, x[1:2])
     @NLobjective(model, Min, x[1] * x[2])
     @test_throws(
-        ErrorException("A nonlinear objective is already set in the model"),
+        ErrorException(
+            "A nonlinear objective created by the legacy `@NLobjective` is " *
+            "set in the model. This does not support modification.",
+        ),
         set_objective_coefficient(model, [x[1]], [x[1]], [2]),
     )
     return
@@ -344,7 +356,7 @@ function test_set_objective_coefficient_quadratic_batch_dimension_error()
     @objective(model, Min, x[1] * x[2])
     @test_throws(
         DimensionMismatch(
-            "The number of variables and coefficients must match",
+            "The number of variables (1, 1) and coefficients (2) must match",
         ),
         set_objective_coefficient(model, [x[1]], [x[1]], [2, 3]),
     )

--- a/test/test_objective.jl
+++ b/test/test_objective.jl
@@ -67,7 +67,7 @@ function test_objective_coef_update_linear_objective_batch_error()
     @NLobjective(model, Min, x[1] * x[2])
     @test_throws(
         ErrorException("A nonlinear objective is already set in the model"),
-        set_objective_coefficients(model, [x[1], x[2]], [2, 3]),
+        set_objective_coefficient(model, [x[1], x[2]], [2, 3]),
     )
     return
 end
@@ -80,7 +80,7 @@ function test_objective_coef_update_linear_objective_batch_dimension_error()
         DimensionMismatch(
             "The number of variables and coefficients must match",
         ),
-        set_objective_coefficients(model, [x[1], x[2]], [2]),
+        set_objective_coefficient(model, [x[1], x[2]], [2]),
     )
     return
 end
@@ -90,16 +90,16 @@ function test_objective_coef_batch_update_linear_objective_changes()
     @variable(model, x)
     @variable(model, y)
     @objective(model, Max, x)
-    set_objective_coefficients(model, [x, y], [4.0, 5.0])
+    set_objective_coefficient(model, [x, y], [4.0, 5.0])
     @test isequal_canonical(objective_function(model), 4x + 5y)
     @objective(model, Max, x + y)
-    set_objective_coefficients(model, [x, y], [4.0, 5.0])
+    set_objective_coefficient(model, [x, y], [4.0, 5.0])
     @test isequal_canonical(objective_function(model), 4x + 5y)
     @objective(model, Min, x)
-    set_objective_coefficients(model, [x], [2.0])
+    set_objective_coefficient(model, [x], [2.0])
     @test isequal_canonical(objective_function(model), 2x)
     @objective(model, Min, x)
-    set_objective_coefficients(model, [y], [2.0])
+    set_objective_coefficient(model, [y], [2.0])
     @test isequal_canonical(objective_function(model), x + 2y)
     return
 end
@@ -118,7 +118,7 @@ function test_objective_coef_update_quadratic_objective_batch_changes()
     @variable(model, x)
     @variable(model, y)
     @objective(model, Max, x^2 + x + y)
-    set_objective_coefficients(model, [x, y], [4.0, 5.0])
+    set_objective_coefficient(model, [x, y], [4.0, 5.0])
     @test isequal_canonical(objective_function(model), x^2 + 4x + 5y)
     return
 end
@@ -303,12 +303,12 @@ function test_set_objective_coefficient_quadratic_batch()
     model = Model()
     @variable(model, x[1:2])
     @objective(model, Min, x[1]^2 + x[1] * x[2] + x[1] + 2)
-    set_objective_coefficients(model, [x[1], x[1]], [x[1], x[2]], [2, 3])
+    set_objective_coefficient(model, [x[1], x[1]], [x[1], x[2]], [2, 3])
     @test isequal_canonical(
         objective_function(model),
         2 * x[1]^2 + 3 * x[1] * x[2] + x[1] + 2,
     )
-    set_objective_coefficients(model, [x[2]], [x[1]], [4])
+    set_objective_coefficient(model, [x[2]], [x[1]], [4])
     @test isequal_canonical(
         objective_function(model),
         2 * x[1]^2 + 4 * x[1] * x[2] + x[1] + 2,
@@ -333,7 +333,7 @@ function test_set_objective_coefficient_quadratic_batch_error()
     @NLobjective(model, Min, x[1] * x[2])
     @test_throws(
         ErrorException("A nonlinear objective is already set in the model"),
-        set_objective_coefficients(model, [x[1]], [x[1]], [2]),
+        set_objective_coefficient(model, [x[1]], [x[1]], [2]),
     )
     return
 end
@@ -346,7 +346,7 @@ function test_set_objective_coefficient_quadratic_batch_dimension_error()
         DimensionMismatch(
             "The number of variables and coefficients must match",
         ),
-        set_objective_coefficients(model, [x[1]], [x[1]], [2, 3]),
+        set_objective_coefficient(model, [x[1]], [x[1]], [2, 3]),
     )
     return
 end
@@ -368,7 +368,7 @@ function test_set_objective_coefficient_quadratic_batch_affine_original()
     model = Model()
     @variable(model, x[1:2])
     @objective(model, Min, x[1] + 2)
-    set_objective_coefficients(model, [x[1], x[1]], [x[1], x[2]], [2, 3])
+    set_objective_coefficient(model, [x[1], x[1]], [x[1], x[2]], [2, 3])
     @test isequal_canonical(
         objective_function(model),
         2 * x[1]^2 + 3 * x[1] * x[2] + x[1] + 2,
@@ -393,7 +393,7 @@ function test_set_objective_coefficient_quadratic_batch_variable_original()
     model = Model()
     @variable(model, x[1:2])
     @objective(model, Min, x[1])
-    set_objective_coefficients(model, [x[1], x[1]], [x[1], x[2]], [2, 3])
+    set_objective_coefficient(model, [x[1], x[1]], [x[1], x[2]], [2, 3])
     @test isequal_canonical(
         objective_function(model),
         2 * x[1]^2 + 3 * x[1] * x[2] + x[1],
@@ -416,7 +416,7 @@ end
 function test_set_objective_coefficient_quadratic_batch_nothing_set()
     model = Model()
     @variable(model, x[1:2])
-    set_objective_coefficients(model, [x[1], x[1]], [x[1], x[2]], [2, 3])
+    set_objective_coefficient(model, [x[1], x[1]], [x[1], x[2]], [2, 3])
     @test isequal_canonical(
         objective_function(model),
         2 * x[1]^2 + 3 * x[1] * x[2],


### PR DESCRIPTION
Modify problems bit by bit can be surprisingly slow in some solvers (like Xpress). Batch modifications like this solve the problems. I was working on a model that changes from 750s to 150s build+modify+solve time after using batch modifications.

`rhs` would be weird in plural as `rhss`, I don't know what to do about it.