### PR TITLE
Deprecate experimental _differentiation_backend

### DIFF
--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -380,8 +380,6 @@ end
     optimize!(
         model::GenericModel;
         ignore_optimize_hook = (model.optimize_hook === nothing),
-        _differentiation_backend::MOI.Nonlinear.AbstractAutomaticDifferentiation =
-            MOI.Nonlinear.SparseReverseMode(),
         kwargs...,
     )
 
@@ -394,21 +392,11 @@ If `ignore_optimize_hook == true`, the optimize hook is ignored and the model is
 solved as if the hook was not set. Keyword arguments `kwargs` are passed to the
 `optimize_hook`. An error is thrown if `optimize_hook` is `nothing` and keyword
 arguments are provided.
-
-## Experimental features
-
-These features may change or be removed in any future version of JuMP.
-
-Pass `_differentiation_backend` to set the
-[`MOI.Nonlinear.AbstractAutomaticDifferentiation`](@ref) backend used to compute
-derivatives of nonlinear programs.
-
-If you require only `:ExprGraph`, it is more efficient to pass
-`_differentiation_backend = MOI.Nonlinear.ExprGraphOnly()`.
 """
 function optimize!(
     model::GenericModel;
     ignore_optimize_hook = (model.optimize_hook === nothing),
+    # _differentiation_backend is deprecated. Remove in JuMP v2.0
     _differentiation_backend::MOI.Nonlinear.AbstractAutomaticDifferentiation = MOI.Nonlinear.SparseReverseMode(),
     kwargs...,
 )


### PR DESCRIPTION
The correct solution is to set the `MOI.AutomaticDifferentiationBackend` attribute of the solver (if applicable).