### PR TITLE
[docs] remove admonitions from callack manual page

### DIFF
--- a/docs/src/manual/callbacks.md
+++ b/docs/src/manual/callbacks.md
@@ -8,7 +8,7 @@ DocTestFilters = [r"≤|<=", r"≥|>=", r" == | = ", r" ∈ | in ", r"MathOptInt
 
 # [Solver-independent Callbacks](@id callbacks_manual)
 
-Many mixed-integer (linear, conic, and nonlinear) programming solvers offer
+Some mixed-integer (linear, conic, and nonlinear) programming solvers offer
 the ability to modify the solve process. Examples include changing branching
 decisions in branch-and-bound, adding custom cutting planes, providing custom
 heuristics to find feasible solutions, or implementing on-demand separators to
@@ -23,30 +23,28 @@ callbacks:
  2. user-cuts
  3. heuristic solutions
 
+Even though JuMP provides a solver-independent way of writing these three
+callbacks, you should not assume that you will see identical behavior when
+running the same code on different solvers. For example, some solvers may ignore
+user-cuts for various reasons, while other solvers may add every user-cut. Read
+the underlying solver's callback documentation to understand details specific to
+each solver.
+
 ## Available solvers
 
-Solver-independent callback support is limited to a few solvers. This includes
-[CPLEX](https://github.com/jump-dev/CPLEX.jl),
-[GLPK](https://github.com/jump-dev/GLPK.jl),
-[Gurobi](https://github.com/jump-dev/Gurobi.jl),
-[Xpress](https://github.com/jump-dev/Xpress.jl), and
-[SCIP](https://github.com/scipopt/SCIP.jl) (SCIP does not support lazy
-constraints).
+Solver-independent callback support is limited to a few solvers, including:
 
-!!! warning
-    While JuMP provides a solver-independent way of accessing callbacks, you
-    should not assume that you will see identical behavior when running the same
-    code on different solvers. For example, some solvers may ignore user-cuts
-    for various reasons, while other solvers may add every user-cut. Read the
-    underlying solver's callback documentation to understand details specific to
-    each solver.
+ * [CPLEX](https://github.com/jump-dev/CPLEX.jl)
+ * [GLPK](https://github.com/jump-dev/GLPK.jl)
+ * [Gurobi](https://github.com/jump-dev/Gurobi.jl)
+ * [SCIP](https://github.com/scipopt/SCIP.jl) (SCIP does not support lazy
+   constraints).
+ * [Xpress](https://github.com/jump-dev/Xpress.jl)
 
-!!! tip
-    This page discusses solver-_independent_ callbacks. However, each solver
-    listed above also provides a solver-_dependent_ callback to provide access
-    to the full range of solver-specific features. Consult the solver's README
-    for an example of how to use the solver-dependent callback. This will
-    require you to understand the C interface of the solver.
+Each solver listed above also provides a solver-_dependent_ callback to provide
+access to the full range of solver-specific features. Consult the solver's
+README for an example of how to use the solver-dependent callback. This will
+require you to understand the C interface of the solver.
 
 ## Things you can and cannot do during solver-independent callbacks
 
@@ -69,13 +67,9 @@ If you need to query any other information, use a solver-dependent callback
 instead. Each solver supporting a solver-dependent callback has information on
 how to use it in the README of their GitHub repository.
 
-If you want to modify the problem in a callback, you _must_ use a lazy
-constraint.
-
-!!! warning
-    You can only set each callback once. Calling `set` twice will over-write
-    the earlier callback. In addition, if you use a solver-independent
-    callback, you cannot set a solver-dependent callback.
+You can only set each callback once. Calling [`set_attribute`](@ref) twice will
+over-write the earlier callback. In addition, if you use a solver-independent
+callback, you cannot set a solver-dependent callback.
 
 ## Lazy constraints
 
@@ -122,28 +116,36 @@ my_callback_function (generic function with 1 method)
 julia> set_attribute(model, MOI.LazyConstraintCallback(), my_callback_function)
 ```
 
-!!! info
-    The lazy constraint callback _may_ be called at fractional or integer
-    nodes in the branch-and-bound tree. There is no guarantee that the
-    callback is called at _every_ primal solution.
+### Notes
 
-!!! warning
-    Only add a lazy constraint if your primal solution violates the constraint.
-    Adding the lazy constraint irrespective of feasibility may result in the
-    solver returning an incorrect solution, or lead to many constraints being
-    added, slowing down the solution process.
+ * The lazy constraint callback _may_ be called at fractional or integer nodes
+   in the branch-and-bound tree. Use [`callback_node_status`](@ref) to
+   distinguish.
+
+ * There is no guarantee that the callback is called at _every_ primal solution.
+
+ * The solver may visit a point that was cut off by a previous lazy constraint,
+   for example, because the earlier lazy constraint was removed during presolve.
+   If this happens, you must re-add the lazy constraint.
+
+ * Only add a lazy constraint if the primal solution violates the constraint.
+   Adding the lazy constraint irrespective of feasibility may result in the
+   solver returning an incorrect solution, or lead to many constraints being
+   added, slowing down the solution process. For example, instead of:
     ```julia
     model = Model()
     @variable(model, x <= 10, Int)
     @objective(model, Max, x)
     function bad_callback_function(cb_data)
-        # Don't do this!
         con = @build_constraint(x <= 2)
         MOI.submit(model, MOI.LazyConstraint(cb_data), con)
         return
     end
+    ```
+    do
+    ```julia
     function good_callback_function(cb_data)
-        if callback_value(x) > 2
+        if callback_value(cb_data, x) > 2
             con = @build_constraint(x <= 2)
             MOI.submit(model, MOI.LazyConstraint(cb_data), con)
         end
@@ -151,11 +153,6 @@ julia> set_attribute(model, MOI.LazyConstraintCallback(), my_callback_function)
     end
     set_attribute(model, MOI.LazyConstraintCallback(), good_callback_function)
     ```
-
-!!! warning
-    During the solve, a solver may visit a point that was cut off by a previous
-    lazy constraint, for example, because the earlier lazy constraint was removed
-    during presolve. If this happens, you must re-add the lazy constraint.
 
 ## User cuts
 
@@ -168,7 +165,7 @@ infeasible in the hopes of obtaining an integer solution. For more details
 about the difference between user cuts and lazy constraints see the
 aforementioned [blog post](https://orinanobworld.blogspot.com/2012/08/user-cuts-versus-lazy-constraints.html).
 
-A user-cut callback can be set using the following syntax:
+A user-cut callback can be added using the following syntax:
 
 ```jldoctest
 julia> model = Model();
@@ -190,16 +187,16 @@ my_callback_function (generic function with 1 method)
 julia> set_attribute(model, MOI.UserCutCallback(), my_callback_function)
 ```
 
-!!! warning
-    User cuts must not change the set of integer feasible solutions.
-    Equivalently, user cuts can only remove fractional solutions. If you add a
-    cut that removes an integer solution (even one that is not optimal), the
-    solver may return an incorrect solution.
+### Notes
 
-!!! info
-    The user-cut callback _may_ be called at fractional nodes in the
-    branch-and-bound tree. There is no guarantee that the callback is called
-    at _every_ fractional primal solution.
+ * User cuts **must not** change the set of integer feasible solutions.
+   Equivalently, user cuts can only remove fractional solutions. If you add a
+   cut that removes an integer solution (even one that is not optimal), the
+   solver may return an incorrect solution.
+
+ * The user-cut callback _may_ be called at fractional nodes in the
+   branch-and-bound tree. There is no guarantee that the callback is called at
+   _every_ fractional primal solution.
 
 ## Heuristic solutions
 
@@ -209,8 +206,8 @@ than plain branch-and-bound would to tighten the bound, allowing us to fathom
 nodes quicker and to tighten the integrality gap.
 
 Some heuristics take integer solutions and explore their "local neighborhood"
-(for example, flipping binary variables, fix some variables and solve a smaller MILP)
-and others take fractional solutions and attempt to round them in an
+(for example, flipping binary variables, fix some variables and solve a smaller
+MILP) and others take fractional solutions and attempt to round them in an
 intelligent way.
 
 You may want to add a heuristic of your own if you have some special insight
@@ -218,7 +215,7 @@ into the problem structure that the solver is not aware of, for example, you can
 consistently take fractional solutions and intelligently guess integer
 solutions from them.
 
-A heuristic solution callback can be set using the following syntax:
+A heuristic solution callback can be added using the following syntax:
 
 ```jldoctest
 julia> model = Model();
@@ -228,11 +225,17 @@ julia> @variable(model, x <= 10.5, Int);
 julia> @objective(model, Max, x);
 
 julia> function my_callback_function(cb_data)
-           x_val = callback_value(cb_data, x)
            status = MOI.submit(
-               model, MOI.HeuristicSolution(cb_data), [x], [floor(Int, x_val)]
+               model,
+               MOI.HeuristicSolution(cb_data),
+               [x],
+               # Heuristic solution by rounding down to nearest integer
+               Float64[floor(Int, callback_value(cb_data, x))],
            )
-           println("I submitted a heuristic solution, and the status was: ", status)
+           println(
+               "I submitted a heuristic solution, and the status was: ",
+               status,
+           )
            return
        end
 my_callback_function (generic function with 1 method)
@@ -240,21 +243,19 @@ my_callback_function (generic function with 1 method)
 julia> set_attribute(model, MOI.HeuristicCallback(), my_callback_function)
 ```
 
-The third argument to `submit` is a vector of JuMP variables, and the
-fourth argument is a vector of values corresponding to each variable.
+[`MOI.submit`](@ref) returns a [`MOI.HeuristicSolutionStatus`](@ref) enum that
+indicates whether the solver accepted the solution. The possible return codes
+are:
 
-`MOI.submit` returns an enum that depends on whether the solver accepted the
-solution. The possible return codes are:
+ - [`MOI.HEURISTIC_SOLUTION_ACCEPTED`](@ref)
+ - [`MOI.HEURISTIC_SOLUTION_REJECTED`](@ref)
+ - [`MOI.HEURISTIC_SOLUTION_UNKNOWN`](@ref)
 
- - `MOI.HEURISTIC_SOLUTION_ACCEPTED`
- - `MOI.HEURISTIC_SOLUTION_REJECTED`
- - `MOI.HEURISTIC_SOLUTION_UNKNOWN`
+### Notes
 
-!!! warning
-    Some solvers may accept partial solutions. Others require a feasible integer
-    solution for every variable. If in doubt, provide a complete solution.
+ * Some solvers may accept partial solutions. Others require a feasible integer
+   solution for every variable. If in doubt, provide a complete solution.
 
-!!! info
-    The heuristic solution callback _may_ be called at fractional nodes in the
-    branch-and-bound tree. There is no guarantee that the callback is called
-    at _every_ fractional primal solution.
+ * The heuristic solution callback _may_ be called at fractional nodes in the
+   branch-and-bound tree. There is no guarantee that the callback is called at
+   _every_ fractional primal solution.

--- a/docs/src/manual/callbacks.md
+++ b/docs/src/manual/callbacks.md
@@ -132,27 +132,27 @@ julia> set_attribute(model, MOI.LazyConstraintCallback(), my_callback_function)
    Adding the lazy constraint irrespective of feasibility may result in the
    solver returning an incorrect solution, or lead to many constraints being
    added, slowing down the solution process. For example, instead of:
-    ```julia
-    model = Model()
-    @variable(model, x <= 10, Int)
-    @objective(model, Max, x)
-    function bad_callback_function(cb_data)
-        con = @build_constraint(x <= 2)
-        MOI.submit(model, MOI.LazyConstraint(cb_data), con)
-        return
-    end
-    ```
-    do
-    ```julia
-    function good_callback_function(cb_data)
-        if callback_value(cb_data, x) > 2
-            con = @build_constraint(x <= 2)
-            MOI.submit(model, MOI.LazyConstraint(cb_data), con)
-        end
-        return
-    end
-    set_attribute(model, MOI.LazyConstraintCallback(), good_callback_function)
-    ```
+   ```julia
+   model = Model()
+   @variable(model, x <= 10, Int)
+   @objective(model, Max, x)
+   function bad_callback_function(cb_data)
+       con = @build_constraint(x <= 2)
+       MOI.submit(model, MOI.LazyConstraint(cb_data), con)
+       return
+   end
+   ```
+   do
+   ```julia
+   function good_callback_function(cb_data)
+       if callback_value(cb_data, x) > 2
+           con = @build_constraint(x <= 2)
+           MOI.submit(model, MOI.LazyConstraint(cb_data), con)
+       end
+       return
+   end
+   set_attribute(model, MOI.LazyConstraintCallback(), good_callback_function)
+   ```
 
 ## User cuts
 


### PR DESCRIPTION
Preview: https://jump.dev/JuMP.jl/previews/PR3977/manual/callbacks/

I get a bit overwhelmed trying to read the page because there are so many warnings and admonition boxes: https://jump.dev/JuMP.jl/stable/manual/callbacks/#Lazy-constraints

<img width="770" alt="image" src="https://github.com/user-attachments/assets/79933564-99dc-437f-af06-ac6553efce30" />
