### PR TITLE
Prep for v1.23.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuMP"
 uuid = "4076af6c-e467-56ae-b986-b466b2749572"
 repo = "https://github.com/jump-dev/JuMP.jl.git"
-version = "1.23.4"
+version = "1.23.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -57,7 +57,7 @@
 [Gurobi]
     rev = "9bafe7d3e4ed198b97836362a62bb48a14d408bc"
 [HiGHS]
-    rev = "v1.12.0"
+    rev = "v1.12.1"
 [Hypatia]
     rev = "v0.8.1"
     has_html = true
@@ -138,7 +138,7 @@
     has_html = true
 [DAQP]
     user = "darnstrom"
-    rev = "v0.5.2"
+    rev = "v0.6.0"
 [DisjunctiveProgramming]
     user = "hdavid16"
     rev = "6a4d0ac4a7484e52b1dbff9cee310a73d2d23e81"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,20 @@ CurrentModule = JuMP
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version 1.23.5 (Noveber 19, 2024)
+
+### Fixed
+
+ - Fixed a bug broadcasting over [`GenericNonlinearExpr`](@ref) (#3881)
+ - Fixed a bug in [`@constraint`](@ref) which illegally mutated user expressions
+   (#3883) (#3885)
+
+### Other
+
+ - Updated `upload-artifact` GitHub action (#3877)
+ - Added a section on [Common subexpressions](@ref) (#3879)
+ - Fixed a printing change for DimensionalData.jl (#3880)
+
 ## Version 1.23.4 (November 8, 2024)
 
 ### Fixed

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,7 +7,7 @@ CurrentModule = JuMP
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Version 1.23.5 (Noveber 19, 2024)
+## Version 1.23.5 (November 19, 2024)
 
 ### Fixed
 


### PR DESCRIPTION
## Pre-release

 - [x] Check that the pinned packages in `docs/Project.toml` are updated. We pin
       the versions so that changes in the solvers (changes in printing, small
       numeric changes) do not break the printing of the JuMP docs in arbitrary
       commits.
 - [x] Check that the `rev` fields in `docs/packages.toml` are updated. We pin
       the versions of solvers and extensions to ensure that changes to their
       READMEs do not break the JuMP docs in arbitrary commits, and to ensure
       that the versions are compatible with the latest JuMP and
       MathOptInterface releases.
 - [x] Check compat of `DimensionalData` in `Project.toml`
 - [x] Check compat of `MacroTools` in `Project.toml`
 - [x] Update `docs/src/changelog.md`
 - [x] https://github.com/jump-dev/JuMP.jl/actions/runs/11903638009
    - Alpine https://github.com/lanl-ansi/Alpine.jl/pull/254
    - LinearFractional https://github.com/nexteraanalytics/LinearFractional.jl/pull/22
    - PolyJuMP/SumOfSquares: @blegat is refactoring
 - [x] Change the version number in `Project.toml`
 - [x] The commit messages in this PR do not contain `[ci skip]`

## The release

 - [ ] After merging this pull request, comment `[at]JuliaRegistrator register` in
       the GitHub commit. This should automatically publish a new version to the
       Julia registry, as well as create a tag, and rebuild the documentation
       for this tag.

       These steps can take quite a bit of time (1 hour or more), so don't be
       surprised if the new documentation takes a while to appear. In addition,
       the links in the README will be broken until JuliaHub fetches the new
       version on their servers.

## Post-release

 - [ ] Once the tag is created, update the relevant `release-` branch. The latest
       release branch at the time of writing is `release-1.0` (we haven't
       back-ported any patches that needed to create a `release-1.Y` branch). To
       to update the release branch with the v1.10.0 tag, do:
       ```
       git checkout release-1.0
       git pull
       git merge v1.10.0
       git push
       ```