### PR TITLE
Improve printing of symmetric matrices when used in constraints

### DIFF
--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -202,12 +202,12 @@ julia> @variable(model, X[1:2, 1:2], Symmetric)
 
 julia> @constraint(model, X == LinearAlgebra.I)
 [X[1,1] - 1  X[1,2]
- X[1,2]      X[2,2] - 1] ∈ Zeros()
+ ⋅           X[2,2] - 1] ∈ Zeros()
 ```
 
-Despite the model showing the matrix in [`Zeros`](@ref), this will add only
-three rows to the constraint matrix because the symmetric constraints are
-redundant. In contrast, the broadcasting syntax adds four linear constraints:
+This will add only three rows to the constraint matrix because the symmetric
+constraints are redundant. In contrast, the broadcasting syntax adds four linear
+constraints:
 
 ```jldoctest con_symmetric_zeros
 julia> @constraint(model, X .== LinearAlgebra.I)

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -202,7 +202,7 @@ julia> @variable(model, X[1:2, 1:2], Symmetric)
 
 julia> @constraint(model, X == LinearAlgebra.I)
 [X[1,1] - 1  X[1,2]
- ⋅           X[2,2] - 1] ∈ Zeros()
+ ⋯           X[2,2] - 1] ∈ Zeros()
 ```
 
 This will add only three rows to the constraint matrix because the symmetric
@@ -1462,7 +1462,7 @@ julia> Z = [X[1, 1] X[1, 2]; X[1, 2] X[2, 2]]
 
 julia> @constraint(model, LinearAlgebra.Symmetric(Z) >= 0, PSDCone())
 [X[1,1]  X[1,2]
- ⋅       X[2,2]] ∈ PSDCone()
+ ⋯       X[2,2]] ∈ PSDCone()
 ```
 
 Note that the lower triangular entries are ignored even if they are
