### PR TITLE
Add print_macro_timing_summary

### DIFF
--- a/docs/src/tutorials/getting_started/debugging.jl
+++ b/docs/src/tutorials/getting_started/debugging.jl
@@ -394,11 +394,11 @@ end
 
 begin
     N = 200
-    demand = vcat(-1.0, zeros(N - 2), 1.0);
-    edges = [(i, j) for i in 1:N for j in 1:N if i < j];
+    demand = vcat(-1.0, zeros(N - 2), 1.0)
+    edges = [(i, j) for i in 1:N for j in 1:N if i < j]
     model = Model()
     set_macro_timing(model, true)
-    @variable(model, flows[e in edges] >= 0);
+    @variable(model, flows[e in edges] >= 0)
     @constraint(
         model,
         [n in 1:N],

--- a/docs/src/tutorials/getting_started/debugging.jl
+++ b/docs/src/tutorials/getting_started/debugging.jl
@@ -386,7 +386,39 @@ end
 #   you do not have enough memory to store the model. Use a computer with more
 #   RAM.
 
-# ### Strategies
+# ### Macro timing
+
+# JuMP has a built-in feature that can measure the time spent in each macro.
+# Turn it on using [`set_macro_timing`](@ref), build the model, and then use
+# [`print_macro_timing_summary`](@ref) to print a summary. Here's an example:
+
+begin
+    N = 200
+    demand = vcat(-1.0, zeros(N - 2), 1.0);
+    edges = [(i, j) for i in 1:N for j in 1:N if i < j];
+    model = Model()
+    set_macro_timing(model, true)
+    @variable(model, flows[e in edges] >= 0);
+    @constraint(
+        model,
+        [n in 1:N],
+        sum(flows[(i, j)] for (i, j) in edges if j == n) -
+        sum(flows[(i, j)] for (i, j) in edges if i == n) == demand[n]
+    )
+    print_macro_timing_summary(model)
+end
+
+# In this case, you can see that the `@constraint` call dominates the runtime.
+# If it isn't obvious why that is, read the [Performance problems with sum-if formulations](@ref)
+# tutorial.
+
+# Note that the macro timing feature measures only the time spent inside JuMP
+# macros. It does not measure regular Julia code outside the macros.
+
+# ### Other strategies
+
+# If the macro timing feature does not reveal the bottleneck, it means that your
+# issue is in regular Julia code that is not inside a JuMP macro.
 
 # The strategy to debug JuMP models that have performance problems depends on
 # how long your model takes to build.

--- a/src/Containers/macro.jl
+++ b/src/Containers/macro.jl
@@ -325,15 +325,24 @@ end
 _strip_LineNumberNode(x) = x
 
 """
+    build_macro_expression_string(macro_name, args)
+
+Reconstruct a string of the macro input expression from the name and arguments.
+"""
+function build_macro_expression_string(macro_name, args)
+    str_args = join(_strip_LineNumberNode.(args), ", ")
+    return string("`@", macro_name, "(", str_args, ")`")
+end
+
+"""
     build_error_fn(macro_name, args, source)
 
 Return a function that can be used in place of `Base.error`, but which
 additionally prints the macro from which it was called.
 """
 function build_error_fn(macro_name, args, source)
-    str_args = join(_strip_LineNumberNode.(args), ", ")
-    msg = "At $(source.file):$(source.line): `@$macro_name($str_args)`: "
-    error_fn(str...) = error(msg, str...)
+    msg = build_macro_expression_string(macro_name, args)
+    error_fn(str...) = error("At $(source.file):$(source.line): $msg: ", str...)
     return error_fn
 end
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -126,6 +126,8 @@ mutable struct GenericModel{T<:Real} <: AbstractModel
     set_string_names_on_creation::Bool
     #
     variable_in_set_ref::Dict{Any,MOI.ConstraintIndex}
+    # A dictionary to store timing information from the JuMP macros.
+    macro_times::Dict{Tuple{LineNumberNode,String},Float64}
 end
 
 value_type(::Type{GenericModel{T}}) where {T} = T
@@ -237,6 +239,7 @@ function direct_generic_model(
         Dict{Symbol,Any}(),
         true,
         Dict{Any,MOI.ConstraintIndex}(),
+        Dict{Tuple{LineNumberNode,String},Float64}(),
     )
 end
 
@@ -937,6 +940,7 @@ function Base.empty!(model::GenericModel)::GenericModel
     model.nlp_model = nothing
     empty!(model.obj_dict)
     empty!(model.ext)
+    empty!(model.macro_times)
     model.is_model_dirty = false
     return model
 end

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -127,6 +127,7 @@ mutable struct GenericModel{T<:Real} <: AbstractModel
     #
     variable_in_set_ref::Dict{Any,MOI.ConstraintIndex}
     # A dictionary to store timing information from the JuMP macros.
+    enable_macro_timing::Bool
     macro_times::Dict{Tuple{LineNumberNode,String},Float64}
 end
 
@@ -239,6 +240,7 @@ function direct_generic_model(
         Dict{Symbol,Any}(),
         true,
         Dict{Any,MOI.ConstraintIndex}(),
+        false,
         Dict{Tuple{LineNumberNode,String},Float64}(),
     )
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -510,7 +510,7 @@ Use [`print_macro_timing_summary`](@ref) to display a summary.
 
 ## Example
 
-```jldoctest; filter=[r"Total time: .+ seconds", r"├.+", r"└.+"]
+```jldoctest; filter=[r"Total time inside macros: .+ seconds", r"├.+", r"└.+"]
 julia> begin
            model = Model()
            set_macro_timing(model, true)
@@ -519,7 +519,7 @@ julia> begin
        end;
 
 julia> print_macro_timing_summary(model)
-Total time: 5.33690e-02 seconds
+Total time inside macros: 5.33690e-02 seconds
 │
 ├ 2.96490e-02 s [55.55%]
 │ ├ REPL[8]:3
@@ -542,6 +542,8 @@ function _string_summary(x)
     return x[1:32] * " [...] " * x[end-31:end]
 end
 
+_format_time(x::Float64) = string(_format(x), " seconds")
+
 """
     print_macro_timing_summary([io::IO = stdout], model::GenericModel)
 
@@ -552,7 +554,7 @@ Before calling this method, you must have enabled the macro timing feature using
 
 ## Example
 
-```jldoctest; filter=[r"Total time: .+ seconds", r"├.+", r"└.+"]
+```jldoctest; filter=[r"Total time inside macros: .+ seconds", r"├.+", r"└.+"]
 julia> begin
            model = Model()
            set_macro_timing(model, true)
@@ -561,7 +563,7 @@ julia> begin
        end;
 
 julia> print_macro_timing_summary(model)
-Total time: 5.33690e-02 seconds
+Total time inside macros: 5.33690e-02 seconds
 │
 ├ 2.96490e-02 s [55.55%]
 │ ├ REPL[8]:3
@@ -575,13 +577,13 @@ Total time: 5.33690e-02 seconds
 function print_macro_timing_summary(io::IO, model::GenericModel)
     total_time = sum(values(model.macro_times))
     times = sort!(collect(model.macro_times); by = last, rev = true)
-    println(io, "Total time: ", JuMP._format(total_time), " seconds")
+    println(io, "Total time inside macros: ", _format_time(total_time))
     for i in 1:length(times)
         (source, expr), time = times[i]
         percent = round(100 * time / total_time; digits = 2)
         a, b = ifelse(i < length(times), ('├', '│'), ('└', ' '))
         println(io, "│")
-        println(io, "$a ", JuMP._format(time), " s [$percent%]")
+        println(io, "$a ", _format(time), " s [$percent%]")
         println(io, "$b ├ $(source.file):$(source.line)")
         println(io, "$b └ ", replace(_string_summary(expr), "\n" => ""))
     end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -530,7 +530,7 @@ Total time: 5.33690e-02 seconds
   └ `@objective(model, Min, sum(x))`
 ```
 """
-function set_macro_timing(::GenericModel, value::Bool)
+function set_macro_timing(model::GenericModel, value::Bool)
     model.enable_macro_timing = value
     return
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -392,24 +392,48 @@ function _finalize_macro(
     source::LineNumberNode;
     register_name::Union{Nothing,Symbol} = nothing,
     wrap_let::Bool = false,
+    time_it::Union{Nothing,String} = nothing,
 )
     @assert Meta.isexpr(model, :escape)
-    if wrap_let && model.args[1] isa Symbol
-        code = quote
-            let $model = $model
+    ret = gensym()
+    code = if wrap_let && model.args[1] isa Symbol
+        quote
+            $ret = let $model = $model
                 $code
             end
         end
+    else
+        :($ret = $code)
     end
     if register_name !== nothing
         sym_name = Meta.quot(register_name)
         code = quote
             _error_if_cannot_register($model, $sym_name)
-            $(esc(register_name)) = $model[$sym_name] = $code
+            $code
+            $(esc(register_name)) = $model[$sym_name] = $ret
+        end
+    end
+    if time_it !== nothing
+        code = quote
+            start_time = time()
+            $code
+            _add_or_set_macro_time(
+                $model,
+                ($(QuoteNode(source)), $time_it),
+                time() - start_time,
+            )
+            $ret
         end
     end
     is_valid_code = :(_valid_model($model, $(Meta.quot(model.args[1]))))
     return Expr(:block, source, is_valid_code, code)
+end
+
+_add_or_set_macro_time(model::AbstractModel, key, value) = nothing
+
+function _add_or_set_macro_time(model::GenericModel, key, value)
+    model.macro_times[key] = get!(model.macro_times, key, 0.0) + value
+    return
 end
 
 function _error_if_cannot_register(model::AbstractModel, name::Symbol)
@@ -472,6 +496,59 @@ function _plural_macro_code(model, block, macro_sym)
         end
     end
     return code
+end
+
+function _string_summary(x)
+    if length(x) <= 75
+        return x
+    end
+    return x[1:32] * " [...] " * x[end-31:end]
+end
+
+"""
+    print_macro_timing_summary([io::IO = stdout], model::GenericModel)
+
+Print a summary of the runtime of each macro.
+
+## Example
+
+```jldoctest; filter=[r"Total time: .+ seconds", r"├.+", r"└.+"]
+julia> begin
+           model = Model()
+           @variable(model, x[1:2])
+           @objective(model, Min, sum(x))
+       end;
+
+julia> print_macro_timing_summary(model)
+Total time: 5.33690e-02 seconds
+│
+├ 2.96490e-02 s [55.55%]
+│ ├ REPL[8]:3
+│ └ `@variable(model, x[1:2])`
+│
+└ 2.37200e-02 s [44.45%]
+  ├ REPL[8]:4
+  └ `@objective(model, Min, sum(x))`
+```
+"""
+function print_macro_timing_summary(io::IO, model::GenericModel)
+    total_time = sum(values(model.macro_times))
+    times = sort!(collect(model.macro_times); by = last, rev = true)
+    println(io, "Total time: ", JuMP._format(total_time), " seconds")
+    for i in 1:length(times)
+        (source, expr), time = times[i]
+        percent = round(100 * time / total_time; digits = 2)
+        a, b = ifelse(i < length(times), ('├', '│'), ('└', ' '))
+        println(io, "│")
+        println(io, "$a ", JuMP._format(time), " s [$percent%]")
+        println(io, "$b ├ $(source.file):$(source.line)")
+        println(io, "$b └ ", replace(_string_summary(expr), "\n" => ""))
+    end
+    return
+end
+
+function print_macro_timing_summary(model::GenericModel)
+    return print_macro_timing_summary(stdout, model)
 end
 
 for file in readdir(joinpath(@__DIR__, "macros"))

--- a/src/macros/@constraint.jl
+++ b/src/macros/@constraint.jl
@@ -179,6 +179,10 @@ macro constraint(input_args...)
         __source__;
         register_name = name,
         wrap_let = true,
+        time_it = Containers.build_macro_expression_string(
+            :constraint,
+            input_args,
+        ),
     )
 end
 

