### PR TITLE
Fix printing of Interval in LaTeX

### DIFF
--- a/src/print.jl
+++ b/src/print.jl
@@ -80,7 +80,7 @@ end
 
 # Helper function that rounds carefully for the purposes of printing Reals
 # for example, 5.3  =>  5.3, and 1.0  =>  1
-function _string_round(mode, x::Union{Float32,Float64})
+function _string_round(mode::MIME, x::Union{Float32,Float64})
     if isinteger(x) && typemin(Int64) <= x <= typemax(Int64)
         return string(round(Int64, x))
     end
@@ -1054,7 +1054,7 @@ function in_set_string(mode::MIME, set::MOI.EqualTo)
     return string(_math_symbol(mode, :eq), " ", _string_round(mode, set.value))
 end
 
-function in_set_string(::MIME"text/latex", set::MOI.Interval)
+function in_set_string(mode::MIME"text/latex", set::MOI.Interval)
     lower = _string_round(mode, set.lower)
     upper = _string_round(mode, set.upper)
     return string("\\in [", lower, ", ", upper, "]")

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -964,8 +964,10 @@ end
 
 function test_print_text_latex_interval_set()
     @test in_set_string(MIME("text/latex"), MOI.Interval(1, 2)) == "\\in [1, 2]"
-    @test in_set_string(MIME("text/latex"), MOI.Interval(1.0, 2.0)) == "\\in [1, 2]"
-    @test in_set_string(MIME("text/latex"), MOI.Interval(1.5, 2.5)) == "\\in [1.5, 2.5]"
+    @test in_set_string(MIME("text/latex"), MOI.Interval(1.0, 2.0)) ==
+          "\\in [1, 2]"
+    @test in_set_string(MIME("text/latex"), MOI.Interval(1.5, 2.5)) ==
+          "\\in [1.5, 2.5]"
     return
 end
 

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -964,6 +964,8 @@ end
 
 function test_print_text_latex_interval_set()
     @test in_set_string(MIME("text/latex"), MOI.Interval(1, 2)) == "\\in [1, 2]"
+    @test in_set_string(MIME("text/latex"), MOI.Interval(1.0, 2.0)) == "\\in [1, 2]"
+    @test in_set_string(MIME("text/latex"), MOI.Interval(1.5, 2.5)) == "\\in [1.5, 2.5]"
     return
 end
 


### PR DESCRIPTION
Reproduce it with:
```julia
julia> model = Model();

julia> @variable(model, x);

julia> @constraint(model, x in MOI.Interval(0.5, 1.5))
x ∈ [0.5, 1.5]

julia> latex_formulation(model)
$$ \begin{aligned}
\text{feasibility}\\
Error showing value of type JuMP._LatexModel{Model}:
ERROR: MethodError: no method matching _escape_if_scientific(::typeof(mode), ::String)
The function `_escape_if_scientific` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  _escape_if_scientific(::MIME{Symbol("text/latex")}, ::String)
   @ JuMP ~/.julia/dev/JuMP/src/print.jl:73
  _escape_if_scientific(::MIME, ::String)
   @ JuMP ~/.julia/dev/JuMP/src/print.jl:71

Stacktrace:
  [1] _string_round
    @ ~/.julia/dev/JuMP/src/print.jl:87 [inlined]
  [2] in_set_string(::MIME{Symbol("text/latex")}, set::MathOptInterface.Interval{Float64})
    @ JuMP ~/.julia/dev/JuMP/src/print.jl:1058
```
After the PR:
```julia
julia> latex_formulation(model)
$$ \begin{aligned}
\text{feasibility}\\
\text{Subject to} \quad & x \in [0.5, 1.5]\\
\end{aligned} $$
```

Found by @johnaoga in https://github.com/dionysos-dev/Dionysos.jl/pull/383