### PR TITLE
[Containers] remove IndexAnyCartesian

### DIFF
--- a/src/Containers/Containers.jl
+++ b/src/Containers/Containers.jl
@@ -19,10 +19,6 @@ module Containers
 
 import OrderedCollections
 
-# Arbitrary typed indices. Linear indexing not supported.
-struct IndexAnyCartesian <: Base.IndexStyle end
-Base.IndexStyle(::IndexAnyCartesian, ::IndexAnyCartesian) = IndexAnyCartesian()
-
 export DenseAxisArray, SparseAxisArray
 
 include("DenseAxisArray.jl")

--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -448,10 +448,6 @@ function Base.setindex!(
     return
 end
 
-function Base.IndexStyle(::Type{DenseAxisArray{T,N,Ax}}) where {T,N,Ax}
-    return IndexAnyCartesian()
-end
-
 function Base.setindex!(
     A::DenseAxisArray{T,N},
     value::DenseAxisArray{T,N},


### PR DESCRIPTION
This doesn't appear to actually be used anywhere. I think it's just stale legacy from earlier versions.

The `IndexStyle` method was never called, because it requires a free type parameter or `::Type{<:DenseAxisArr`