### PR TITLE
Replace diagm by Diagonal

### DIFF
--- a/docs/src/tutorials/conic/experiment_design.jl
+++ b/docs/src/tutorials/conic/experiment_design.jl
@@ -129,7 +129,7 @@ set_silent(aOpt)
 @constraint(aOpt, sum(np) <= n)
 for i in 1:q
     matrix = [
-        V*LinearAlgebra.Dagonal(np ./ n)*V' eye[:, i]
+        V*LinearAlgebra.Diagonal(np ./ n)*V' eye[:, i]
         eye[i, :]' u[i]
     ]
     @constraint(aOpt, matrix >= 0, PSDCone())
@@ -172,7 +172,7 @@ set_silent(eOpt)
 @variable(eOpt, t)
 @constraint(
     eOpt,
-    V * LinearAlgebra.Dagonal(np ./ n) * V' - (t .* eye) >= 0,
+    V * LinearAlgebra.Diagonal(np ./ n) * V' - (t .* eye) >= 0,
     PSDCone(),
 )
 @constraint(eOpt, sum(np) <= n)
@@ -206,7 +206,7 @@ set_silent(dOpt)
 @variable(dOpt, t)
 @objective(dOpt, Max, t)
 @constraint(dOpt, sum(np) <= n)
-E = V * LinearAlgebra.Dagonal(np ./ n) * V'
+E = V * LinearAlgebra.Diagonal(np ./ n) * V'
 @constraint(dOpt, [t; 1; triangle_vec(E)] in MOI.LogDetConeTriangle(q))
 optimize!(dOpt)
 assert_is_solved_and_feasible(dOpt)

--- a/docs/src/tutorials/conic/experiment_design.jl
+++ b/docs/src/tutorials/conic/experiment_design.jl
@@ -129,7 +129,7 @@ set_silent(aOpt)
 @constraint(aOpt, sum(np) <= n)
 for i in 1:q
     matrix = [
-        V*LinearAlgebra.diagm(0 => np ./ n)*V' eye[:, i]
+        V*LinearAlgebra.Dagonal(np ./ n)*V' eye[:, i]
         eye[i, :]' u[i]
     ]
     @constraint(aOpt, matrix >= 0, PSDCone())
@@ -172,7 +172,7 @@ set_silent(eOpt)
 @variable(eOpt, t)
 @constraint(
     eOpt,
-    V * LinearAlgebra.diagm(0 => np ./ n) * V' - (t .* eye) >= 0,
+    V * LinearAlgebra.Dagonal(np ./ n) * V' - (t .* eye) >= 0,
     PSDCone(),
 )
 @constraint(eOpt, sum(np) <= n)
@@ -206,7 +206,7 @@ set_silent(dOpt)
 @variable(dOpt, t)
 @objective(dOpt, Max, t)
 @constraint(dOpt, sum(np) <= n)
-E = V * LinearAlgebra.diagm(0 => np ./ n) * V'
+E = V * LinearAlgebra.Dagonal(np ./ n) * V'
 @constraint(dOpt, [t; 1; triangle_vec(E)] in MOI.LogDetConeTriangle(q))
 optimize!(dOpt)
 assert_is_solved_and_feasible(dOpt)

--- a/docs/src/tutorials/conic/simple_examples.jl
+++ b/docs/src/tutorials/conic/simple_examples.jl
@@ -56,7 +56,7 @@ end
 function solve_max_cut_sdp(weights)
     N = size(weights, 1)
     ## Calculate the (weighted) Laplacian of the graph: L = D - W.
-    L = LinearAlgebra.diagm(0 => weights * ones(N)) - weights
+    L = LinearAlgebra.Dagonal(weights * ones(N)) - weights
     model = Model(Clarabel.Optimizer)
     set_silent(model)
     @variable(model, X[1:N, 1:N], PSD)

--- a/docs/src/tutorials/conic/simple_examples.jl
+++ b/docs/src/tutorials/conic/simple_examples.jl
@@ -56,7 +56,7 @@ end
 function solve_max_cut_sdp(weights)
     N = size(weights, 1)
     ## Calculate the (weighted) Laplacian of the graph: L = D - W.
-    L = LinearAlgebra.Dagonal(weights * ones(N)) - weights
+    L = LinearAlgebra.Diagonal(weights * ones(N)) - weights
     model = Model(Clarabel.Optimizer)
     set_silent(model)
     @variable(model, X[1:N, 1:N], PSD)

--- a/test/test_nlp.jl
+++ b/test/test_nlp.jl
@@ -518,7 +518,7 @@ function _dense_hessian(hessian_sparsity, V, n)
     raw = SparseArrays.sparse(I, J, V, n, n)
     return Matrix(
         raw + raw' -
-        SparseArrays.sparse(LinearAlgebra.diagm(0 => LinearAlgebra.diag(raw))),
+        SparseArrays.sparse(LinearAlgebra.Dagonal(LinearAlgebra.diag(raw))),
     )
 end
 
@@ -869,12 +869,12 @@ function test_dense_Hessian()
     values = ones(18)
     MOI.eval_hessian_lagrangian(d, V, values, 1.0, Float64[])
     @test _dense_hessian(hessian_sparsity, V, 18) ≈
-          ones(18, 18) - LinearAlgebra.diagm(0 => ones(18))
+          ones(18, 18) - LinearAlgebra.Dagonal(ones(18))
     values[1] = 0.5
     MOI.eval_hessian_lagrangian(d, V, values, 1.0, Float64[])
     @test _dense_hessian(hessian_sparsity, V, 18) ≈ [
         0 ones(17)'
-        ones(17) (ones(17, 17)-LinearAlgebra.diagm(0 => ones(17)))/2
+        ones(17) (ones(17, 17)-LinearAlgebra.Dagonal(ones(17)))/2
     ]
     return
 end

--- a/test/test_nlp.jl
+++ b/test/test_nlp.jl
@@ -518,7 +518,7 @@ function _dense_hessian(hessian_sparsity, V, n)
     raw = SparseArrays.sparse(I, J, V, n, n)
     return Matrix(
         raw + raw' -
-        SparseArrays.sparse(LinearAlgebra.Dagonal(LinearAlgebra.diag(raw))),
+        SparseArrays.sparse(LinearAlgebra.Diagonal(LinearAlgebra.diag(raw))),
     )
 end
 
@@ -869,12 +869,12 @@ function test_dense_Hessian()
     values = ones(18)
     MOI.eval_hessian_lagrangian(d, V, values, 1.0, Float64[])
     @test _dense_hessian(hessian_sparsity, V, 18) ≈
-          ones(18, 18) - LinearAlgebra.Dagonal(ones(18))
+          ones(18, 18) - LinearAlgebra.Diagonal(ones(18))
     values[1] = 0.5
     MOI.eval_hessian_lagrangian(d, V, values, 1.0, Float64[])
     @test _dense_hessian(hessian_sparsity, V, 18) ≈ [
         0 ones(17)'
-        ones(17) (ones(17, 17)-LinearAlgebra.Dagonal(ones(17)))/2
+        ones(17) (ones(17, 17)-LinearAlgebra.Diagonal(ones(17)))/2
     ]
     return
 end


### PR DESCRIPTION
`diagm` may be familiar to some users, especially coming from MATLAB but may puzzle others.
`Diagonal` is quite clear and readable for everyone so I think it should be an overall win.