### PR TITLE
Improve matrix inequality support

### DIFF
--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -117,7 +117,7 @@ julia> model = Model();
 julia> @variable(model, x, start = 2.0);
 
 julia> @constraint(model, c, [2x] in Nonnegatives())
-c : [2 x] ∈ MathOptInterface.Nonnegatives(1)
+c : [2 x] ∈ Nonnegatives()
 
 julia> set_dual_start_value(c, [0.0])
 
@@ -174,7 +174,7 @@ julia> model = Model();
 julia> @variable(model, x, start = 2.0);
 
 julia> @constraint(model, c, [2x] in Nonnegatives())
-c : [2 x] ∈ MathOptInterface.Nonnegatives(1)
+c : [2 x] ∈ Nonnegatives()
 
 julia> set_dual_start_value(c, [0.0])
 
@@ -253,7 +253,7 @@ julia> model = Model();
 julia> @variable(model, x, start = 2.0);
 
 julia> @constraint(model, c, [2x] in Nonnegatives())
-c : [2 x] ∈ MathOptInterface.Nonnegatives(1)
+c : [2 x] ∈ Nonnegatives()
 
 julia> set_start_value(c, [4.0])
 
@@ -333,7 +333,7 @@ julia> model = Model();
 julia> @variable(model, x, start = 2.0);
 
 julia> @constraint(model, c, [2x] in Nonnegatives())
-c : [2 x] ∈ MathOptInterface.Nonnegatives(1)
+c : [2 x] ∈ Nonnegatives()
 
 julia> set_start_value(c, [4.0])
 
@@ -368,7 +368,7 @@ julia> model = Model();
 julia> @variable(model, x);
 
 julia> @constraint(model, c, [2x] in Nonnegatives())
-c : [2 x] ∈ MathOptInterface.Nonnegatives(1)
+c : [2 x] ∈ Nonnegatives()
 
 julia> name(c)
 "c"
@@ -404,7 +404,7 @@ julia> model = Model();
 julia> @variable(model, x);
 
 julia> @constraint(model, c, [2x] in Nonnegatives())
-c : [2 x] ∈ MathOptInterface.Nonnegatives(1)
+c : [2 x] ∈ Nonnegatives()
 
 julia> set_name(c, "my_constraint")
 
@@ -412,7 +412,7 @@ julia> name(c)
 "my_constraint"
 
 julia> c