--- a/src/macros/@expression.jl
+++ b/src/macros/@expression.jl
@@ -94,6 +94,10 @@ macro expression(input_args...)
         __source__;
         register_name = name,
         wrap_let = true,
+        time_it = Containers.build_macro_expression_string(
+            :expression,
+            input_args,
+        ),
     )
 end
 

--- a/src/macros/@force_nonlinear.jl
+++ b/src/macros/@force_nonlinear.jl
@@ -84,10 +84,10 @@ julia> @expression(model, @force_nonlinear(x * 2.0 * (1 + x) * x))
 x * 2.0 * (1 + x) * x
 
 julia> @allocated @expression(model, x * 2.0 * (1 + x) * x)
-3584
+3680
 
 julia> @allocated @expression(model, @force_nonlinear(x * 2.0 * (1 + x) * x))
-672
+768
 ```
 """
 macro force_nonlinear(expr)

--- a/src/macros/@objective.jl
+++ b/src/macros/@objective.jl
@@ -107,7 +107,15 @@ macro objective(input_args...)
         set_objective($esc_model, $sense, $expr)
         $expr
     end
-    return _finalize_macro(esc_model, code, __source__)
+    return _finalize_macro(
+        esc_model,
+        code,
+        __source__;
+        time_it = Containers.build_macro_expression_string(
+            :objective,
+            input_args,
+        ),
+    )
 end
 
 function _parse_moi_sense(error_fn::Function, sense)

--- a/src/macros/@variable.jl
+++ b/src/macros/@variable.jl
@@ -320,6 +320,10 @@ macro variable(input_args...)
         __source__;
         register_name = name,
         wrap_let = true,
+        time_it = Containers.build_macro_expression_string(
+            :variable,
+            input_args,
+        ),
     )
 end
 


### PR DESCRIPTION
This is still somewhat of a WIP. We need to:

 - [x] Decide whether to add this, or document more general ways of profiling Julia code
 - [x] Decide whether to make this always on, or opt-in
 - [x] Decide what information to store
 - [x] Decide when to clear the dictionary
 - [x] Add better documentation

Related to #3664

My demo for why this is useful is https://github.com/olejandro/TIMES.jl. Three constraints take 60% of the total macro build time.
```julia
julia> include("demo.jl")
Create demo: 0.077038 seconds (314.69 k allocations: 16.376 MiB, 18.66% compilation time)
Running HiGHS 1.10.0 (git hash: fd8665394e): Copyright (c) 2025 HiGHS under MIT licence terms
LP   has 604 rows; 950 cols; 1920 nonzeros
Coefficient ranges:
  Matrix [1e-02, 1e+04]
  Cost   [1e+00, 1e+00]
  Bound  [1e-01, 1e+01]
  RHS    [9e-02, 8e+03]