@@ -1470,7 +1470,7 @@ different so use it with caution:
 ```jldoctest con_psd
 julia> @constraint(model, LinearAlgebra.Symmetric(X) >= 0, PSDCone())
 [X[1,1]  X[1,2]
- ⋅       X[2,2]] ∈ PSDCone()
+ ⋯       X[2,2]] ∈ PSDCone()
 ```
 (Note that no error is thrown, even though `X` is not symmetric.)
 

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -1462,7 +1462,7 @@ julia> Z = [X[1, 1] X[1, 2]; X[1, 2] X[2, 2]]
 
 julia> @constraint(model, LinearAlgebra.Symmetric(Z) >= 0, PSDCone())
 [X[1,1]  X[1,2]
- X[1,2]  X[2,2]] ∈ PSDCone()
+ ⋅       X[2,2]] ∈ PSDCone()
 ```
 
 Note that the lower triangular entries are ignored even if they are
@@ -1470,9 +1470,9 @@ different so use it with caution:
 ```jldoctest con_psd
 julia> @constraint(model, LinearAlgebra.Symmetric(X) >= 0, PSDCone())
 [X[1,1]  X[1,2]
- X[1,2]  X[2,2]] ∈ PSDCone()
+ ⋅       X[2,2]] ∈ PSDCone()
 ```
-(Note the `(2, 1)` element of the constraint is `X[1,2]`, not `X[2,1]`.)
+(Note that no error is thrown, even though `X` is not symmetric.)
 
 ## Complementarity constraints
 

--- a/src/print.jl
+++ b/src/print.jl
@@ -908,9 +908,9 @@ function function_string(
                 line *= " & "
             end
             if A isa LinearAlgebra.Symmetric && i > j
-                line *= "\\cdot"
+                line *= "\\cdots"
             elseif A isa LinearAlgebra.UpperTriangular && i > j
-                line *= "\\cdot"
+                line *= "\\cdots"
             else
                 line *= function_string(mode, A[i, j])
             end
@@ -935,7 +935,9 @@ function function_string(
     constraint::VectorConstraint{F,S,SymmetricMatrixShape},
 ) where {F,S}
     f = reshape_vector(jump_function(constraint), shape(constraint))
-    return function_string(mode, LinearAlgebra.UpperTriangular(f))
+    str = function_string(mode, LinearAlgebra.UpperTriangular(f))
+    return replace(str, "⋅" => "⋯")
+
 end
 
 function function_string(mode::MIME, p::NonlinearExpression)

--- a/src/print.jl
+++ b/src/print.jl
@@ -909,6 +909,8 @@ function function_string(
             end
             if A isa LinearAlgebra.Symmetric && i > j
                 line *= "\\cdot"
+            elseif A isa LinearAlgebra.UpperTriangular && i > j
+                line *= "\\cdot"
             else
                 line *= function_string(mode, A[i, j])
             end
@@ -921,6 +923,19 @@ end
 function function_string(mode, constraint::AbstractConstraint)
     f = reshape_vector(jump_function(constraint), shape(constraint))
     return function_string(mode, f)
+end
+
+# A special case for symmetric matrix constraints. Since the shape is
+# SymmetricMatrixShape, we know that MOI has been passed the upper triangle of
+# the matrix. We can make this clearer to users by printing the
+# LinearAlgebra.UpperTriangular. There shouldn't be any cases in which the
+# constraint function becomes ambiguous.
+function function_string(
+    mode,
+    constraint::VectorConstraint{F,S,SymmetricMatrixShape},
+) where {F,S}
+    f = reshape_vector(jump_function(constraint), shape(constraint))
+    return function_string(mode, LinearAlgebra.UpperTriangular(f))
 end
 
 function function_string(mode::MIME, p::NonlinearExpression)

--- a/src/print.jl
+++ b/src/print.jl
@@ -937,7 +937,6 @@ function function_string(
     f = reshape_vector(jump_function(constraint), shape(constraint))
     str = function_string(mode, LinearAlgebra.UpperTriangular(f))
     return replace(str, "⋅" => "⋯")
-
 end
 
 function function_string(mode::MIME, p::NonlinearExpression)

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -126,7 +126,7 @@ julia> b = [1 2; 2 4];
 
 julia> cref = @constraint(model, Symmetric(a - b) in PSDCone())
 [x - 1  2 x - 2
- ⋅      x - 4] ∈ PSDCone()
+ ⋯      x - 4] ∈ PSDCone()
 
 julia> jump_function(constraint_object(cref))
 3-element Vector{AffExpr}:

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -125,8 +125,8 @@ julia> a = [x 2x; 2x x];
 julia> b = [1 2; 2 4];
 
 julia> cref = @constraint(model, Symmetric(a - b) in PSDCone())
-[x - 1    2 x - 2
- 2 x - 2  x - 4] ∈ PSDCone()
+[x - 1  2 x - 2
+ ⋅      x - 4] ∈ PSDCone()
 
 julia> jump_function(constraint_object(cref))
 3-element Vector{AffExpr}:

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -605,7 +605,7 @@ Subject to
  con : a + b - 10 c + c1 - 2 x $le 1
  a*b $le 2
  [a  b
-  b  x] $inset $(PSDCone())
+  ⋅  x] $inset $(PSDCone())
  [a, b, c] $inset $(MOI.PositiveSemidefiniteConeTriangle(2))
  [a  b
   c  x] $inset $(PSDCone())
@@ -1091,6 +1091,22 @@ function test_invalid_references()
     mime = MIME("text/latex")
     @test sprint(show, mime, x[1]) == "\$ InvalidVariableRef \$"
     @test sprint(show, mime, c[1]) == "InvalidConstraintRef"
+    return
+end
+
+function test_symmetric_constraint()
+    model = Model()
+    @variable(model, x[1:2, 1:2], Symmetric)
+    @test function_string(MIME("text/plain"), x) ==
+          "[x[1,1]  x[1,2]\n x[1,2]  x[2,2]]"
+    @test function_string(MIME("text/latex"), x) ==
+          "\\begin{bmatrix}\nx_{1,1} & x_{1,2}\\\\\n\\cdot & x_{2,2}\\\\\n\\end{bmatrix}"
+    c = @constraint(model, x in PSDCone())
+    o = constraint_object(c)
+    @test function_string(MIME("text/plain"), o) ==
+          "[x[1,1]  x[1,2]\n ⋅       x[2,2]]"
+    @test function_string(MIME("text/latex"), o) ==
+          "\\begin{bmatrix}\nx_{1,1} & x_{1,2}\\\\\n\\cdot & x_{2,2}\\\\\n\\end{bmatrix}"
     return
 end
 

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -605,7 +605,7 @@ Subject to
  con : a + b - 10 c + c1 - 2 x $le 1
  a*b $le 2
  [a  b
-  ⋅  x] $inset $(PSDCone())
+  ⋯  x] $inset $(PSDCone())
  [a, b, c] $inset $(MOI.PositiveSemidefiniteConeTriangle(2))
  [a  b
   c  x] $inset $(PSDCone())
@@ -666,7 +666,7 @@ Names registered in the model: a, a1, b, b1, c, c1, con, fi, soc, u, x, y, z""";
         " & a\\times b \\leq 2\\\\\n" *
         " & \\begin{bmatrix}\n" *
         "a & b\\\\\n" *
-        "\\cdot & x\\\\\n" *
+        "\\cdots & x\\\\\n" *
         "\\end{bmatrix} \\in \\text{$(PSDCone())}\\\\\n" *
         " & [a, b, c] \\in \\text{MathOptInterface.PositiveSemidefiniteConeTriangle(2)}\\\\\n" *
         " & \\begin{bmatrix}\n" *
@@ -1100,13 +1100,13 @@ function test_symmetric_constraint()
     @test function_string(MIME("text/plain"), x) ==
           "[x[1,1]  x[1,2]\n x[1,2]  x[2,2]]"
     @test function_string(MIME("text/latex"), x) ==
-          "\\begin{bmatrix}\nx_{1,1} & x_{1,2}\\\\\n\\cdot & x_{2,2}\\\\\n\\end{bmatrix}"
+          "\\begin{bmatrix}\nx_{1,1} & x_{1,2}\\\\\n\\cdots & x_{2,2}\\\\\n\\end{bmatrix}"
     c = @constraint(model, x in PSDCone())
     o = constraint_object(c)
     @test function_string(MIME("text/plain"), o) ==
-          "[x[1,1]  x[1,2]\n ⋅       x[2,2]]"
+          "[x[1,1]  x[1,2]\n ⋯       x[2,2]]"
     @test function_string(MIME("text/latex"), o) ==
-          "\\begin{bmatrix}\nx_{1,1} & x_{1,2}\\\\\n\\cdot & x_{2,2}\\\\\n\\end{bmatrix}"
+          "\\begin{bmatrix}\nx_{1,1} & x_{1,2}\\\\\n\\cdots & x_{2,2}\\\\\n\\end{bmatrix}"
     return
 end
 


### PR DESCRIPTION
Closes #3764

So there is an argument for this, especially if we merge https://github.com/jump-dev/JuMP.jl/pull/3766, because it will help distinguish when JuMP exploits symmetry.