### PR TITLE
[docs] remove has_values and has_duals from documentation

### DIFF
--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -648,8 +648,8 @@ equality constraint, it depends on which direction is binding.
     and [`reduced_cost`](@ref) instead.
 
 The dual value associated with a constraint in the most recent solution can be
-accessed using the [`dual`](@ref) function. Use [`has_duals`](@ref) to check if
-the model has a dual solution available to query. For example:
+accessed using the [`dual`](@ref) function. For example:
+
 ```jldoctest con_duality
 julia> model = Model(HiGHS.Optimizer);
 
@@ -664,13 +664,13 @@ con : x ≤ 1
 julia> @objective(model, Min, -2x)
 -2 x
 
-julia> has_duals(model)
-false
+julia> dual_status(model)
+NO_SOLUTION::ResultStatusCode = 0
 
 julia> optimize!(model)
 
-julia> has_duals(model)
-true
+julia> dual_status(model)
+FEASIBLE_POINT::ResultStatusCode = 1
 
 julia> dual(con)
 -2.0
@@ -679,6 +679,9 @@ julia> @objective(model, Max, 2x)
 2 x
 
 julia> optimize!(model)
+
+julia> dual_status(model)
+FEASIBLE_POINT::ResultStatusCode = 1
 
 julia> dual(con)
 -2.0

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -167,13 +167,6 @@ The first means that the solver doesn't have a solution to return, and the
 second means that the primal solution is a certificate of dual infeasibility (a
 primal unbounded ray).
 
-You can also use [`has_values`](@ref), which returns `true` if there is a
-solution that can be queried, and `false` otherwise.
-```jldoctest solutions
-julia> has_values(model)
-true
-```
-
 ### Objective values
 
 The objective value of a solved problem can be obtained via
@@ -281,13 +274,6 @@ Other common returns are [`NO_SOLUTION`](@ref), and [`INFEASIBILITY_CERTIFICATE`
 The first means that the solver doesn't have a solution to return, and the
 second means that the dual solution is a certificate of primal infeasibility (a
 dual unbounded ray).
-
-You can also use [`has_duals`](@ref), which returns `true` if there is a
-solution that can be queried, and `false` otherwise.
-```jldoctest solutions
-julia> has_duals(model)
-true
-```
 
 ### Dual solution values
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -1281,7 +1281,7 @@ That is, if `con_ref` is the reference of a constraint `func`-in-`set`, it
 returns the value of `func` evaluated at the value of the variables (given by
 [`value(::GenericVariableRef)`](@ref)).
 
-Use [`has_values`](@ref) to check if a result exists before asking for values.
+Use [`primal_status`](@ref) to check if a result exists before asking for values.
 
 See also: [`result_count`](@ref).
 
@@ -1365,7 +1365,7 @@ end
 Return the dual value of constraint `con_ref` associated with result index
 `result` of the most-recent solution returned by the solver.
 
-Use [`has_duals`](@ref) to check if a result exists before asking for values.
+Use [`dual_status`](@ref) to check if a result exists before asking for values.
 
 See also: [`result_count`](@ref), [`shadow_price`](@ref).
 
@@ -1387,8 +1387,8 @@ julia> @objective(model, Max, 2 * x + 1);
 
 julia> optimize!(model)
 
-julia> has_duals(model)
-true
+julia> dual_status(model)
+FEASIBLE_POINT::ResultStatusCode = 1
 
 julia> dual(c)
 -2.0
@@ -1419,8 +1419,7 @@ Return the change in the objective from an infinitesimal relaxation of the
 constraint.
 
 The shadow price is computed from [`dual`](@ref) and can be queried only when
-`has_duals` is `true` and the objective sense is `MIN_SENSE` or `MAX_SENSE`
-(not `FEASIBILITY_SENSE`).
+the objective sense is `MIN_SENSE` or `MAX_SENSE` (not `FEASIBILITY_SENSE`).
 
 See also [`reduced_cost`](@ref JuMP.reduced_cost).
 
@@ -1463,8 +1462,8 @@ julia> @objective(model, Max, 2 * x + 1);
 
 julia> optimize!(model)
 
-julia> has_duals(model)
-true
+julia> dual_status(model)
+FEASIBLE_POINT::ResultStatusCode = 1
 
 julia> shadow_price(c)
 2.0

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -2078,7 +2078,7 @@ end
 Return the value of variable `v` associated with result index `result` of the
 most-recent returned by the solver.
 
-Use [`has_values`](@ref) to check if a result exists before asking for values.
+Use [`primal_status`](@ref) to check if a result exists before asking for values.
 
 See also: [`result_count`](@ref).
 """
@@ -2620,8 +2620,8 @@ julia> @objective(model, Max, 2 * x + 1);
 
 julia> optimize!(model)
 
-julia> has_duals(model)
-true
+julia> dual_status(model)
+FEASIBLE_POINT::ResultStatusCode = 1
 
 julia> reduced_cost(x)
 2.0


### PR DESCRIPTION
x-ref https://discourse.julialang.org/t/about-jump-is-solved-and-feasible/126868/3

People using `has_values` or `has_duals` are almost certainly using it wrong.