### PR TITLE
Fix bug which mutates user expressions in constraint macro

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -253,6 +253,16 @@ function _rewrite_expression(expr::Expr)
     new_expr = MacroTools.postwalk(_rewrite_to_jump_logic, expr)
     new_aff, parse_aff = _MA.rewrite(new_expr; move_factors_into_sums = false)
     ret = gensym()
+    has_copy_if_mutable = Ref(false)
+    MacroTools.postwalk(parse_aff) do x
+        if x === MutableArithmetics.copy_if_mutable
+            has_copy_if_mutable[] = true
+        end
+        return x
+    end
+    if !has_copy_if_mutable[]
+        new_aff = :($_MA.copy_if_mutable($new_aff))
+    end
     code = quote
         $parse_aff
         $ret = $flatten!($new_aff)

--- a/src/macros/@constraint.jl
+++ b/src/macros/@constraint.jl
@@ -475,7 +475,9 @@ function parse_constraint_head(
             "`$ub >= ... >= $lb`.",
         )
     end
-    new_aff, parse_aff = _rewrite_expression(aff)
+    # Add +0 so that it creates a copy that we can mutate in future callers.
+    # We should fix this in MutableArithmetics.
+    new_aff, parse_aff = _rewrite_expression(:($aff + 0))
     new_lb, parse_lb = _rewrite_expression(lb)
     new_ub, parse_ub = _rewrite_expression(ub)
     parse_code = quote
@@ -765,7 +767,9 @@ function parse_constraint_call(
     func,
     set,
 )
-    f, parse_code = _rewrite_expression(func)
+    # Add +0 so that it creates a copy that we can mutate in future callers.
+    # We should fix this in MutableArithmetics.
+    f, parse_code = _rewrite_expression(:($func + 0))
     build_call = if vectorized
         :(build_constraint.($error_fn, _desparsify($f), $(esc(set))))
     else
@@ -1020,6 +1024,9 @@ function _clear_constant!(α::Number)
     return zero(α), α
 end
 
+# !!! warning
+#     This method assumes that we can mutate `expr`. Ensure that this is the
+#     case upstream of this call site.
 function build_constraint(
     ::Function,
     expr::Union{Number,GenericAffExpr,GenericQuadExpr},

--- a/src/macros/@constraint.jl
+++ b/src/macros/@constraint.jl
@@ -475,9 +475,7 @@ function parse_constraint_head(
             "`$ub >= ... >= $lb`.",
         )
     end
-    # Add +0 so that it creates a copy that we can mutate in future callers.
-    # We should fix this in MutableArithmetics.
-    new_aff, parse_aff = _rewrite_expression(:($aff + 0))
+    new_aff, parse_aff = _rewrite_expression(aff)
     new_lb, parse_lb = _rewrite_expression(lb)
     new_ub, parse_ub = _rewrite_expression(ub)
     parse_code = quote
@@ -767,9 +765,7 @@ function parse_constraint_call(
     func,
     set,
 )
-    # Add +0 so that it creates a copy that we can mutate in future callers.
-    # We should fix this in MutableArithmetics.
-    f, parse_code = _rewrite_expression(:($func + 0))
+    f, parse_code = _rewrite_expression(func)
     build_call = if vectorized
         :(build_constraint.($error_fn, _desparsify($f), $(esc(set))))
     else

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -2490,7 +2490,7 @@ end
 function test_do_not_mutate_expression_double_sided_comparison()
     model = Model()
     @variable(model, x)
-    @expression(model, a[1:1], x+1)
+    @expression(model, a[1:1], x + 1)
     @constraint(model, -1 <= a[1] <= 1)
     @test isequal_canonical(a[1], x + 1)
     return
@@ -2499,7 +2499,7 @@ end
 function test_do_not_mutate_expression_single_sided_comparison()
     model = Model()
     @variable(model, x)
-    @expression(model, a[1:1], x+1)
+    @expression(model, a[1:1], x + 1)
     @constraint(model, a[1] >= 1)
     @test isequal_canonical(a[1], x + 1)
     return
@@ -2508,7 +2508,7 @@ end
 function test_do_not_mutate_expression_in_set()
     model = Model()
     @variable(model, x)
-    @expression(model, a[1:1], x+1)
+    @expression(model, a[1:1], x + 1)
     @constraint(model, a[1] in MOI.Interval(-1, 1))
     @test isequal_canonical(a[1], x + 1)
     return

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -2487,4 +2487,31 @@ function test_array_scalar_sets()
     return
 end
 
+function test_do_not_mutate_expression_double_sided_comparison()
+    model = Model()
+    @variable(model, x)
+    @expression(model, a[1:1], x+1)
+    @constraint(model, -1 <= a[1] <= 1)
+    @test isequal_canonical(a[1], x + 1)
+    return
+end
+
+function test_do_not_mutate_expression_single_sided_comparison()
+    model = Model()
+    @variable(model, x)
+    @expression(model, a[1:1], x+1)
+    @constraint(model, a[1] >= 1)
+    @test isequal_canonical(a[1], x + 1)
+    return
+end
+
+function test_do_not_mutate_expression_in_set()
+    model = Model()
+    @variable(model, x)
+    @expression(model, a[1:1], x+1)
+    @constraint(model, a[1] in MOI.Interval(-1, 1))
+    @test isequal_canonical(a[1], x + 1)
+    return
+end
+
 end  # module


### PR DESCRIPTION
Closes #3882

This is a temporary fix. A longer-term approach is to return the `is_mutable::Bool` value from MutableArithemtics:
https://github.com/jump-dev/MutableArithmetics.jl/blob/d47000d5e02100458aff33670684a95f105ec40a/src/rewrite.jl#L341
which would let JuMP decide whether it needed to call `copy_if_mutable`.