### PR TITLE
Update to cache v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:


### PR DESCRIPTION
According to https://github.com/julia-actions/cache/releases/tag/v2.0.0, we should be fine as we're not using self-hosted CI on an old OS