Presolving model
265 rows, 287 cols, 965 nonzeros  0s
Dependent equations search running on 25 equations with time limit of 1000.00s
Dependent equations search removed 0 rows and 0 nonzeros in 0.00s (limit = 1000.00s)
228 rows, 245 cols, 826 nonzeros  0s
Presolve : Reductions: rows 228(-376); columns 245(-705); elements 826(-1094)
Solving the presolved LP
Using EKK dual simplex solver - serial
  Iteration        Objective     Infeasibilities num(sum)
          0     1.2861637975e+04 Pr: 30(74.9799) 0s
        157     3.8706151237e+04 Pr: 0(0); Du: 0(4.9738e-14) 0s
Solving the original LP from the solution after postsolve
Model status        : Optimal
Simplex   iterations: 157
Objective value     :  3.8706151237e+04
Relative P-D gap    :  3.7595872395e-16
HiGHS run time      :          0.00
Solve model: 0.006873 seconds (13.25 k allocations: 1.235 MiB)
Total time: 1.41840e-02 seconds
│
├ 3.39603e-03 s [23.94%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/constraints.jl:287
│ └ `@constraint(model, EQ_PTRANS[(r [...] or ts = sets.RPC_TS[r, p, c])))`
│
├ 3.31283e-03 s [23.36%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/constraints.jl:307
│ └ `@constraint(model, EQG_COMBAL[( [...]  * (data[:COM_FR])[r, t, c, s])`
│
├ 2.64120e-03 s [18.62%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/constraints.jl:88
│ └ `@constraint(model, EQL_CAPACT[( [...] RTP_CPT[r, y, p]))        end)`
│
├ 7.82967e-04 s [5.52%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/variables.jl:13
│ └ `@variable(model, PrcFlo[indices["var_PrcFlo"]] >= 0)`
│
├ 6.01053e-04 s [4.24%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/constraints.jl:74
│ └ `@constraint(model, EQ_ACTFLO[(r [...] nd for c = sets.RP_PGC[r, p])))`
│
├ 5.24044e-04 s [3.69%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/constraints.jl:225
│ └ `@expression(model, EXPR_FLOSHR[ [...] f c in sets.RPIO_C[r, p, io])))`
│
├ 4.39882e-04 s [3.1%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/constraints.jl:46
│ └ `@constraint(model, EQ_OBJVAR[(r [...] )) == RegObj["OBJVAR", r, cur])`
│
├ 3.83854e-04 s [2.71%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/constraints.jl:538
│ └ `@constraint(model, EQ_STGTSS[(r [...] s, all_s) in data[:RS_PRETS])))`
│
├ 2.97070e-04 s [2.09%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/variables.jl:12
│ └ `@variable(model, PrcAct[indices["var_PrcAct"]] >= 0)`
│
├ 2.17915e-04 s [1.54%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/constraints.jl:237
│ └ `@constraint(model, EQL_FLOSHR[( [...]  <= PrcFlo[(r, v, t, p, c, s)])`
│
├ 1.98126e-04 s [1.4%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/constraints.jl:18
│ └ `@constraint(model, EQ_OBJINV[(r [...] or (v, t, p) = sets.R_CPT[r])))`
│
├ 1.74999e-04 s [1.23%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/variables.jl:10
│ └ `@variable(model, lo(:CAP_BND, i [...] r_PrcCap"]] <= up(:CAP_BND, i))`
│
├ 1.49965e-04 s [1.06%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/constraints.jl:33
│ └ `@constraint(model, EQ_OBJFIX[(r [...] )) == RegObj["OBJFIX", r, cur])`
│
├ 1.49012e-04 s [1.05%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/variables.jl:11
│ └ `@variable(model, lo(:NCAP_BND,  [...] _PrcCap"]] <= up(:NCAP_BND, i))`
│
├ 1.14918e-04 s [0.81%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/variables.jl:8
│ └ `@variable(model, ComPrd[indices["var_ComPrd"]] >= 0)`
│
├ 1.08957e-04 s [0.77%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/variables.jl:15
│ └ `@variable(model, StgFlo[indices["var_StgFlo"]] >= 0)`
│
├ 1.07050e-04 s [0.75%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/constraints.jl:198
│ └ `@constraint(model, EQL_CPT[(r,  [...] s.RTP_CPT, (r, y, p), Set()))))`
│
├ 1.02997e-04 s [0.73%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/constraints.jl:211
│ └ `@constraint(model, EQG_CPT[(r,  [...] s.RTP_CPT, (r, y, p), Set()))))`
│
├ 9.29832e-05 s [0.66%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/constraints.jl:185
│ └ `@constraint(model, EQE_CPT[(r,  [...] s.RTP_CPT, (r, y, p), Set()))))`
│
├ 8.89301e-05 s [0.63%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/variables.jl:9
│ └ `@variable(model, ComNet[indices["var_ComNet"]] >= 0)`
│
├ 6.60419e-05 s [0.47%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/variables.jl:14
│ └ `@variable(model, IreFlo[indices["var_IreFlo"]] >= 0)`
│
├ 4.98295e-05 s [0.35%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/variables.jl:7
│ └ `@variable(model, RegObj[OBV, data[:REGION], data[:CURRENCY]] >= 0)`
│
├ 4.72069e-05 s [0.33%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/constraints.jl:249
│ └ `@constraint(model, EQE_FLOSHR[( [...]  == PrcFlo[(r, v, t, p, c, s)])`
│
├ 2.88486e-05 s [0.2%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/parameters.jl:5
│ └ `@expression(model, MILE[y in da [...] [:MILEYR]    1else    0end)`
│
├ 2.28882e-05 s [0.16%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/constraints.jl:120
│ └ `@constraint(model, EQG_CAPACT[( [...] RTP_CPT[r, y, p]))        end)`
│
├ 1.90735e-05 s [0.13%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/objective.jl:5
│ └ `@objective(model, Min, sum((Reg [...]  for (r, cur) = data[:RDCUR])))`
│
├ 1.69277e-05 s [0.12%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/constraints.jl:402
│ └ `@constraint(model, EQE_COMBAL[( [...]  * (data[:COM_FR])[r, t, c, s])`
│
├ 1.47820e-05 s [0.1%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/constraints.jl:243
│ └ `@constraint(model, EQG_FLOSHR[( [...]  >= PrcFlo[(r, v, t, p, c, s)])`
│
├ 1.28746e-05 s [0.09%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/constraints.jl:257
│ └ `@constraint(model, EQE_ACTEFF[( [...] )) for ts = sets.RP_TS[r, p])))`
│
├ 1.09673e-05 s [0.08%]
│ ├ /Users/oscar/.julia/dev/TIMES/src/constraints.jl:152
│ └ `@constraint(model, EQE_CAPACT[( [...] RTP_CPT[r, y, p]))        end)`
│
└ 9.77516e-06 s [0.07%]
  ├ /Users/oscar/.julia/dev/TIMES/src/constraints.jl:499
  └ `@constraint(model, EQE_COMPRD[( [...]  c, s] == ComPrd[(r, t, c, s)])`
```