### PR TITLE
Prep for v1.21.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuMP"
 uuid = "4076af6c-e467-56ae-b986-b466b2749572"
 repo = "https://github.com/jump-dev/JuMP.jl.git"
-version = "1.21.0"
+version = "1.21.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -81,7 +81,7 @@
 # [Penopt]
 #     rev = "486f07d3f3a11f12012ea3ada702a3ee55c8fdc5"
 [PolyJuMP]
-    rev = "v0.7.3"
+    rev = "v0.7.4"
     extension = true
 [SCS]
     rev = "v2.0.0"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,21 @@ CurrentModule = JuMP
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version 1.21.1 (April 11, 2024)
+
+### Fixed
+
+ - Fixed behavior of complex-value related functions like `real`, `imag`, `conj`
+   and `abs2` when called on [`GenericNonlinearExpr`](@ref). This fixes a method
+   error when calling `x'` where `x` is an array of nonlinear expressions. As a
+   related consequence, we now always error when creating nonlinear expressions
+   with complex components. Previously, only some constructors were checked for
+   complex expressionns. (#3724)
+
+### Other
+
+ - Documentation improvements (#3719) (#3720) (#3721) (#3722)
+
 ## Version 1.21.0 (March 31, 2024)
 
 ### Added


### PR DESCRIPTION
## Pre-release

 - [x] Check that the pinned packages in `docs/Project.toml` are updated. We pin
       the versions so that changes in the solvers (changes in printing, small
       numeric changes) do not break the printing of the JuMP docs in arbitrary
       commits.
 - [x] Check that the `rev` fields in `docs/packages.toml` are updated. We pin
       the versions of solvers and extensions to ensure that changes to their
       READMEs do not break the JuMP docs in arbitrary commits, and to ensure
       that the versions are compatible with the latest JuMP and
       MathOptInterface releases.
 - [x] Check compat of `DimensionalData` in `Project.toml`
 - [x] Check compat of `MacroTools` in `Project.toml`
 - [x] Update `docs/src/changelog.md`
 - [x] https://github.com/jump-dev/JuMP.jl/actions/runs/8637630824
 - [x] Change the version number in `Project.toml`
 - [x] The commit messages in this PR do not contain `[ci skip]`

## The release

 - [ ] After merging this pull request, comment `[at]JuliaRegistrator register` in
       the GitHub commit. This should automatically publish a new version to the
       Julia registry, as well as create a tag, and rebuild the documentation
       for this tag.

       These steps can take quite a bit of time (1 hour or more), so don't be
       surprised if the new documentation takes a while to appear. In addition,
       the links in the README will be broken until JuliaHub fetches the new
       version on their servers.

## Post-release

 - [ ] Once the tag is created, update the relevant `release-` branch. The latest
       release branch at the time of writing is `release-1.0` (we haven't
       back-ported any patches that needed to create a `release-1.Y` branch). To
       to update the release branch with the v1.10.0 tag, do:
       ```
       git checkout release-1.0
       git pull
       git merge v1.10.0
       git push
       ```