### PR TITLE
Fix adjoint of GenericNonlinearExpr

### DIFF
--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -291,6 +291,12 @@ function Base.one(::Type{GenericNonlinearExpr{V}}) where {V}
     return GenericNonlinearExpr{V}(:+, 1.0)
 end
 
+Base.conj(x::GenericNonlinearExpr) = x
+Base.real(x::GenericNonlinearExpr) = x
+Base.imag(x::GenericNonlinearExpr) = zero(x)
+Base.abs2(x::GenericNonlinearExpr) = x^2
+Base.isreal(::GenericNonlinearExpr) = true
+
 # Univariate operators
 
 _is_real(::Any) = false

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -334,6 +334,7 @@ for f in MOI.Nonlinear.DEFAULT_UNIVARIATE_OPERATORS
         end
     elseif isdefined(Base, f)
         @eval function Base.$(f)(x::AbstractJuMPScalar)
+            _throw_if_not_real(x)
             return GenericNonlinearExpr{variable_ref_type(x)}($op, x)
         end
     elseif isdefined(MOI.Nonlinear, :SpecialFunctions)
@@ -341,6 +342,7 @@ for f in MOI.Nonlinear.DEFAULT_UNIVARIATE_OPERATORS
         SF = MOI.Nonlinear.SpecialFunctions
         if isdefined(SF, f)
             @eval function $(SF).$(f)(x::AbstractJuMPScalar)
+                _throw_if_not_real(x)
                 return GenericNonlinearExpr{variable_ref_type(x)}($op, x)
             end
         end
@@ -359,14 +361,20 @@ for f in (:+, :-, :*, :^, :/, :atan, :min, :max)
     op = Meta.quot(f)
     @eval begin
         function Base.$(f)(x::AbstractJuMPScalar, y::_Constant)
+            _throw_if_not_real(x)
+            _throw_if_not_real(y)
             rhs = convert(Float64, _constant_to_number(y))
             return GenericNonlinearExpr{variable_ref_type(x)}($op, x, rhs)
         end
         function Base.$(f)(x::_Constant, y::AbstractJuMPScalar)
+            _throw_if_not_real(x)
+            _throw_if_not_real(y)
             lhs = convert(Float64, _constant_to_number(x))
             return GenericNonlinearExpr{variable_ref_type(y)}($op, lhs, y)
         end
         function Base.$(f)(x::AbstractJuMPScalar, y::AbstractJuMPScalar)
+            _throw_if_not_real(x)
+            _throw_if_not_real(y)
             return GenericNonlinearExpr{variable_ref_type(x)}($op, x, y)
         end
     end

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -85,6 +85,9 @@ struct GenericNonlinearExpr{V<:AbstractVariableRef} <: AbstractJuMPScalar
         head::Symbol,
         args::Vararg{Any},
     ) where {V<:AbstractVariableRef}
+        for arg in args
+            _throw_if_not_real(arg)
+        end
         return new{V}(head, Any[a for a in args])
     end
 
@@ -92,6 +95,9 @@ struct GenericNonlinearExpr{V<:AbstractVariableRef} <: AbstractJuMPScalar
         head::Symbol,
         args::Vector{Any},
     ) where {V<:AbstractVariableRef}
+        for arg in args
+            _throw_if_not_real(arg)
+        end
         return new{V}(head, args)
     end
 end
@@ -328,7 +334,6 @@ for f in MOI.Nonlinear.DEFAULT_UNIVARIATE_OPERATORS
         end
     elseif isdefined(Base, f)
         @eval function Base.$(f)(x::AbstractJuMPScalar)
-            _throw_if_not_real(x)
             return GenericNonlinearExpr{variable_ref_type(x)}($op, x)
         end
     elseif isdefined(MOI.Nonlinear, :SpecialFunctions)
@@ -336,7 +341,6 @@ for f in MOI.Nonlinear.DEFAULT_UNIVARIATE_OPERATORS
         SF = MOI.Nonlinear.SpecialFunctions
         if isdefined(SF, f)
             @eval function $(SF).$(f)(x::AbstractJuMPScalar)
-                _throw_if_not_real(x)
                 return GenericNonlinearExpr{variable_ref_type(x)}($op, x)
             end
         end
@@ -355,20 +359,14 @@ for f in (:+, :-, :*, :^, :/, :atan, :min, :max)
     op = Meta.quot(f)
     @eval begin
         function Base.$(f)(x::AbstractJuMPScalar, y::_Constant)
