### PR TITLE
Support TIME_LIMIT in is_solved_and_feasible

### DIFF
--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -808,8 +808,8 @@ end
         model::GenericModel;
         allow_local::Bool = true,
         allow_almost::Bool = false,
-        additional_termination_statuses::Vector{MOI.TerminationStatusCode} =
-            MOI.TerminationStatusCode[],
+        additional_termination_statuses::Vector{TerminationStatusCode} =
+            TerminationStatusCode[],
         dual::Bool = false,
         result::Int = 1,
     )
@@ -884,8 +884,7 @@ function is_solved_and_feasible(
     dual::Bool = false,
     allow_local::Bool = true,
     allow_almost::Bool = false,
-    additional_termination_statuses::Vector{MOI.TerminationStatusCode} =
-        MOI.TerminationStatusCode[],
+    additional_termination_statuses::Vector{TerminationStatusCode} = TerminationStatusCode[],
     result::Int = 1,
 )
     status = termination_status(model)

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -884,7 +884,7 @@ function is_solved_and_feasible(
     dual::Bool = false,
     allow_local::Bool = true,
     allow_almost::Bool = false,
-    additional_termination_statuses::Vector{TerminationStatusCode} = TerminationStatusCode[],
+    additional_termination_statuses::Vector{MOI.TerminationStatusCode} = MOI.TerminationStatusCode[],
     result::Int = 1,
 )
     status = termination_status(model)

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -1254,6 +1254,7 @@ function test_is_solved_and_feasible()
         MOI.ALMOST_OPTIMAL,
         MOI.ALMOST_LOCALLY_SOLVED,
         MOI.TIME_LIMIT,
+        MOI.OTHER_ERROR,
     ]
         _global = term == MOI.OPTIMAL
         has_local = _global || (term == MOI.LOCALLY_SOLVED)
@@ -1272,6 +1273,8 @@ function test_is_solved_and_feasible()
                 MOI.set(mock, MOI.PrimalStatus(), primal)
                 MOI.set(mock, MOI.DualStatus(), dual)
                 @test is_solved_and_feasible(model) == (has_local && _primal)
+                @test is_solved_and_feasible(model; allow_time_limit = true) ==
+                      (has_local && _primal) || (term == MOI.TIME_LIMIT)
                 @test is_solved_and_feasible(model; dual = true) ==
                       (has_local && _primal && _dual)
                 @test is_solved_and_feasible(model; allow_local = false) ==

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -1273,8 +1273,10 @@ function test_is_solved_and_feasible()
                 MOI.set(mock, MOI.PrimalStatus(), primal)
                 MOI.set(mock, MOI.DualStatus(), dual)
                 @test is_solved_and_feasible(model) == (has_local && _primal)
-                @test is_solved_and_feasible(model; allow_time_limit = true) ==
-                      (has_local && _primal) || (term == MOI.TIME_LIMIT)
+                @test is_solved_and_feasible(
+                    model;
+                    additional_termination_statuses = [TIME_LIMIT],
+                ) == (has_local && _primal) || (term == MOI.TIME_LIMIT)
                 @test is_solved_and_feasible(model; dual = true) ==
                       (has_local && _primal && _dual)
                 @test is_solved_and_feasible(model; allow_local = false) ==


### PR DESCRIPTION
Originally added in https://github.com/jump-dev/JuMP.jl/pull/3668, doesn't look like we discussed `TIME_LIMIT`.

But this came up last year in a discussion I had with Simon Bowly, where I thought we did support `TIME_LIMIT`.

And then @ccoffrin just asked me about it as well.

I tend to think that most people who set a time limit and get given a feasible solution would say that `is_solved_and_feasible` is `true`.

If we decide to add, there's an open question whether we should fold this into `allow_local`, or whether we add a new `allow_time_limit` kwarg.