-my_constraint : [2 x] ∈ MathOptInterface.Nonnegatives(1)
+my_constraint : [2 x] ∈ Nonnegatives()
 ```
 """
 function set_name(

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -739,7 +739,7 @@ function build_constraint(error_fn::Function, ::AbstractMatrix, ::Zeros)
         "Unsupported matrix in vector-valued set. Did you mean to use the " *
         "broadcasting syntax `.==` for element-wise equality? Alternatively, " *
         "this syntax is supported in the special case that the matrices are " *
-        "`LinearAlgebra.Symmetric` or `LinearAlgebra.Hermitian`.",
+        "`Array`, `LinearAlgebra.Symmetric`, or `LinearAlgebra.Hermitian`.",
     )
 end
 
@@ -838,4 +838,34 @@ function build_constraint(
     return error_fn(
         "The syntax `x <= y, $set` not supported. Use `y >= x, $set` instead.",
     )
+end
+
+function build_constraint(
+    error_fn::Function,
+    f::Union{Array,LinearAlgebra.Symmetric},
+    set::Nonnegatives,
+)
+    s = shape(f)
+    x = vectorize(f, s)
+    return VectorConstraint(x, moi_set(set, length(x)), s)
+end
+
+function build_constraint(
+    error_fn::Function,
+    f::Union{Array,LinearAlgebra.Symmetric},
+    set::Nonpositives,
+)
+    s = shape(f)
+    x = vectorize(f, s)
+    return VectorConstraint(x, moi_set(set, length(x)), s)
+end
+
+function build_constraint(
+    error_fn::Function,
+    f::Union{Array,LinearAlgebra.Symmetric},
+    set::Zeros,
+)
+    s = shape(f)
+    x = vectorize(f, s)
+    return VectorConstraint(x, moi_set(set, length(x)), s)
 end

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -194,5 +194,6 @@ struct ArrayShape{N} <: AbstractShape
 end
 
 reshape_vector(x, shape::ArrayShape) = reshape(x, shape.dims)
+reshape_vector(::Nothing, shape::ArrayShape) = nothing
 
 vectorize(x, ::ArrayShape) = vec(x)

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -2304,10 +2304,10 @@ function _imag(s::String)
 end
 
 _real(v::ScalarVariable) = _mapinfo(real, v)
-_real(scalar::AbstractJuMPScalar) = real(scalar)
+_real(scalar) = real(scalar)
 
 _imag(v::ScalarVariable) = _mapinfo(imag, v)
-_imag(scalar::AbstractJuMPScalar) = imag(scalar)
+_imag(scalar) = imag(scalar)
 
 _conj(v::ScalarVariable) = _mapinfo(conj, v)
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -3000,7 +3000,7 @@ julia> normalized_coefficient(con, x)
 5.0
 
 julia> @constraint(model, con_vec, [x, 2x + 1, 3] >= 0)
-con_vec : [x, 2 x + 1, 3] ∈ MathOptInterface.Nonnegatives(3)
+con_vec : [x, 2 x + 1, 3] ∈ Nonnegatives()
 
 julia> normalized_coefficient(con_vec, x)
 2-element Vector{Tuple{Int64, Float64}}:
@@ -3052,7 +3052,7 @@ julia> normalized_coefficient(con, x[1], x[2])
 3.0
 
 julia> @constraint(model, con_vec, x.^2 <= [1, 2])
-con_vec : [x[1]² - 1, x[2]² - 2] ∈ MathOptInterface.Nonpositives(2)
+con_vec : [x[1]² - 1, x[2]² - 2] ∈ Nonpositives()
 
 julia> normalized_coefficient(con_vec, x[1], x[1])
 1-element Vector{Tuple{Int64, Float64}}:

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -1635,6 +1635,12 @@ function test_hermitian_in_zeros()
     model = Model()
     @variable(model, H[1:2, 1:2] in HermitianPSDCone())
     c = @constraint(model, H == LinearAlgebra.I)
+    @test c.shape == HermitianMatrixShape(2; needs_adjoint_dual = true)
+    set_dual_start_value(c, [1 2+1im; 2-1im 3])
+    @test dual_start_value(c) ==
+          LinearAlgebra.Hermitian([1.0 2.0+1.0im; 2.0-1.0im 3.0])
+    @test MOI.get(backend(model), MOI.ConstraintDualStart(), index(c)) ==
+          [1.0, 4.0, 3.0, 2.0]
     con = constraint_object(c)
     @test isequal_canonical(con.func[1], real(H[1, 1]) - 1)
     @test isequal_canonical(con.func[2], real(H[1, 2]))
@@ -1650,6 +1656,11 @@ function test_symmetric_in_zeros()
     model = Model()
     @variable(model, H[1:2, 1:2], Symmetric)
     c = @constraint(model, H == LinearAlgebra.I)
+    @test c.shape == SymmetricMatrixShape(2; needs_adjoint_dual = true)
+    set_dual_start_value(c, [1 2; 2 3])
+    @test dual_start_value(c) == LinearAlgebra.Symmetric([1.0 2.0; 2.0 3.0])
+    @test MOI.get(backend(model), MOI.ConstraintDualStart(), index(c)) ==
+          [1.0, 4.0, 3.0]
     con = constraint_object(c)
     @test isequal_canonical(con.func[1], H[1, 1] - 1)
     @test isequal_canonical(con.func[2], H[1, 2] - 0)

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -1910,7 +1910,7 @@ function test_symmetric_matrix_inequality()
         o = constraint_object(c)
         @test isequal_canonical(o.func, g)
         @test o.set == moi_set(set, 3)
-        @test o.shape == SymmetricMatrixShape(2)
+        @test o.shape == SymmetricMatrixShape(2; needs_adjoint_dual = true)
         @test reshape_set(o.set, o.shape) == set
         primal = value(start_value, c)
         @test primal isa LinearAlgebra.Symmetric
@@ -1963,7 +1963,7 @@ function test_symmetric_equality()
     o = constraint_object(c)
     @test isequal_canonical(o.func, g)
     @test o.set == moi_set(Zeros(), 3)
-    @test o.shape == SymmetricMatrixShape(2)
+    @test o.shape == SymmetricMatrixShape(2; needs_adjoint_dual = true)
     @test reshape_set(o.set, o.shape) == Zeros()
     primal = value(start_value, c)
     @test primal isa LinearAlgebra.Symmetric

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -1955,8 +1955,8 @@ end
 
 function test_matrix_in_vector_set()
     model = Model()
-    @variable(model, X[1:2, 1:2])
-    A = [1 2; 3 4]
+    @variable(model, X[2:3, 2:3])
+    A = Containers.DenseAxisArray([1 2; 3 4], 2:3, 2:3)
     @test_throws_runtime(
         ErrorException(
             "In `@constraint(model, X >= A)`: " *
@@ -1983,7 +1983,7 @@ function test_matrix_in_vector_set()
             "Unsupported matrix in vector-valued set. Did you mean to use the " *
             "broadcasting syntax `.==` for element-wise equality? Alternatively, " *
             "this syntax is supported in the special case that the matrices are " *
-            "`LinearAlgebra.Symmetric` or `LinearAlgebra.Hermitian`.",
+            "`Array`, `LinearAlgebra.Symmetric`, or `LinearAlgebra.Hermitian`.",
         ),
         @constraint(model, X == A),
     )


### PR DESCRIPTION
- [x] Requires #3797 to be merged first

Follow-up to #3766.

In our discussion of https://github.com/jump-dev/JuMP.jl/pull/3766, we never really talked about the fact that `==` is not ambiguous.