-            _throw_if_not_real(x)
-            _throw_if_not_real(y)
             rhs = convert(Float64, _constant_to_number(y))
             return GenericNonlinearExpr{variable_ref_type(x)}($op, x, rhs)
         end
         function Base.$(f)(x::_Constant, y::AbstractJuMPScalar)
-            _throw_if_not_real(x)
-            _throw_if_not_real(y)
             lhs = convert(Float64, _constant_to_number(x))
             return GenericNonlinearExpr{variable_ref_type(y)}($op, lhs, y)
         end
         function Base.$(f)(x::AbstractJuMPScalar, y::AbstractJuMPScalar)
-            _throw_if_not_real(x)
-            _throw_if_not_real(y)
             return GenericNonlinearExpr{variable_ref_type(x)}($op, x, y)
         end
     end

--- a/test/test_nlp_expr.jl
+++ b/test/test_nlp_expr.jl
@@ -1059,4 +1059,37 @@ function test_nlp_matrix_adjoint()
     return
 end
 
+function test_error_complex_literal_pow()
+    model = Model()
+    @variable(model, x in ComplexPlane())
+    @test_throws(
+        ErrorException(
+            "Cannot build `GenericNonlinearExpr` because a term is complex-" *
+            "valued: `($x)::$(typeof(x))`",
+        ),
+        x^3,
+    )
+    return
+end
+
+function test_error_nonlinear_expr_complex_constructor()
+    model = Model()
+    @variable(model, x in ComplexPlane())
+    @test_throws(
+        ErrorException(
+            "Cannot build `GenericNonlinearExpr` because a term is complex-" *
+            "valued: `($x)::$(typeof(x))`",
+        ),
+        NonlinearExpr(:^, Any[x, 3]),
+    )
+    @test_throws(
+        ErrorException(
+            "Cannot build `GenericNonlinearExpr` because a term is complex-" *
+            "valued: `($x)::$(typeof(x))`",
+        ),
+        NonlinearExpr(:^, x, 3),
+    )
+    return
+end
+
 end  # module

--- a/test/test_nlp_expr.jl
+++ b/test/test_nlp_expr.jl
@@ -1035,4 +1035,28 @@ function test_convert_float_nonlinear_expr()
     return
 end
 
+function test_nlp_adjoint()
+    model = Model()
+    @variable(model, x)
+    y = sin(x)
+    @test y' === y
+    @test conj(y) === y
+    @test real(y) === y
+    @test isequal_canonical(imag(y), zero(y))
+    @test isequal_canonical(abs2(y), y^2)
+    @test isreal(y)
+    return
+end
+
+function test_nlp_matrix_adjoint()
+    model = Model()
+    @variable(model, x[1:2])
+    y = sin.(x)
+    @test isequal_canonical(
+        @expression(model, expr, y' * y),
+        NonlinearExpr(:+, Any[0.0, y[2] * y[2], y[1] * y[1]]),
+    )
+    return
+end
+
 end  # module

--- a/test/test_nlp_expr.jl
+++ b/test/test_nlp_expr.jl
@@ -1054,7 +1054,7 @@ function test_nlp_matrix_adjoint()
     y = sin.(x)
     @test isequal_canonical(
         @expression(model, expr, y' * y),
-        NonlinearExpr(:+, Any[0.0, y[2] * y[2], y[1] * y[1]]),
+        NonlinearExpr(:+, Any[0.0, y[2]*y[2], y[1]*y[1]]),
     )
     return
 end

--- a/test/test_operator.jl
+++ b/test/test_operator.jl
@@ -621,7 +621,6 @@ function test_complex_pow()
     @test y^0 == (1.0 + 0im)
     @test y^1 == y
     @test y^2 == y * y
-    @test isequal_canonical(y^3, NonlinearExpr(:^, Any[y, 3]))
     return
 end
 


### PR DESCRIPTION
Closes #3723

So I didn't really think through the implications of this prior.

We kinda punted on the question of whether `ScalarNonlinearFunction` is `<:Real` or `<:Complex`. But I think it's time to pick `<:Real`, and if we need it, we can introduce something like:
```julia
struct ComplexScalarNonlinearFunction
    real::ScalarNonlinearFunction
    imag::ScalarNonlinearFunctionn
end
```