### PR TITLE
Fix querying dual of symmetric equality constraints

### DIFF
--- a/src/variables.jl
+++ b/src/variables.jl
@@ -2304,10 +2304,10 @@ function _imag(s::String)
 end
 
 _real(v::ScalarVariable) = _mapinfo(real, v)
-_real(scalar::AbstractJuMPScalar) = real(scalar)
+_real(scalar) = real(scalar)
 
 _imag(v::ScalarVariable) = _mapinfo(imag, v)
-_imag(scalar::AbstractJuMPScalar) = imag(scalar)
+_imag(scalar) = imag(scalar)
 
 _conj(v::ScalarVariable) = _mapinfo(conj, v)
 

--- a/test/test_constraint.jl
+++ b/test/test_constraint.jl
@@ -1635,6 +1635,12 @@ function test_hermitian_in_zeros()
     model = Model()
     @variable(model, H[1:2, 1:2] in HermitianPSDCone())
     c = @constraint(model, H == LinearAlgebra.I)
+    @test c.shape == HermitianMatrixShape(2; needs_adjoint_dual = true)
+    set_dual_start_value(c, [1 2+1im; 2-1im 3])
+    @test dual_start_value(c) ==
+          LinearAlgebra.Hermitian([1.0 2.0+1.0im; 2.0-1.0im 3.0])
+    @test MOI.get(backend(model), MOI.ConstraintDualStart(), index(c)) ==
+          [1.0, 4.0, 3.0, 2.0]
     con = constraint_object(c)
     @test isequal_canonical(con.func[1], real(H[1, 1]) - 1)
     @test isequal_canonical(con.func[2], real(H[1, 2]))
@@ -1650,6 +1656,11 @@ function test_symmetric_in_zeros()
     model = Model()
     @variable(model, H[1:2, 1:2], Symmetric)
     c = @constraint(model, H == LinearAlgebra.I)
+    @test c.shape == SymmetricMatrixShape(2; needs_adjoint_dual = true)
+    set_dual_start_value(c, [1 2; 2 3])
+    @test dual_start_value(c) == LinearAlgebra.Symmetric([1.0 2.0; 2.0 3.0])
+    @test MOI.get(backend(model), MOI.ConstraintDualStart(), index(c)) ==
+          [1.0, 4.0, 3.0]
     con = constraint_object(c)
     @test isequal_canonical(con.func[1], H[1, 1] - 1)
     @test isequal_canonical(con.func[2], H[1, 2] - 0)


### PR DESCRIPTION
Closes #3796

I need to think about whether there is a better option. I don't think we should just fix the default `reshape_vector` because we don't need to modify anything for the primal? Just the dual?