### PR TITLE
Support vector-valued constraints in normalized_coefficient

### DIFF
--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -843,7 +843,7 @@ julia> normalized_coefficient(con, x[1], x[2])
 ### Vector constraints
 
 To modify the coefficients of a vector-valued constraint, use
-[`set_normalized_coefficients`](@ref).
+[`set_normalized_coefficient`](@ref).
 ```jldoctest
 julia> model = Model();
 
@@ -853,12 +853,12 @@ x
 julia> @constraint(model, con, [2x + 3x, 4x] in MOI.Nonnegatives(2))
 con : [5 x, 4 x] ∈ MathOptInterface.Nonnegatives(2)
 
-julia> set_normalized_coefficients(con, x, [(1, 3.0)])
+julia> set_normalized_coefficient(con, x, [(1, 3.0)])
 
 julia> con
 con : [3 x, 4 x] ∈ MathOptInterface.Nonnegatives(2)
 
-julia> set_normalized_coefficients(con, x, [(1, 2.0), (2, 5.0)])
+julia> set_normalized_coefficient(con, x, [(1, 2.0), (2, 5.0)])
 
 julia> con
 con : [2 x, 5 x] ∈ MathOptInterface.Nonnegatives(2)

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -2801,7 +2801,7 @@ end
 Return the coefficient associated with `variable` in `constraint` after JuMP has
 normalized the constraint into its standard form.
 
-See also [`set_normalized_coefficient`](@ref).
+See also [`set_normalized_coefficient`](@ref) and [`set_normalized_coefficients`](@ref)..
 
 ## Example
 
@@ -2816,6 +2816,15 @@ con : 5 x ≤ 2
 
 julia> normalized_coefficient(con, x)
 5.0
+
+julia> @constraint(model, con_vec, [x, 2x + 1, 3] >= 0)
+[x, 2 x + 1, 3] ∈ MathOptInterface.Nonnegatives(3)
+
+julia> normalized_coefficient(con_vec, x)
+3-element Vector{Float64}:
+ 1.0
+ 2.0
+ 0.0
 ```
 """
 function normalized_coefficient(
@@ -2823,6 +2832,13 @@ function normalized_coefficient(
     variable::AbstractVariableRef,
 ) where {F<:Union{MOI.ScalarAffineFunction,MOI.ScalarQuadraticFunction}}
     return coefficient(constraint_object(constraint).func, variable)
+end
+
+function normalized_coefficient(
+    constraint::ConstraintRef{<:AbstractModel,<:MOI.ConstraintIndex{F}},
+    variable::AbstractVariableRef,
+) where {F<:Union{MOI.VectorAffineFunction,MOI.VectorQuadraticFunction}}
+    return coefficient.(constraint_object(constraint).func, variable)
 end
 
 """
@@ -2861,6 +2877,15 @@ function normalized_coefficient(
 ) where {F<:MOI.ScalarQuadraticFunction}
     con = constraint_object(constraint)
     return coefficient(con.func, variable_1, variable_2)
+end
+
+function normalized_coefficient(
+    constraint::ConstraintRef{<:AbstractModel,<:MOI.ConstraintIndex{F}},
+    variable_1::AbstractVariableRef,
+    variable_2::AbstractVariableRef,
+) where {F<:MOI.VectorQuadraticFunction}
+    con = constraint_object(constraint)
+    return coefficient.(con.func, variable_1, variable_2)
 end
 
 ###

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -2853,14 +2853,8 @@ function normalized_coefficient(
     constraint::ConstraintRef{<:AbstractModel,<:MOI.ConstraintIndex{F}},
     variable::AbstractVariableRef,
 ) where {T,F<:Union{MOI.VectorAffineFunction{T},MOI.VectorQuadraticFunction{T}}}
