### PR TITLE
[docs] change to use Clarabel in more tutorials

### DIFF
--- a/docs/src/tutorials/conic/ellipse_approx.jl
+++ b/docs/src/tutorials/conic/ellipse_approx.jl
@@ -69,8 +69,8 @@ function generate_point_cloud(
     return S
 end
 
-# For the sake of this example, let's take ``m = 600``:
-S = generate_point_cloud(600);
+# For the sake of this example, let's take ``m = 100``:
+S = generate_point_cloud(100);
 
 # We will visualise the points (and ellipse) using the Plots package:
 
@@ -234,7 +234,7 @@ g = triangle_vec(LinearAlgebra.Symmetric([s z'; z Z]))
 scale_g = [1.0, sqrt(2), 1.0, sqrt(2), sqrt(2), 1.0]
 @constraint(
     model,
-    scale_g .* g in MOI.Scaled(MOI.PositiveSemidefiniteConeTriangle(1+n)),
+    scale_g .* g in MOI.Scaled(MOI.PositiveSemidefiniteConeTriangle(1 + n)),
 )
 f = [1 - S[i, :]' * Z * S[i, :] + 2 * S[i, :]' * z - s for i in 1:m]
 @constraint(model, f in MOI.Nonnegatives(m))

--- a/docs/src/tutorials/conic/ellipse_approx.jl
+++ b/docs/src/tutorials/conic/ellipse_approx.jl
@@ -19,10 +19,10 @@
 # This tutorial uses the following packages:
 
 using JuMP
+import Clarabel
 import LinearAlgebra
 import Plots
 import Random
-import SCS
 import Test
 
 # ## Problem formulation
@@ -91,10 +91,7 @@ plot = Plots.scatter(
 # Now let's build and the JuMP model. We'll compute ``D`` and ``c`` after the
 # solve.
 
-model = Model(SCS.Optimizer)
-## We need to use a tighter tolerance for this example, otherwise the bounding
-## ellipse won't actually be bounding...
-set_attribute(model, "eps_rel", 1e-7)
+model = Model(Clarabel.Optimizer)
 set_silent(model)
 m, n = size(S)
 @variable(model, z[1:n])
@@ -140,8 +137,8 @@ Plots.plot!(plot, data; c = :crimson, label = nothing)
 # ## Alternative formulations
 
 # The formulation of `model` uses [`MOI.RootDetConeSquare`](@ref). However,
-# because SCS does not natively support this cone, JuMP automatically
-# reformulates the problem into an equivalent problem that SCS _does_ support.
+# because Clarabel does not natively support this cone, JuMP automatically
+# reformulates the problem into an equivalent problem that Clarabel _does_ support.
 # You can see the reformulation that JuMP chose using [`print_active_bridges`](@ref):
 
 print_active_bridges(model)
@@ -150,16 +147,16 @@ print_active_bridges(model)
 # ```raw
 # * Unsupported objective: MOI.VariableIndex
 # |  bridged by:
-# |   MOIB.Objective.FunctionizeBridge{Float64}
-# |  introduces:
+# |   MOIB.Objective.FunctionConversionBridge{Float64}
+# |  may introduce:
 # |   * Supported objective: MOI.ScalarAffineFunction{Float64}
 # ```
-# This says that SCS does not support a `MOI.VariableIndex` objective function,
-# and that JuMP used a [`MOI.Bridges.Objective.FunctionizeBridge`](@ref) to
-# convert it into a `MOI.ScalarAffineFunction{Float64}` objective function.
+# This says that Clarabel does not support a `MOI.VariableIndex` objective
+# function, and that JuMP used a [`MOI.Bridges.Objective.FunctionConversionBridge`](@ref)
+# to convert it into a `MOI.ScalarAffineFunction{Float64}` objective function.
 
 # We can leave JuMP to do the reformulation, or we can rewrite our model to
-# have an objective function that SCS natively supports:
+# have an objective function that Clarabel natively supports:
 
 @objective(model, Max, 1.0 * t + 0.0);
 
@@ -170,7 +167,7 @@ print_active_bridges(model)
 # we get `* Supported objective: MOI.ScalarAffineFunction{Float64}`.
 
 # We can manually implement some other reformulations to change our model to
-# something that SCS more closely supports by:
+# something that Clarabel more closely supports by:
 #
 #  * Replacing the [`MOI.VectorOfVariables`](@ref) in [`MOI.PositiveSemidefiniteConeTriangle`](@ref)
 #    constraint `@variable(model, Z[1:n, 1:n], PSD)` with the
@@ -190,11 +187,7 @@ print_active_bridges(model)
 #    constraint with [`MOI.VectorAffineFunction`](@ref) in
 #    [`MOI.RootDetConeTriangle`](@ref).
 
-# Note that we still need to bridge [`MOI.PositiveSemidefiniteConeTriangle`](@ref)
-# constraints because SCS uses an internal `SCS.ScaledPSDCone` set instead.
-
-model = Model(SCS.Optimizer)
-set_attribute(model, "eps_rel", 1e-6)
+model = Model(Clarabel.Optimizer)
 set_silent(model)
 @variable(model, z[1:n])
 @variable(model, s)
@@ -220,17 +213,55 @@ solve_time_1 = solve_time(model)
 
 print_active_bridges(model)
 
-# The last bullet shows how JuMP reformulated the [`MOI.RootDetConeTriangle`](@ref)
-# constraint by adding a mix of [`MOI.PositiveSemidefiniteConeTriangle`](@ref)
-# and [`MOI.GeometricMeanCone`](@ref) constraints.
+# Note that we still need to bridge [`MOI.PositiveSemidefiniteConeTriangle`](@ref)
+# constraints because Clarabel uses the [`MOI.Scaled`](@ref) PSD cone.
 
-# Because SCS doesn't natively support the [`MOI.GeometricMeanCone`](@ref),
-# these constraints were further bridged using a [`MOI.Bridges.Constraint.GeoMeanToPowerBridge`](@ref)
+model = Model(Clarabel.Optimizer)
+set_silent(model)
+@variable(model, z[1:n])
+@variable(model, s)
+@variable(model, t)
+@variable(model, Z[1:n, 1:n], Symmetric)
+## The former @constraint(model, Z in PSDCone())
+f = triangle_vec(Z)
+scale_f = [1.0, sqrt(2), 1.0]
+@constraint(
+    model,
+    scale_f .* f in MOI.Scaled(MOI.PositiveSemidefiniteConeTriangle(n)),
+)
+## The former LinearAlgebra.Symmetric([s z'; z Z]) >= 0, PSDCone()
+g = triangle_vec(LinearAlgebra.Symmetric([s z'; z Z]))
+scale_g = [1.0, sqrt(2), 1.0, sqrt(2), sqrt(2), 1.0]
+@constraint(
+    model,
+    scale_g .* g in MOI.Scaled(MOI.PositiveSemidefiniteConeTriangle(1+n)),
+)
+f = [1 - S[i, :]' * Z * S[i, :] + 2 * S[i, :]' * z - s for i in 1:m]
+@constraint(model, f in MOI.Nonnegatives(m))
+@constraint(model, 1 * [t; triangle_vec(Z)] .+ 0 in MOI.RootDetConeTriangle(n))
+@objective(model, Max, 1 * t + 0)
+optimize!(model)
+assert_is_solved_and_feasible(model)
+Test.@test isapprox(D, value.(Z); atol = 1e-3)  #src
+solve_time_2 = solve_time(model)
+
+# This formulation gives the much smaller graph:
+
+print_active_bridges(model)
+
+# Now there is only a single `Unsupported constraint` bullet, showing how JuMP
+# reformulated the [`MOI.RootDetConeTriangle`](@ref) constraint by adding a mix
+# of [`MOI.PositiveSemidefiniteConeTriangle`](@ref) and
+# [`MOI.GeometricMeanCone`](@ref) constraints.
+
+# Because Clarabel doesn't natively support the [`MOI.GeometricMeanCone`](@ref),
+# these constraints were further bridged using a
+# [`MOI.Bridges.Constraint.GeoMeanToPowerBridge`](@ref)
 # to a series of [`MOI.PowerCone`](@ref) constraints.
 
 # However, there are many other ways that a [`MOI.GeometricMeanCone`](@ref) can
-# be reformulated into something that SCS supports. Let's see what happens if we
-# use [`remove_bridge`](@ref) to remove the
+# be reformulated into something that Clarabel supports. Let's see what happens
+# if we use [`remove_bridge`](@ref) to remove the
 # [`MOI.Bridges.Constraint.GeoMeanToPowerBridge`](@ref):
 
 remove_bridge(model, MOI.Bridges.Constraint.GeoMeanToPowerBridge)
@@ -239,25 +270,25 @@ assert_is_solved_and_feasible(model)
 
 # This time, the solve took:
 
-solve_time_2 = solve_time(model)
+solve_time_3 = solve_time(model)
 
 # where previously it took
 
-solve_time_1
+solve_time_2
 
 # Why was the solve time different?
 
 print_active_bridges(model)
 
-# This time, JuMP used a [`MOI.Bridges.Constraint.GeoMeanBridge`](@ref) to
-# reformulate the constraint into a set of [`MOI.RotatedSecondOrderCone`](@ref)
+# This time, JuMP used a [`MOI.Bridges.Constraint.GeoMeantoRelEntrBridge`](@ref)
+# to reformulate the constraint into a set of [`MOI.RelativeEntropyCone`](@ref)
 # constraints, which were further reformulated into a set of supported
-# [`MOI.SecondOrderCone`](@ref) constraints.
+# [`MOI.ExponentialCone`](@ref) constraints.
 
 # Since the two models are equivalent, we can conclude that for this particular
-# model, the [`MOI.SecondOrderCone`](@ref) formulation is more efficient.
+# model, the formulations have similar performance.
 
 # In general though, the performance of a particular reformulation is problem-
-# and solver-specific. Therefore, JuMP chooses to minimize the number of bridges in
-# the default reformulation, leaving you to explore alternative formulations
+# and solver-specific. Therefore, JuMP chooses to minimize the number of bridges
+# in the default reformulation, leaving you to explore alternative formulations
 # using the tools and techniques shown in this tutorial.

--- a/docs/src/tutorials/conic/experiment_design.jl
+++ b/docs/src/tutorials/conic/experiment_design.jl
@@ -30,7 +30,7 @@
 # This tutorial uses the following packages:
 
 using JuMP
-import SCS
+import Clarabel
 import LinearAlgebra
 import MathOptInterface as MOI
 import Random
@@ -122,7 +122,7 @@ eye = Matrix{Float64}(LinearAlgebra.I, q, q);
 # \end{aligned}
 # ```
 
-aOpt = Model(SCS.Optimizer)
+aOpt = Model(Clarabel.Optimizer)
 set_silent(aOpt)
 @variable(aOpt, np[1:p], lower_bound = 0, upper_bound = n_max)
 @variable(aOpt, u[1:q], lower_bound = 0)
@@ -166,7 +166,7 @@ value.(np)
 # \end{aligned}
 # ```
 
-eOpt = Model(SCS.Optimizer)
+eOpt = Model(Clarabel.Optimizer)
 set_silent(eOpt)
 @variable(eOpt, 0 <= np[1:p] <= n_max)
 @variable(eOpt, t)
@@ -200,7 +200,7 @@ value.(np)
 # \end{aligned}
 # ```
 
-dOpt = Model(SCS.Optimizer)
+dOpt = Model(Clarabel.Optimizer)
 set_silent(dOpt)
 @variable(dOpt, np[1:p], lower_bound = 0, upper_bound = n_max)
 @variable(dOpt, t)

--- a/docs/src/tutorials/conic/logistic_regression.jl
+++ b/docs/src/tutorials/conic/logistic_regression.jl
@@ -35,9 +35,9 @@
 # This tutorial uses the following packages:
 
 using JuMP
+import Clarabel
 import MathOptInterface as MOI
 import Random
-import SCS
 
 Random.seed!(2713);
 
@@ -177,7 +177,7 @@ end
 # We generate the dataset.
 #
 # !!! warning
-#     Be careful here, for large n and p SCS could fail to converge.
+#     Be careful here, for large n and p Clarabel could fail to converge.
 #
 n, p = 200, 10
 X, y = generate_dataset(n, p; shift = 10.0);
@@ -185,7 +185,7 @@ X, y = generate_dataset(n, p; shift = 10.0);
 ## We could now solve the logistic regression problem
 λ = 10.0
 model = build_logit_model(X, y, λ)
-set_optimizer(model, SCS.Optimizer)
+set_optimizer(model, Clarabel.Optimizer)
 set_silent(model)
 optimize!(model)
 assert_is_solved_and_feasible(model)
@@ -228,7 +228,7 @@ count_nonzero(v::Vector; tol = 1e-6) = sum(abs.(v) .>= tol)
 ## We solve the sparse logistic regression problem on the same dataset as before.
 λ = 10.0
 sparse_model = build_sparse_logit_model(X, y, λ)
-set_optimizer(sparse_model, SCS.Optimizer)
+set_optimizer(sparse_model, Clarabel.Optimizer)
 set_silent(sparse_model)
 optimize!(sparse_model)
 assert_is_solved_and_feasible(sparse_model)

--- a/docs/src/tutorials/conic/min_ellipse.jl
+++ b/docs/src/tutorials/conic/min_ellipse.jl
@@ -42,9 +42,9 @@
 # This tutorial uses the following packages:
 
 using JuMP
+import Clarabel
 import LinearAlgebra
 import Plots
-import SCS
 import Test
 
 # ## Data
@@ -93,10 +93,7 @@ plot
 # Now let's build the model, using the change-of-variables `P²` = ``P^2`` and
 # `P_q` = ``P q``. We'll recover the true value of `P` and `q` after the solve.
 
-model = Model(SCS.Optimizer)
-## We need to use a tighter tolerance for this example, otherwise the bounding
-## ellipse won't actually be bounding...
-set_attribute(model, "eps_rel", 1e-6)
+model = Model(Clarabel.Optimizer)
 set_silent(model)
 m, n = length(ellipses), size(first(ellipses).A, 1)
 @variable(model, τ[1:m] >= 0)

--- a/docs/src/tutorials/conic/quantum_discrimination.jl
+++ b/docs/src/tutorials/conic/quantum_discrimination.jl
@@ -16,8 +16,8 @@
 # This tutorial uses the following packages:
 
 using JuMP
+import Clarabel
 import LinearAlgebra
-import SCS
 
 # ## Formulation
 
@@ -66,7 +66,7 @@ end
 # To model the problem in JuMP, we need a solver that supports positive
 # semidefinite matrices:
 
-model = Model(SCS.Optimizer)
+model = Model(Clarabel.Optimizer)
 set_silent(model)
 
 # Then, we construct our set of `E` variables:
@@ -127,7 +127,7 @@ solution = [value.(e) for e in E]
 # equality constraints. We can simplify the problem by replacing ``E_N`` with
 # ``E_N = I - \sum\limits_{i=1}^{N-1} E_i``. This results in:
 
-model = Model(SCS.Optimizer)
+model = Model(Clarabel.Optimizer)
 set_silent(model)
 E = [@variable(model, [1:d, 1:d] in HermitianPSDCone()) for i in 1:N-1]
 E_N = LinearAlgebra.Hermitian(LinearAlgebra.I - sum(E))

--- a/docs/src/tutorials/conic/simple_examples.jl
+++ b/docs/src/tutorials/conic/simple_examples.jl
@@ -13,10 +13,10 @@
 # This tutorial uses the following packages:
 
 using JuMP
+import Clarabel
 import LinearAlgebra
 import Plots
 import Random
-import SCS
 import Test
 
 # ## Maximum cut via SDP
@@ -57,7 +57,7 @@ function solve_max_cut_sdp(weights)
     N = size(weights, 1)
     ## Calculate the (weighted) Laplacian of the graph: L = D - W.
     L = LinearAlgebra.diagm(0 => weights * ones(N)) - weights
-    model = Model(SCS.Optimizer)
+    model = Model(Clarabel.Optimizer)
     set_silent(model)
     @variable(model, X[1:N, 1:N], PSD)
     for i in 1:N
@@ -128,7 +128,7 @@ function example_matrix_completion(; svdtol = 1e-6)
     n = 20
     mask = rand(rng, 1:25, n, n) .== 1
     B = randn(rng, n, n)
-    model = Model(SCS.Optimizer)
+    model = Model(Clarabel.Optimizer)
     @variable(model, X[1:n, 1:n])
     @constraint(model, X[mask] .== B[mask])
     @variable(model, t)
@@ -156,7 +156,7 @@ function example_k_means_clustering()
     for i in 1:m, j in i+1:m
         W[i, j] = W[j, i] = exp(-LinearAlgebra.norm(a[i] - a[j]) / 1.0)
     end
-    model = Model(SCS.Optimizer)
+    model = Model(Clarabel.Optimizer)
     set_silent(model)
     @variable(model, Z[1:m, 1:m] >= 0, PSD)
     @objective(model, Min, LinearAlgebra.tr(W * (LinearAlgebra.I - Z)))
@@ -206,7 +206,7 @@ example_k_means_clustering()
 # ```
 
 function example_correlation_problem()
-    model = Model(SCS.Optimizer)
+    model = Model(Clarabel.Optimizer)
     set_silent(model)
     @variable(model, X[1:3, 1:3], PSD)
     S = ["A", "B", "C"]
@@ -281,7 +281,7 @@ example_correlation_problem()
 # For more details, see [Matousek2013,Linial2002](@cite).
 
 function example_minimum_distortion()
-    model = Model(SCS.Optimizer)
+    model = Model(Clarabel.Optimizer)
     set_silent(model)
     D = [
         0.0 1.0 1.0 1.0
@@ -364,7 +364,7 @@ example_minimum_distortion()
 # For more details, see [Barvinok2002,Knuth1994](@cite).
 
 function example_theta_problem()
-    model = Model(SCS.Optimizer)
+    model = Model(Clarabel.Optimizer)
     set_silent(model)
     E = [(1, 2), (2, 3), (3, 4), (4, 5), (5, 1)]
     @variable(model, X[1:5, 1:5], PSD)
@@ -403,7 +403,7 @@ function example_robust_uncertainty_sets()
     Σhat = 1 / (d - 1) * (M - ones(d) * μhat')' * (M - ones(d) * μhat')
     Γ1(𝛿, N) = R / sqrt(N) * (2 + sqrt(2 * log(1 / 𝛿)))
     Γ2(𝛿, N) = 2 * R^2 / sqrt(N) * (2 + sqrt(2 * log(2 / 𝛿)))
-    model = Model(SCS.Optimizer)
+    model = Model(Clarabel.Optimizer)
     set_silent(model)
     @variable(model, Σ[1:d, 1:d], PSD)
     @variable(model, u[1:d])

--- a/docs/src/tutorials/conic/tips_and_tricks.jl
+++ b/docs/src/tutorials/conic/tips_and_tricks.jl
@@ -34,9 +34,9 @@
 # This tutorial uses the following packages:
 
 using JuMP
+import Clarabel
 import LinearAlgebra
 import MathOptInterface as MOI
-import SCS
 
 import Random      # hide
 Random.seed!(1234) # hide
@@ -84,7 +84,7 @@ nothing            # hide
 
 # It is most commonly used to represent the L2-norm of the vector $x$:
 
-model = Model(SCS.Optimizer)
+model = Model(Clarabel.Optimizer)
 set_silent(model)
 @variable(model, x[1:3])
 @variable(model, t)
@@ -107,7 +107,7 @@ value(t), value.(x)
 
 data = [1.0, 2.0, 3.0, 4.0]
 target = [0.45, 1.04, 1.51, 1.97]
-model = Model(SCS.Optimizer)
+model = Model(Clarabel.Optimizer)
 set_silent(model)
 @variable(model, θ)
 @variable(model, t)
@@ -131,7 +131,7 @@ value(θ), value(t)
 
 # To model ``\exp(x) \le z``, use `(x, 1, z)`:
 
-model = Model(SCS.Optimizer)
+model = Model(Clarabel.Optimizer)
 set_silent(model)
 @variable(model, x == 1.5)
 @variable(model, z)
@@ -145,7 +145,7 @@ value(z), exp(1.5)
 
 # To model ``x \le \log(z)``, use `(x, 1, z)`:
 
-model = Model(SCS.Optimizer)
+model = Model(Clarabel.Optimizer)
 set_silent(model)
 @variable(model, x)
 @variable(model, z == 1.5)
@@ -161,7 +161,7 @@ value(x), log(1.5)
 
 N = 3
 x0 = rand(N)
-model = Model(SCS.Optimizer)
+model = Model(Clarabel.Optimizer)
 set_silent(model)
 @variable(model, x[i = 1:N] == x0[i])
 @variable(model, t)
@@ -205,7 +205,7 @@ value(t), log(sum(exp.(x0)))
 
 m, n = 10, 15
 A, b = randn(m, n), rand(m, 1)
-model = Model(SCS.Optimizer)
+model = Model(Clarabel.Optimizer)
 set_silent(model)
 @variable(model, t[1:n])
 @variable(model, x[1:n])
@@ -224,7 +224,7 @@ objective_value(model)
 # There is also the [`MOI.RelativeEntropyCone`](@ref) for explicitly encoding
 # the relative entropy function
 
-model = Model(SCS.Optimizer)
+model = Model(Clarabel.Optimizer)
 set_silent(model)
 @variable(model, t)
 @variable(model, x[1:n])
@@ -248,7 +248,7 @@ objective_value(model)
 # we can model ``t \ge x^p`` using the power cone ``(t, 1, x)`` with
 # ``\alpha = 1 / p``. Thus, to model ``t \ge x^3`` with ``x \ge 0``
 
-model = Model(SCS.Optimizer)
+model = Model(Clarabel.Optimizer)
 set_silent(model)
 @variable(model, t)
 @variable(model, x >= 1.5)
@@ -270,7 +270,7 @@ value(t), value(x)
 
 function p_norm(x::Vector, p)
     N = length(x)
-    model = Model(SCS.Optimizer)
+    model = Model(Clarabel.Optimizer)
     set_silent(model)
     @variable(model, r[1:N])
     @variable(model, t)
@@ -316,7 +316,7 @@ LinearAlgebra.norm(x, 4), p_norm(x, 4)
 
 A = [3 2 4; 2 0 2; 4 2 3]
 I = Matrix{Float64}(LinearAlgebra.I, 3, 3)
-model = Model(SCS.Optimizer)
+model = Model(Clarabel.Optimizer)
 set_silent(model)
 @variable(model, t)
 @objective(model, Min, t)
@@ -332,7 +332,7 @@ objective_value(model)
 # K_{geo} = \{ (t, x) \in \mathbb{R}^n : x \ge 0, t \le \sqrt[n-1]{x_1 x_2 \cdots x_{n-1}} \}
 # ```
 
-model = Model(SCS.Optimizer)
+model = Model(Clarabel.Optimizer)
 set_silent(model)
 @variable(model, x[1:4])
 @variable(model, t)
@@ -348,7 +348,7 @@ value(t), value.(x)
 # K = \{ (t, X) \in \mathbb{R}^{1+d^2} : t \le \det(X)^{\frac{1}{d}} \}
 # ```
 
-model = Model(SCS.Optimizer)
+model = Model(Clarabel.Optimizer)
 set_silent(model)
 @variable(model, t)
 @variable(model, X[1:2, 1:2])
@@ -367,7 +367,7 @@ value(t), sqrt(LinearAlgebra.det(value.(X)))
 # column-wise upper triangle of the matrix as a vector in the order that JuMP
 # requires.
 
-model = Model(SCS.Optimizer)
+model = Model(Clarabel.Optimizer)
 set_silent(model)
 @variable(model, t)
 @variable(model, X[1:2, 1:2], Symmetric)
@@ -384,7 +384,7 @@ value(t), sqrt(LinearAlgebra.det(value.(X)))
 # K = \{ (t, u, X) \in \mathbb{R}^{2+d^2} : t \le u \log(\det(X / u)) \}
 # ```
 
-model = Model(SCS.Optimizer)
+model = Model(Clarabel.Optimizer)
 set_silent(model)
 @variable(model, t)
 @variable(model, u)
@@ -405,7 +405,7 @@ value(t), 0.5 * log(LinearAlgebra.det(value.(X) ./ 0.5))
 # column-wise upper triangle of the matrix as a vector in the order that JuMP
 # requires.
 
-model = Model(SCS.Optimizer)
+model = Model(Clarabel.Optimizer)
 set_silent(model)
 @variable(model, t)
 @variable(model, u)
@@ -426,7 +426,7 @@ value(t), 0.5 * log(LinearAlgebra.det(value.(X) ./ 0.5))
 # ```
 # where ``\sigma_i`` is the `i` singular value of ``X``.
 
-model = Model(SCS.Optimizer)
+model = Model(Clarabel.Optimizer)
 set_silent(model)
 @variable(model, t)
 @variable(model, X[1:2, 1:3])
@@ -445,7 +445,7 @@ value(t), sum(LinearAlgebra.svdvals(value.(X)))
 # ```
 # where ``\sigma_i`` is the `i` singular value of ``X``.
 
-model = Model(SCS.Optimizer)
+model = Model(Clarabel.Optimizer)
 set_silent(model)
 @variable(model, t)
 @variable(model, X[1:2, 1:3])


### PR DESCRIPTION
This discourse post (https://discourse.julialang.org/t/jump-scs-tutorial-example-fails-on-simple-data/125857/3) points out that SCS is not very robust, and indeed, in many places we need to tweak the tolerances to get things to work. We already have Clarabel in docs, so let's use that instead.