### PR TITLE
Fix broadcasting over NonlinearExpr objects

### DIFF
--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -104,6 +104,8 @@ struct GenericNonlinearExpr{V<:AbstractVariableRef} <: AbstractJuMPScalar
     end
 end
 
+Base.broadcastable(f::GenericNonlinearExpr) = Ref(f)
+
 variable_ref_type(::Type{GenericNonlinearExpr}, ::Any) = nothing
 
 function variable_ref_type(::Type{GenericNonlinearExpr}, x::AbstractJuMPScalar)

--- a/test/test_nlp_expr.jl
+++ b/test/test_nlp_expr.jl
@@ -1134,4 +1134,14 @@ function test_promote_type()
     return
 end
 
+function test_broadcastable()
+    model = Model()
+    @variable(model, x, start = 2)
+    f = sin(x)^2
+    @test Base.broadcastable(f) isa Base.RefValue{NonlinearExpr}
+    @test value(start_value, f) ≈ sin(2)^2
+    @test value.(start_value, f) ≈ sin(2)^2
+    return
+end
+
 end  # module


### PR DESCRIPTION
This now has the same behaviour as AffExpr and QuadExpr