-    ret = Tuple{Int,T}[]
-    for (i, fi) in enumerate(constraint_object(constraint).func)
-        c = coefficient(fi, variable)
-        if !iszero(c)
-            push!(ret, (i, c))
-        end
-    end
-    return ret
+    c = coefficient.(constraint_object(constraint).func, variable)
+    return filter!(!iszero ∘ last, collect(enumerate(c)))
 end
 
 """
@@ -2916,14 +2910,9 @@ function normalized_coefficient(
     variable_1::AbstractVariableRef,
     variable_2::AbstractVariableRef,
 ) where {T,F<:MOI.VectorQuadraticFunction{T}}
-    ret = Tuple{Int,T}[]
-    for (i, fi) in enumerate(constraint_object(constraint).func)
-        c = coefficient(fi, variable_1, variable_2)
-        if !iszero(c)
-            push!(ret, (i, c))
-        end
-    end
-    return ret
+    f = constraint_object(constraint).func
+    c = coefficient.(f, variable_1, variable_2)
+    return filter!(!iszero ∘ last, collect(enumerate(c)))
 end
 
 ###

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -2818,7 +2818,7 @@ julia> normalized_coefficient(con, x)
 5.0
 
 julia> @constraint(model, con_vec, [x, 2x + 1, 3] >= 0)
-[x, 2 x + 1, 3] ∈ MathOptInterface.Nonnegatives(3)
+con_vec : [x, 2 x + 1, 3] ∈ MathOptInterface.Nonnegatives(3)
 
 julia> normalized_coefficient(con_vec, x)
 3-element Vector{Float64}:

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -2624,7 +2624,7 @@ function set_normalized_coefficient(
 end
 
 """
