### PR TITLE
Convert AbstractString to String in set_attribute

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1'
+          version: '1.10'
       - name: Install dependencies
         shell: julia --color=yes --project=docs/ {0}
         run: |

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -1251,6 +1251,10 @@ function get_attribute(
     return get_attribute(model, String(name))
 end
 
+_string_if_abstract_string(value) = value
+_string_if_abstract_string(value::String) = value
+_string_if_abstract_string(value::AbstractString) = String(value)
+
 """
     set_attribute(model::GenericModel, attr::MOI.AbstractModelAttribute, value)
     set_attribute(x::GenericVariableRef, attr::MOI.AbstractVariableAttribute, value)
@@ -1285,7 +1289,7 @@ function set_attribute(
     attr::MOI.AbstractModelAttribute,
     value,
 )
-    MOI.set(model, attr, value)
+    MOI.set(model, attr, _string_if_abstract_string(value))
     return
 end
 
@@ -1294,7 +1298,7 @@ function set_attribute(
     attr::MOI.AbstractVariableAttribute,
     value,
 )
-    MOI.set(owner_model(x), attr, x, value)
+    MOI.set(owner_model(x), attr, x, _string_if_abstract_string(value))
     return
 end
 
@@ -1303,7 +1307,7 @@ function set_attribute(
     attr::MOI.AbstractConstraintAttribute,
     value,
 )
-    MOI.set(owner_model(cr), attr, cr, value)
+    MOI.set(owner_model(cr), attr, cr, _string_if_abstract_string(value))
     return
 end
 
@@ -1344,7 +1348,7 @@ function set_attribute(
     attr::MOI.AbstractOptimizerAttribute,
     value,
 )
-    MOI.set(model, attr, value)
+    MOI.set(model, attr, _string_if_abstract_string(value))
     return
 end
 

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -1254,8 +1254,8 @@ end
 # Some MOI attributes have a strict value type, like ::String or ::Float64, but
 # users may pass other generic subtypes, like SubString instead of String.
 # Rather than throw obtuse errors, we can catch and fix some common cases. We
-# shouldn't fix every case (e.g., AbstractString -> String) because users might
-# intentionally want the other subtype.
+# shouldn't fix every case (for example, AbstractString -> String) because
+# users might intentionally want the other subtype.
 #
 # The default case is to do nothing:
 _to_concrete_value_type_if_needed(::MOI.AnyAttribute, value) = value

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -1332,7 +1332,9 @@ function test_set_abstract_string()
     @test ret isa String && ret == "foo"
     set_attribute(model, abstract_string, abstract_string)
     ret = get_attribute(model, abstract_string)
-    @test ret isa String && ret == "foo"
+    # This `ret` is NOT a `::String` because we don't know the value type of the
+    # attribute.
+    @test ret isa typeof(abstract_string) && ret == "foo"
     return
 end
 

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -1313,4 +1313,27 @@ function test_is_solved_and_feasible()
     return
 end
 
+function test_set_abstract_string()
+    abstract_string = split("foo.bar", ".")[1]
+    model = Model() do
+        return MOI.Utilities.MockOptimizer(
+            MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+        )
+    end
+    set_attribute(model, MOI.Name(), abstract_string)
+    @test get_attribute(model, MOI.Name()) == "foo"
+    @variable(model, x)
+    set_attribute(x, MOI.VariableName(), abstract_string)
+    ret = get_attribute(x, MOI.VariableName())
+    @test ret isa String && ret == "foo"
+    c = @constraint(model, 2x >= 1)
+    set_attribute(c, MOI.ConstraintName(), abstract_string)
+    ret = get_attribute(c, MOI.ConstraintName())
+    @test ret isa String && ret == "foo"
+    set_attribute(model, abstract_string, abstract_string)
+    ret = get_attribute(model, abstract_string)
+    @test ret isa String && ret == "foo"
+    return
+end
+
 end  # module TestModels


### PR DESCRIPTION
Closes #3839

<s>I want to do an extension test. Anyone expecting some subtype of `AbstractString` will now get a `String`. But it seems that this is a bug fix that addresses the most common use-cases...</s> This is now safe.

https://github.com/jump-dev/JuMP.jl/actions/runs/11223971621