### PR TITLE
Allow changing coefficient type in read_from_file

### DIFF
--- a/src/file_formats.jl
+++ b/src/file_formats.jl
@@ -88,6 +88,14 @@ function Base.write(
     return
 end
 
+_value_type(model::MOI.Utilities.AbstractModelLike{T}) where {T} = T
+
+# This fallback may not get the correct value type. However, since
+# all models defined in `MOI.FileFormats` are created with
+# `MOI.Utilities.@model` except `NL` which only supports `Float64`,
+# this does the job for now.
+_value_type(model::MOI.ModelLike) = Float64
+
 """
     read_from_file(
         filename::String;
@@ -105,12 +113,11 @@ Other `kwargs` are passed to the `Model` constructor of the chosen format.
 function read_from_file(
     filename::String;
     format::MOI.FileFormats.FileFormat = MOI.FileFormats.FORMAT_AUTOMATIC,
-    coefficient_type::Type = Float64,
     kwargs...,
 )
-    src = MOI.FileFormats.Model(; format, filename, coefficient_type, kwargs...)
+    src = MOI.FileFormats.Model(; format, filename, kwargs...)
     MOI.read_from_file(src, filename)
-    model = GenericModel{coefficient_type}()
+    model = GenericModel{_value_type(model)}()
     MOI.copy_to(model, src)
     return model
 end

--- a/src/file_formats.jl
+++ b/src/file_formats.jl
@@ -91,9 +91,9 @@ end
 _value_type(model::MOI.Utilities.AbstractModelLike{T}) where {T} = T
 
 # This fallback may not get the correct value type. However, since
-# all models defined in `MOI.FileFormats` are created with
-# `MOI.Utilities.@model` except `NL` which only supports `Float64`,
-# this does the job for now.
+# all models defined in `MOI.FileFormats` return a
+# `MOI.Utilities.GenericModel` except `NL` and `MOF` which only supports
+# `Float64`, this does the job for now.
 _value_type(model::MOI.ModelLike) = Float64
 
 """

--- a/src/file_formats.jl
+++ b/src/file_formats.jl
@@ -88,13 +88,13 @@ function Base.write(
     return
 end
 
-_value_type(model::MOI.Utilities.AbstractModelLike{T}) where {T} = T
+_value_type(::MOI.Utilities.AbstractModelLike{T}) where {T} = T
 
 # This fallback may not get the correct value type. However, since
 # all models defined in `MOI.FileFormats` return a
 # `MOI.Utilities.GenericModel` except `NL` and `MOF` which only supports
 # `Float64`, this does the job for now.
-_value_type(model::MOI.ModelLike) = Float64
+_value_type(::MOI.ModelLike) = Float64
 
 """
     read_from_file(
@@ -117,7 +117,7 @@ function read_from_file(
 )
     src = MOI.FileFormats.Model(; format, filename, kwargs...)
     MOI.read_from_file(src, filename)
-    model = GenericModel{_value_type(model)}()
+    model = GenericModel{_value_type(src)}()
     MOI.copy_to(model, src)
     return model
 end

--- a/src/file_formats.jl
+++ b/src/file_formats.jl
@@ -105,14 +105,12 @@ Other `kwargs` are passed to the `Model` constructor of the chosen format.
 function read_from_file(
     filename::String;
     format::MOI.FileFormats.FileFormat = MOI.FileFormats.FORMAT_AUTOMATIC,
+    coefficient_type::Type = Float64,
     kwargs...,
 )
-    src =
-        MOI.FileFormats.Model(; format = format, filename = filename, kwargs...)
+    src = MOI.FileFormats.Model(; format, filename, coefficient_type, kwargs...)
     MOI.read_from_file(src, filename)
-    # TODO(odow): what number type to choose? Are there any non-Float64 file
-    # formats?
-    model = GenericModel{Float64}()
+    model = GenericModel{coefficient_type}()
     MOI.copy_to(model, src)
     return model
 end

--- a/test/test_file_formats.jl
+++ b/test/test_file_formats.jl
@@ -6,7 +6,9 @@
 module TestFileFormats
 
 using JuMP
-using LinearAlgebra, Test
+using Test
+
+import LinearAlgebra
 
 function test_mof_file()
     model = Model()
@@ -141,7 +143,7 @@ end
 function test_sdpa_bigfloat()
     model = Model()
     @variable(model, x)
-    @constraint(model, Symmetric([1 x; x 1]) in PSDCone())
+    @constraint(model, LinearAlgebra.Symmetric([1 x; x 1]) in PSDCone())
     @objective(model, Max, 2x)
     write_to_file(model, "model.dat-s")
     model_2 = read_from_file("model.dat-s"; number_type = BigFloat)

--- a/test/test_file_formats.jl
+++ b/test/test_file_formats.jl
@@ -6,7 +6,7 @@
 module TestFileFormats
 
 using JuMP
-using Test
+using LinearAlgebra, Test
 
 function test_mof_file()
     model = Model()
@@ -135,6 +135,18 @@ function test_nl_round_trip()
         @test c.expression == constraints[c.set]
     end
     rm("model.nl")
+    return
+end
+
+function test_sdpa_bigfloat()
+    model = Model()
+    @variable(model, x)
+    @constraint(model, Symmetric([1 x; x 1]) in PSDCone())
+    @objective(model, Max, 2x)
+    write_to_file(model, "model.dat-s")
+    model_2 = read_from_file("model.dat-s"; number_type = BigFloat)
+    @test model_2 isa GenericModel{BigFloat}
+    rm("model.dat-s")
     return
 end
 


### PR DESCRIPTION
Before this PR
```julia
julia> file = joinpath(dirname(dirname(pathof(MOI))), "test", "FileFormats", "SDPA", "models", "example_A.dat-s")
"/home/blegat/.julia/packages/MathOptInterface/jqDoD/test/FileFormats/SDPA/models/example_A.dat-s"

julia> model = read_from_file(file)
A JuMP Model
Minimization problem with:
Variables: 2
Objective function type: AffExpr
`Vector{AffExpr}`-in-`MathOptInterface.PositiveSemidefiniteConeTriangle`: 2 constraints
Model mode: AUTOMATIC
CachingOptimizer state: NO_OPTIMIZER
Solver name: No optimizer attached.

julia> set_optimizer(model, Clarabel.Optimizer{BigFloat})

julia> optimize!(model)
ERROR: MathOptInterface.UnsupportedAttribute{MathOptInterface.ObjectiveFunction{MathOptInterface.ScalarAffineFunction{Float64}}}: Attribute MathOptInterface.ObjectiveFunction{MathOptInterface.ScalarAffineFunction{Float64}}() is not supported by the model.
Stacktrace:
  [1] bridge_type(b::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{…}}, F::Type{MathOptInterface.ScalarAffineFunction{…}})
    @ MathOptInterface.Bridges ~/.julia/packages/MathOptInterface/jqDoD/src/Bridges/lazy_bridge_optimizer.jl:546
  [2] concrete_bridge_type(b::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.CachingOptimizer{…}}, F::Type{MathOptInterface.ScalarAffineFunction{…}})
    @ MathOptInterface.Bridges.Objective ~/.julia/packages/MathOptInterface/jqDoD/src/Bridges/Objective/bridge.jl:68
  [3] set(b::MathOptInterface.Bridges.LazyBridgeOptimizer{…}, attr::MathOptInterface.ObjectiveFunction{…}, func::MathOptInterface.ScalarAffineFunction{…})
    @ MathOptInterface.Bridges ~/.julia/packages/MathOptInterface/jqDoD/src/Bridges/bridge_optimizer.jl:1174
  [4] _pass_attribute(dest::MathOptInterface.Bridges.LazyBridgeOptimizer{…}, src::MathOptInterface.Utilities.UniversalFallback{…}, index_map::MathOptInterface.Utilities.IndexMap, attr::MathOptInterface.ObjectiveFunction{…})
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/jqDoD/src/Utilities/copy.jl:51
  [5] pass_attributes(dest::MathOptInterface.Bridges.LazyBridgeOptimizer{…}, src::MathOptInterface.Utilities.UniversalFallback{…}, index_map::MathOptInterface.Utilities.IndexMap)
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/jqDoD/src/Utilities/copy.jl:38
  [6] default_copy_to(dest::MathOptInterface.Bridges.LazyBridgeOptimizer{…}, src::MathOptInterface.Utilities.UniversalFallback{…})
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/jqDoD/src/Utilities/copy.jl:391
  [7] copy_to
    @ ~/.julia/packages/MathOptInterface/jqDoD/src/Bridges/bridge_optimizer.jl:442 [inlined]
  [8] optimize!
    @ ~/.julia/packages/MathOptInterface/jqDoD/src/MathOptInterface.jl:121 [inlined]
  [9] optimize!(m::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.Bridges.LazyBridgeOptimizer{…}, MathOptInterface.Utilities.UniversalFallback{…}})
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/jqDoD/src/Utilities/cachingoptimizer.jl:321
 [10] optimize!(model::Model; ignore_optimize_hook::Bool, _differentiation_backend::MathOptInterface.Nonlinear.SparseReverseMode, kwargs::@Kwargs{})
    @ JuMP ~/.julia/packages/JuMP/7rBNn/src/optimizer_interface.jl:595
 [11] optimize!(model::Model)
    @ JuMP ~/.julia/packages/JuMP/7rBNn/src/optimizer_interface.jl:546
 [12] top-level scope
    @ REPL[34]:1
Some type information was truncated. Use `show(err)` to see complete types.

julia> add_bridge(model, MOI.Bridges.Constraint.NumberConversionBridge, coefficient_type=BigFloat)

julia> optimize!(model)
ERROR: MethodError: no method matching promote_operation(::typeof(-), ::Type{Float64}, ::Type{MathOptInterface.VectorQuadraticFunction{BigFloat}})

Closest candidates are:
  promote_operation(::typeof(-), ::Type{T}, ::Type{MathOptInterface.VectorNonlinearFunction}) where T<:Number
   @ MathOptInterface ~/.julia/packages/MathOptInterface/jqDoD/src/Utilities/promote_operation.jl:177
  promote_operation(::typeof(-), ::Type{T}, ::Type{MathOptInterface.VectorOfVariables}) where T<:Number
   @ MathOptInterface ~/.julia/packages/MathOptInterface/jqDoD/src/Utilities/promote_operation.jl:169
  promote_operation(::typeof(-), ::Type{T}, ::Type{F}) where {T, F<:Union{AbstractVector{T}, MathOptInterface.ScalarAffineFunction{T}, MathOptInterface.ScalarNonlinearFunction, MathOptInterface.ScalarQuadraticFunction{T}, MathOptInterface.VectorAffineFunction{T}, MathOptInterface.VectorQuadraticFunction{T}, T}}
   @ MathOptInterface ~/.julia/packages/MathOptInterface/jqDoD/src/Utilities/promote_operation.jl:142
  ...

Stacktrace:
   [1] concrete_bridge_type(::Type{MathOptInterface.Bridges.Constraint.NonnegToNonposBridge{…}}, G::Type{MathOptInterface.VectorQuadraticFunction{…}}, ::Type{MathOptInterface.Nonnegatives})
     @ MathOptInterface.Bridges.Constraint ~/.julia/packages/MathOptInterface/jqDoD/src/Bridges/Constraint/bridges/flip_sign.jl:238
   [2] node(b::MathOptInterface.Bridges.LazyBridgeOptimizer{…}, F::Type{…}, S::Type{…})
     @ MathOptInterface.Bridges ~/.julia/packages/MathOptInterface/jqDoD/src/Bridges/lazy_bridge_optimizer.jl:327
```
After this PR:
```julia
julia> model = read_from_file(file, coefficient_type = BigFloat)
A JuMP Model
Minimization problem with:
Variables: 2
Objective function type: GenericAffExpr{BigFloat, GenericVariableRef{BigFloat}}
`Vector{GenericAffExpr{BigFloat, GenericVariableRef{BigFloat}}}`-in-`MathOptInterface.PositiveSemidefiniteConeTriangle`: 2 constraints
Model mode: AUTOMATIC
CachingOptimizer state: NO_OPTIMIZER
Solver name: No optimizer attached.

julia> set_optimizer(model, Clarabel.Optimizer{BigFloat})

julia> optimize!(model)
-------------------------------------------------------------
           Clarabel.jl v0.9.0  -  Clever Acronym              
                   (c) Paul Goulart                          
                University of Oxford, 2022                   
-------------------------------------------------------------

problem:
  variables     = 2
  constraints   = 6
  nnz(P)        = 0
  nnz(A)        = 6
  cones (total) = 2
    : PSDTriangle = 2,  numel = (3,3)

settings:
  linear algebra: direct / qdldl, precision: BigFloat (256 bit)
  max iter = 200, time limit = Inf,  max step = 0.990
  tol_feas = 1.0e-08, tol_gap_abs = 1.0e-08, tol_gap_rel = 1.0e-08,
  static reg : on, ϵ1 = 1.0e-08, ϵ2 = 4.9e-32
  dynamic reg: on, ϵ = 1.0e-13, δ = 2.0e-07
  iter refine: on, reltol = 1.0e-13, abstol = 1.0e-12, 
               max iter = 10, stop ratio = 5.0
  equilibrate: on, min_scale = 1.0e-04, max_scale = 1.0e+04
               max iter = 10

iter    pcost        dcost       gap       pres      dres      k/t        μ       step      
---------------------------------------------------------------------------------------------
  0   2.3612e+01   2.3612e+01  0.00e+00  4.12e-01  1.27e-17  1.00e+00  5.48e+00   ------   
  1   2.5231e+01   2.5542e+01  1.23e-02  1.86e-01  4.82e-18  6.99e-01  2.02e+00  6.89e-01  
  2   2.8848e+01   2.9441e+01  2.05e-02  7.56e-02  2.56e-17  7.98e-01  9.21e-01  7.76e-01  
  3   2.9576e+01   2.9650e+01  2.52e-03  1.01e-02  3.62e-18  1.01e-01  1.20e-01  8.73e-01  
  4   2.9873e+01   2.9928e+01  1.84e-03  5.53e-03  1.14e-18  6.98e-02  6.72e-02  6.27e-01  
  5   2.9949e+01   2.9960e+01  3.56e-04  1.08e-03  9.18e-19  1.35e-02  1.32e-02  8.13e-01  
  6   2.9985e+01   2.9991e+01  2.09e-04  5.22e-04  1.58e-18  7.68e-03  6.33e-03  6.96e-01  
  7   2.9994e+01   2.9995e+01  4.97e-05  1.25e-04  8.36e-19  1.83e-03  1.54e-03  7.78e-01  
  8   2.9999e+01   2.9999e+01  1.88e-05  4.27e-05  4.24e-19  6.77e-04  5.25e-04  7.92e-01  
  9   2.9999e+01   3.0000e+01  4.65e-06  1.07e-05  1.06e-19  1.68e-04  1.33e-04  7.78e-01  
 10   3.0000e+01   3.0000e+01  1.12e-06  2.40e-06  2.44e-20  4.01e-05  2.97e-05  8.78e-01  
 11   3.0000e+01   3.0000e+01  2.47e-07  5.36e-07  3.43e-21  8.84e-06  6.74e-06  8.00e-01  
 12   3.0000e+01   3.0000e+01  4.12e-08  8.51e-08  9.09e-21  1.46e-06  1.07e-06  9.25e-01  
 13   3.0000e+01   3.0000e+01  7.59e-09  1.60e-08  1.02e-21  2.71e-07  2.03e-07  8.25e-01  
 14   3.0000e+01   3.0000e+01  1.12e-09  2.31e-09  1.91e-19  3.99e-08  2.91e-08  9.38e-01  
---------------------------------------------------------------------------------------------
Terminated with status = solved
solve time = 35.2ms

julia> value.(all_variables(model))
2-element Vector{BigFloat}:
 0.9999999974529094769438466978694298260572236430943294845572438659429688710785798
 0.9999999978004611800133183212387879815915688604520797152607053647751640272731174
```

I'm a bit hesitant between calling this keyword argument `coefficient_type` (like `JuMP.add_bridge`) or `value_type`. For `add_bridge`, IIRC, we chose `coefficient_type` because it didn't really have to match with the model value type. In https://github.com/jump-dev/MathOptInterface.jl/pull/2532, `value_type` as a keyword could be weird because `value` is out of scope there and we could say that in this PR we use `coefficient_type` to be consistent with `MOI.FileFormats.Model`.

Requires

- [x] https://github.com/jump-dev/MathOptInterface.jl/pull/2532