### PR TITLE
only autoinclude files ending with `.jl` in `macros`

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -468,7 +468,9 @@ function _plural_macro_code(model, block, macro_sym)
 end
 
 for file in readdir(joinpath(@__DIR__, "macros"))
-    if occursin(r".jl$", file)
+    # The check for .jl is necessary because some users may have other files
+    # like .cov from running code coverage. See JuMP.jl#3746.
+    if endswith(file, ".jl")
         include(joinpath(@__DIR__, "macros", file))
     end
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -468,5 +468,7 @@ function _plural_macro_code(model, block, macro_sym)
 end
 
 for file in readdir(joinpath(@__DIR__, "macros"))
-    include(joinpath(@__DIR__, "macros", file))
+    if occursin(r".jl$", file)
+        include(joinpath(@__DIR__, "macros", file))
+    end
 end


### PR DESCRIPTION
possible fix for #3746 