### PR TITLE
[docs] use tectonic_jll

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -44,6 +44,7 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Wavelets = "29a6e085-ba6d-5f35-a997-948ac2efa89a"
+tectonic_jll = "d7dd28d6-a5e6-559c-9131-7eb760cdacc5"
 
 [compat]
 CDDLib = "=0.9.4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,6 +11,7 @@ import MathOptInterface
 import Pkg
 import Test
 import TOML
+import tectonic_jll
 
 using JuMP
 using JuMP.Containers
@@ -669,11 +670,19 @@ if _PDF
     # `contents` is a big list of docstrings. By default, they'll
     # show up at the `\chapter` level. That's too high.
     _PAGES[4] = section_title => ["Docstrings" => contents]
-    latex_platform = _IS_GITHUB_ACTIONS ? "docker" : "native"
+    latex_platform = if _IS_GITHUB_ACTIONS
+        Documenter.LaTeX(;
+            platform = "tectonic",
+            tectonic = tectonic_jll.tectonic(),
+        )
+    else
+        Documenter.LaTeX(; platform = "native")
+    end
+
     @time Documenter.makedocs(
         sitename = "JuMP",
         authors = "The JuMP core developers and contributors",
-        format = Documenter.LaTeX(; platform = latex_platform),
+        format = latex_platform,
         build = "latex_build",
         pages = _PAGES,
         debug = true,


### PR DESCRIPTION
Trying out an alternative to the docker image.

A proper fix is probably to sort https://github.com/JuliaDocs/Documenter.jl/pull/2349