-    set_normalized_coefficients(
+    set_normalized_coefficient(
         con_ref::ConstraintRef,
         variable::AbstractVariableRef,
         new_coefficients::Vector{Tuple{Int64,T}},
@@ -2648,13 +2648,13 @@ x
 julia> @constraint(model, con, [2x + 3x, 4x] in MOI.Nonnegatives(2))
 con : [5 x, 4 x] ∈ MathOptInterface.Nonnegatives(2)
 
-julia> set_normalized_coefficients(con, x, [(1, 2.0), (2, 5.0)])
+julia> set_normalized_coefficient(con, x, [(1, 2.0), (2, 5.0)])
 
 julia> con
 con : [2 x, 5 x] ∈ MathOptInterface.Nonnegatives(2)
 ```
 """
-function set_normalized_coefficients(
+function set_normalized_coefficient(
     constraint::ConstraintRef{<:AbstractModel,<:MOI.ConstraintIndex{F}},
     variable::AbstractVariableRef,
     new_coefficients::Vector{Tuple{Int64,T}},
@@ -2669,6 +2669,22 @@ function set_normalized_coefficients(
     return
 end
 
+"""
+    set_normalized_coefficients(
+        constraint::ConstraintRef{<:AbstractModel,<:MOI.ConstraintIndex{F}},
+        variable::AbstractVariableRef,
+        new_coefficients::Vector{Tuple{Int64,T}},
+    ) where {T,F<:Union{MOI.VectorAffineFunction{T},MOI.VectorQuadraticFunction{T}}}
+
+A deprecated method that now redirects to [`set_normalized_coefficient`](@ref).
+"""
+function set_normalized_coefficients(
+    constraint::ConstraintRef{<:AbstractModel,<:MOI.ConstraintIndex{F}},
+    variable::AbstractVariableRef,
+    new_coefficients::Vector{Tuple{Int64,T}},
+) where {T,F<:Union{MOI.VectorAffineFunction{T},MOI.VectorQuadraticFunction{T}}}
+    return set_normalized_coefficient(constraint, variable, new_coefficients)
+end
 """
     set_normalized_coefficient(
         constraint::ConstraintRef,
@@ -2801,7 +2817,7 @@ end
 Return the coefficient associated with `variable` in `constraint` after JuMP has
 normalized the constraint into its standard form.
 
-See also [`set_normalized_coefficient`](@ref) and [`set_normalized_coefficients`](@ref)..
+See also [`set_normalized_coefficient`](@ref).
 
 ## Example
 

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -1013,6 +1013,18 @@ function test_change_coefficients_vector_function()
     @variable(model, x)
     @constraint(model, con, [2x + 3x, 4x] in MOI.Nonnegatives(2))
     @test isequal_canonical(constraint_object(con).func, [5.0x, 4.0x])
+    set_normalized_coefficient(con, x, [(Int64(1), 3.0)])
+    @test isequal_canonical(constraint_object(con).func, [3.0x, 4.0x])
+    set_normalized_coefficient(con, x, [(Int64(1), 2.0), (Int64(2), 5.0)])
+    @test isequal_canonical(constraint_object(con).func, [2.0x, 5.0x])
+    return
+end
+
+function test_change_coefficients_vector_function_DEPRECATED()
+    model = Model()
+    @variable(model, x)
+    @constraint(model, con, [2x + 3x, 4x] in MOI.Nonnegatives(2))
+    @test isequal_canonical(constraint_object(con).func, [5.0x, 4.0x])
     set_normalized_coefficients(con, x, [(Int64(1), 3.0)])
     @test isequal_canonical(constraint_object(con).func, [3.0x, 4.0x])
     set_normalized_coefficients(con, x, [(Int64(1), 2.0), (Int64(2), 5.0)])

--- a/test/test_variable.jl
+++ b/test/test_variable.jl
@@ -1629,10 +1629,11 @@ end
 function test_variable_normalized_coefficient_vector()
     model = Model()
     @variable(model, x[1:3])
-    A = [4 5 0; 0 6 7; 8 0 0; 9 10 11]
+    A = Float64[4 5 0; 0 6 7; 8 0 0; 9 10 11]
+    sparse(y) = filter!(!iszero ∘ last, collect(enumerate(y)))
     @constraint(model, c, A * x >= 0)
     for i in 1:3
-        @test normalized_coefficient(c, x[i]) == A[:, i]
+        @test normalized_coefficient(c, x[i]) == sparse(A[:, i])
     end
     return
 end
@@ -1640,11 +1641,12 @@ end
 function test_variable_normalized_coefficient_vector_quadratic()
     model = Model()
     @variable(model, x[1:3])
-    A = [4 5 0; 0 6 7; 8 0 0; 9 10 11]
+    A = Float64[4 5 0; 0 6 7; 8 0 0; 9 10 11]
+    sparse(y) = filter!(!iszero ∘ last, collect(enumerate(y)))
     @constraint(model, c, A * (x .^ 2) >= 0)
     for i in 1:3, j in 1:3
         b = ifelse(i == j, A[:, i], zeros(4))
-        @test normalized_coefficient(c, x[i], x[j]) == b
+        @test normalized_coefficient(c, x[i], x[j]) == sparse(b)
     end
     return
 end

--- a/test/test_variable.jl
+++ b/test/test_variable.jl
@@ -1641,7 +1641,7 @@ function test_variable_normalized_coefficient_vector_quadratic()
     model = Model()
     @variable(model, x[1:3])
     A = [4 5 0; 0 6 7; 8 0 0; 9 10 11]
-    @constraint(model, c, A * x.^2 >= 0)
+    @constraint(model, c, A * (x .^ 2) >= 0)
     for i in 1:3, j in 1:3
         b = ifelse(i == j, A[:, i], zeros(4))
         @test normalized_coefficient(c, x[i], x[j]) == b

--- a/test/test_variable.jl
+++ b/test/test_variable.jl
@@ -1626,4 +1626,27 @@ function test_variable_one()
     return
 end
 
+function test_variable_normalized_coefficient_vector()
+    model = Model()
+    @variable(model, x[1:3])
+    A = [4 5 0; 0 6 7; 8 0 0; 9 10 11]
+    @constraint(model, c, A * x >= 0)
+    for i in 1:3
+        @test normalized_coefficient(c, x[i]) == A[:, i]
+    end
+    return
+end
+
+function test_variable_normalized_coefficient_vector_quadratic()
+    model = Model()
+    @variable(model, x[1:3])
+    A = [4 5 0; 0 6 7; 8 0 0; 9 10 11]
+    @constraint(model, c, A * x.^2 >= 0)
+    for i in 1:3, j in 1:3
+        b = ifelse(i == j, A[:, i], zeros(4))
+        @test normalized_coefficient(c, x[i], x[j]) == b
+    end
+    return
+end
+
 end  # module TestVariable


### PR DESCRIPTION
Closes #3742 

One naming question:

We actually have `set_normalized_coefficiets` for this case:
https://jump.dev/JuMP.jl/stable/api/JuMP/#set_normalized_coefficients

So we should probably either call this `normalized_coefficients`, or rename `set_normalized_coefficients` to `set_normalized_coefficient` (but leave the current method for backwards compatibility).