### PR TITLE
Fix show of SparseAxisArray for small display size

### DIFF
--- a/src/Containers/SparseAxisArray.jl
+++ b/src/Containers/SparseAxisArray.jl
@@ -467,7 +467,7 @@ function Base.show(io::IOContext, x::SparseAxisArray)
         (i, (key, value)) in enumerate(x.data) if
         i < half_screen_rows || i > length(x) - half_screen_rows
     ]
-    pad = maximum(length(x[1]) for x in key_strings)
+    pad = maximum((length(x[1]) for x in key_strings), init = 0)
     for (i, (key, value)) in enumerate(key_strings)
         print(io, "  [", rpad(key, pad), "]  =  ", value)
         if i != length(key_strings)

--- a/src/Containers/SparseAxisArray.jl
+++ b/src/Containers/SparseAxisArray.jl
@@ -467,7 +467,7 @@ function Base.show(io::IOContext, x::SparseAxisArray)
         (i, (key, value)) in enumerate(x.data) if
         i < half_screen_rows || i > length(x) - half_screen_rows
     ]
-    pad = maximum((length(x[1]) for x in key_strings), init = 0)
+    pad = maximum((length(x[1]) for x in key_strings); init = 0)
     for (i, (key, value)) in enumerate(key_strings)
         print(io, "  [", rpad(key, pad), "]  =  ", value)
         if i != length(key_strings)

--- a/test/Containers/test_SparseAxisArray.jl
+++ b/test/Containers/test_SparseAxisArray.jl
@@ -395,4 +395,14 @@ function test_empty_vector_indices()
     return
 end
 
+function test_small_displaysize()
+    for row in 0:9
+        d = Containers.container(+, [(1, 2)], Containers.SparseAxisArray)
+        io = IOContext(IOBuffer(), :limit => true, :displaysize => (row, 80))
+        show(io, d)
+        @test String(take!(io.io)) == ""
+    end
+    return
+end
+
 end  # module


### PR DESCRIPTION
If you execute a line that returns a `SparseAxisArray` on VS code and the REPL window is too small you get
```julia
JuMP.Containers.SparseAxisArray{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}, 2, Tuple{Int64, Int64}} with 28 entries:
ERROR: ArgumentError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer
Stacktrace:
  [1] _empty_reduce_error()
    @ Base ./reduce.jl:319
  [2] mapreduce_empty(f::Function, op::Base.BottomRF{typeof(max)}, T::Type)
    @ Base ./reduce.jl:321
  [3] reduce_empty(op::Base.MappingRF{JuMP.Containers.var"#73#76", Base.BottomRF{typeof(max)}}, ::Type{Tuple{String, ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}}})
    @ Base ./reduce.jl:358
  [4] reduce_empty_iter
    @ ./reduce.jl:381 [inlined]
  [5] reduce_empty_iter
    @ ./reduce.jl:380 [inlined]
  [6] foldl_impl
    @ ./reduce.jl:49 [inlined]
  [7] mapfoldl_impl
    @ ./reduce.jl:44 [inlined]
  [8] mapfoldl
    @ ./reduce.jl:175 [inlined]
  [9] mapreduce
    @ ./reduce.jl:307 [inlined]
 [10] maximum
    @ ./reduce.jl:761 [inlined]
 [11] show(io::IOContext{Base.TTY}, x::JuMP.Containers.SparseAxisArray{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}, 2, Tuple{Int64, Int64}})
    @ JuMP.Containers ~/.julia/packages/JuMP/RGIK3/src/Containers/SparseAxisArray.jl:470
 [12] show(io::IOContext{Base.TTY}, ::MIME{Symbol("text/plain")}, sa::JuMP.Containers.SparseAxisArray{ConstraintRef{Model, MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}, 2, Tuple{Int64, Int64}})
    @ JuMP.Containers ~/.julia/packages/JuMP/RGIK3/src/Containers/SparseAxisArray.jl:449
 [13] (::REPL.var"#68#69"{REPL.REPLDisplay{REPL.LineEditREPL}, MIME{Symbol("text/plain")}, Base.RefValue{Any}})(io::Any)
    @ REPL ~/.julia/juliaup/julia-1.11.5+0.x64.linux.gnu/share/julia/stdlib/v1.11/REPL/src/REPL.jl:394
 [14] with_repl_linfo(f::Any, repl::REPL.LineEditREPL)
    @ REPL ~/.julia/juliaup/julia-1.11.5+0.x64.linux.gnu/share/julia/stdlib/v1.11/REPL/src/REPL.jl:678
 [15] display(d::REPL.REPLDisplay, mime::MIME{Symbol("text/plain")}, x::Any)
    @ REPL ~/.julia/juliaup/julia-1.11.5+0.x64.linux.gnu/share/julia/stdlib/v1.11/REPL/src/REPL.jl:380
 [16] display(d::REPL.REPLDisplay, x::Any)
    @ REPL ~/.julia/juliaup/julia-1.11.5+0.x64.linux.gnu/share/julia/stdlib/v1.11/REPL/src/REPL.jl:399
 [17] display(x::Any)
    @ Base.Multimedia ./multimedia.jl:340
 [18] #invokelatest#2
    @ ./essentials.jl:1055 [inlined]
 [19] invokelatest
    @ ./essentials.jl:1052 [inlined]
 [20] (::VSCodeServer.var"#69#74"{Bool, Bool, Bool, Module, String, Int64, Int64, String, VSCodeServer.ReplRunCodeRequestParams})()
    @ VSCodeServer ~/.vscode/extensions/julialang.language-julia-1.140.2/scripts/packages/VSCodeServer/src/eval.jl:237
 [21] withpath(f::VSCodeServer.var"#69#74"{Bool, Bool, Bool, Module, String, Int64, Int64, String, VSCodeServer.ReplRunCodeRequestParams}, path::String)
    @ VSCodeServer ~/.vscode/extensions/julialang.language-julia-1.140.2/scripts/packages/VSCodeServer/src/repl.jl:276
```
This PR fixes the issue