### PR TITLE
Improve error message when = is used instead of ==

### DIFF
--- a/src/Containers/macro.jl
+++ b/src/Containers/macro.jl
@@ -54,6 +54,11 @@ function parse_macro_arguments(
                 )
             elseif valid_kwargs !== nothing && !(arg.args[1] in valid_kwargs)
                 error_fn("unsupported keyword argument `$(arg.args[1])`.")
+            elseif !(arg.args[1] isa Symbol)
+                error_fn(
+                    "Invalid keyword argument detected. If you are trying to " *
+                    "construct an equality constraint, use `==` instead of `=`.",
+                )
             end
             kwargs[arg.args[1]] = arg.args[2]
         else

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -2514,4 +2514,16 @@ function test_do_not_mutate_expression_in_set()
     return
 end
 
+function test_malformed_kwarg()
+    model = Model()
+    @variable(model, x[1:1])
+    @test_throws_parsetime(
+        ErrorException(
+            "In `@constraint(model, x[1] = 1)`: Invalid keyword argument detected. If you are trying to construct an equality constraint, use `==` instead of `=`.",
+        ),
+        @constraint(model, x[1] = 1),
+    )
+    return
+end
+
 end  # module


### PR DESCRIPTION
Closes #3891

Fixes https://discourse.julialang.org/t/problem-setting-constraint-in-simple-lp-using-jump/123059

```Julia
julia> function quantile_regression_linear()
           # retrieve views of the relevant data 
           y = rand(1000)
           x = rand(1000)
           N = length(y)
           # initialize the optimization model and solve it 
           model = Model()
           set_silent(model)
           @variable(model, u_plus[1:N] ≥ 0.0)
           @variable(model, u_minus[1:N] ≤ 0.0)
           @variable(model, θ[1:2])
           @constraint(model, [i in 1:N], y[i] - θ[1] - θ[2]*x[i] = u_plus[i] + u_minus[i])
       end
ERROR: LoadError: At REPL[11]:12: `@constraint(model, [i in 1:N], (y[i] - θ[1]) - θ[2] * x[i] = begin
        #= REPL[11]:12 =#
        u_plus[i] + u_minus[i]
    end)`: Invalid keyword argument detected. If you are trying to construct an equality constraint, use `==` instead of `=`.
Stacktrace:
 [1] error(::String, ::String)
   @ Base ./error.jl:44
 [2] (::JuMP.Containers.var"#error_fn#98"{String})(str::String)
   @ JuMP.Containers ~/.julia/dev/JuMP/src/Containers/macro.jl:331
 [3] parse_macro_arguments(error_fn::JuMP.Containers.var"#error_fn#98"{…}, args::Tuple{…}; valid_kwargs::Nothing, num_positional_args::Nothing)
   @ JuMP.Containers ~/.julia/dev/JuMP/src/Containers/macro.jl:58
 [4] parse_macro_arguments(error_fn::Function, args::Tuple{Symbol, Expr, Expr})
   @ JuMP.Containers ~/.julia/dev/JuMP/src/Containers/macro.jl:41
 [5] var"@constraint"(__source__::LineNumberNode, __module__::Module, input_args::Vararg{Any})
   @ JuMP ~/.julia/dev/JuMP/src/macros/@constraint.jl:103
in expression starting at REPL[11]:12
Some type information was truncated. Use `show(err)` to see complete types.
```