### PR TITLE
Fix LinearAlgebra.issymmetric(::AbstractJuMPScalar)

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -1218,6 +1218,8 @@ function LinearAlgebra.hermitian(x::F, ::Symbol) where {F<:AbstractJuMPScalar}
     return convert(F, real(x))
 end
 
+LinearAlgebra.ishermitian(x::AbstractJuMPScalar) = isreal(x)
+
 LinearAlgebra.adjoint(scalar::AbstractJuMPScalar) = conj(scalar)
 
 Base.iterate(x::AbstractJuMPScalar) = (x, true)

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -1207,8 +1207,12 @@ Base.eltype(::Type{T}) where {T<:AbstractJuMPScalar} = T
 
 # These are required to create symmetric containers of AbstractJuMPScalars.
 LinearAlgebra.symmetric_type(::Type{T}) where {T<:AbstractJuMPScalar} = T
-LinearAlgebra.hermitian_type(::Type{T}) where {T<:AbstractJuMPScalar} = T
+
 LinearAlgebra.symmetric(scalar::AbstractJuMPScalar, ::Symbol) = scalar
+
+LinearAlgebra.issymmetric(::AbstractJuMPScalar) = true
+
+LinearAlgebra.hermitian_type(::Type{T}) where {T<:AbstractJuMPScalar} = T
 
 function LinearAlgebra.hermitian(x::F, ::Symbol) where {F<:AbstractJuMPScalar}
     return convert(F, real(x))

--- a/test/test_operator.jl
+++ b/test/test_operator.jl
@@ -739,7 +739,23 @@ function test_is_symmetric()
     @test !LinearAlgebra.issymmetric([x[1] x[2]; x[3] x[3]])
     @test !LinearAlgebra.issymmetric([x[1] x[2]])
     @test LinearAlgebra.issymmetric([x[1] x[2]; x[2] x[3]])
+    @test LinearAlgebra.issymmetric(x[1])
+    @test LinearAlgebra.issymmetric(1.0 * x[1] + 2.0)
+    @test LinearAlgebra.issymmetric(x[1] * x[1])
+    @test LinearAlgebra.issymmetric(log(x[1]))
     return
 end
 
+function test_is_hermitian()
+    model = Model()
+    @variable(model, x)
+    @test LinearAlgebra.ishermitian(x)
+    @test LinearAlgebra.ishermitian(1.0 * x + 2.0)
+    @test LinearAlgebra.ishermitian(x^2)
+    @test LinearAlgebra.ishermitian(log(x))
+    @test !LinearAlgebra.ishermitian(2.0 * im * x)
+    @test !LinearAlgebra.ishermitian(2.0 * im * x * x)
+    return
 end
+
+end  # module


### PR DESCRIPTION
Tests are failing on `nightly` because of https://github.com/JuliaLang/LinearAlgebra.jl/commit/6e8f9a1870dc21712a6feac8fb48511d1a8f82ba