### PR TITLE
[docs] fix: Add correct parameters for set_attribute in installation.md

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -78,9 +78,9 @@ julia> using HiGHS
 
 julia> model = Model(HiGHS.Optimizer);
 
-julia> set_attribute(model, "output_flag" => false)
+julia> set_attribute(model, "output_flag",false)
 
-julia> set_attribute(model, "primal_feasibility_tolerance" => 1e-8)
+julia> set_attribute(model, "primal_feasibility_tolerance", 1e-8)
 ```
 
 !!! note

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -71,14 +71,14 @@ julia> Pkg.add("HiGHS")
 
 Once installed, you can use HiGHS as a solver with JuMP as follows, using
 [`set_attribute`](@ref) to set solver-specific options:
-```julia
+```jldoctest
 julia> using JuMP
 
 julia> using HiGHS
 
 julia> model = Model(HiGHS.Optimizer);
 
-julia> set_attribute(model, "output_flag",false)
+julia> set_attribute(model, "output_flag", false)
 
 julia> set_attribute(model, "primal_feasibility_tolerance", 1e-8)
 ```


### PR DESCRIPTION
Reference : [https://github.com/jump-dev/JuMP.jl/blob/master/src/optimizer_interface.jl](url)

From the implementation of the  
`set_optimizer_attribute(
        model::Union{GenericModel,MOI.OptimizerWithAttributes},
        attr::Union{AbstractString,MOI.AbstractOptimizerAttribute},
        value)` method; 

The function expects three parameters however [Installation Guide](https://jump.dev/JuMP.jl/stable/installation/#Install-a-solver) uses a (model,key value pair) in the solvers' section which throws a Method Error at runtime. This fix would solve the issue.