### PR TITLE
Add value(::Function, ::X) and value(::X; result::Int) for Symmetric and Hermitian

### DIFF
--- a/src/sd.jl
+++ b/src/sd.jl
@@ -232,7 +232,7 @@ function reshape_vector(
     matrix = Matrix{T}(undef, shape.side_dimension, shape.side_dimension)
     k = 0
     for j in 1:shape.side_dimension
-        for i in 1:j-1
+        for i in 1:(j-1)
             k += 1
             matrix[j, i] = matrix[i, j] = 0.5 * v[k]
         end
@@ -306,7 +306,7 @@ end
 
 function vectorize(matrix, ::SkewSymmetricMatrixShape)
     n = LinearAlgebra.checksquare(matrix)
-    return [matrix[i, j] for j in 1:n for i in 1:j-1]
+    return [matrix[i, j] for j in 1:n for i in 1:(j-1)]
 end
 
 """
@@ -432,7 +432,7 @@ end
 
 function value(
     Q::LinearAlgebra.Symmetric{V,Matrix{V}},
-) where {V<:AbstractVariableRef}
+) where {V<:AbstractJuMPScalar}
     return LinearAlgebra.Symmetric(
         value.(LinearAlgebra.parent(Q)),
         LinearAlgebra.sym_uplo(Q.uplo),
@@ -667,6 +667,15 @@ function build_variable(
         _vectorize_complex_variables(error_fn, variables),
         set,
         shape,
+    )
+end
+
+function value(
+    Q::LinearAlgebra.Hermitian{V,Matrix{V}},
+) where {V<:AbstractJuMPScalar}
+    return LinearAlgebra.Hermitian(
+        value.(LinearAlgebra.parent(Q)),
+        LinearAlgebra.sym_uplo(Q.uplo),
     )
 end
 

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -430,15 +430,6 @@ function build_variable(
     return build_variable(error_fn, variables, set)
 end
 
-function value(
-    Q::LinearAlgebra.Symmetric{V,Matrix{V}},
-) where {V<:AbstractJuMPScalar}
-    return LinearAlgebra.Symmetric(
-        value.(LinearAlgebra.parent(Q)),
-        LinearAlgebra.sym_uplo(Q.uplo),
-    )
-end
-
 function build_constraint(
     error_fn::Function,
     Q::LinearAlgebra.Symmetric{V,M},
@@ -670,15 +661,6 @@ function build_variable(
     )
 end
 
-function value(
-    Q::LinearAlgebra.Hermitian{V,Matrix{V}},
-) where {V<:AbstractJuMPScalar}
-    return LinearAlgebra.Hermitian(
-        value.(LinearAlgebra.parent(Q)),
-        LinearAlgebra.sym_uplo(Q.uplo),
-    )
-end
-
 function build_constraint(
     ::Function,
     Q::LinearAlgebra.Hermitian{V,M},
@@ -870,4 +852,44 @@ for S in (Nonnegatives, Nonpositives, Zeros)
             end
         end
     end
+end
+
+function value(
+    var_value::Function,
+    Q::LinearAlgebra.Symmetric{V,Matrix{V}},
+) where {V<:AbstractJuMPScalar}
+    return LinearAlgebra.Symmetric(
+        value.(var_value, LinearAlgebra.parent(Q)),
+        LinearAlgebra.sym_uplo(Q.uplo),
+    )
+end
+
+function value(
+    Q::LinearAlgebra.Symmetric{V,Matrix{V}};
+    result::Int = 1,
+) where {V<:AbstractJuMPScalar}
+    return LinearAlgebra.Symmetric(
+        value.(LinearAlgebra.parent(Q); result),
+        LinearAlgebra.sym_uplo(Q.uplo),
+    )
+end
+
+function value(
+    var_value::Function,
+    Q::LinearAlgebra.Hermitian{V,Matrix{V}},
+) where {V<:AbstractJuMPScalar}
+    return LinearAlgebra.Hermitian(
+        value.(var_value, LinearAlgebra.parent(Q)),
+        LinearAlgebra.sym_uplo(Q.uplo),
+    )
+end
+
+function value(
+    Q::LinearAlgebra.Hermitian{V,Matrix{V}};
+    result::Int = 1,
+) where {V<:AbstractJuMPScalar}
+    return LinearAlgebra.Hermitian(
+        value.(LinearAlgebra.parent(Q); result),
+        LinearAlgebra.sym_uplo(Q.uplo),
+    )
 end

--- a/src/sd.jl
+++ b/src/sd.jl
@@ -232,7 +232,7 @@ function reshape_vector(
     matrix = Matrix{T}(undef, shape.side_dimension, shape.side_dimension)
     k = 0
     for j in 1:shape.side_dimension
-        for i in 1:(j-1)
+        for i in 1:j-1
             k += 1
             matrix[j, i] = matrix[i, j] = 0.5 * v[k]
         end
@@ -306,7 +306,7 @@ end
 
 function vectorize(matrix, ::SkewSymmetricMatrixShape)
     n = LinearAlgebra.checksquare(matrix)
-    return [matrix[i, j] for j in 1:n for i in 1:(j-1)]
+    return [matrix[i, j] for j in 1:n for i in 1:j-1]
 end
 
 """

--- a/test/test_generate_and_solve.jl
+++ b/test/test_generate_and_solve.jl
@@ -433,9 +433,9 @@ function test_generate_solve_complex_SDP()
     JuMP._eval_as_variable(_set_val, x[2, 2], 2.0)
     optimize!(m)
 
-    @test [2.0 1.0 + 1.0im; 1.0 - 1.0im 2.0] == value.(x)
+    @test [2.0 1.0+1.0im; 1.0-1.0im 2.0] == value.(x)
     @test value(x) isa Hermitian
-    @test [2.0 1.0 + 1.0im; 1.0 - 1.0im 2.0] == @inferred value(x)
+    @test [2.0 1.0+1.0im; 1.0-1.0im 2.0] == @inferred value(x)
     return
 end
 


### PR DESCRIPTION
Closes #3998 

I also took the liberty of generalizing `value(::Symmetric)` to work with `AbstractJuMPScalar`, as it was failing for `AffExpr` for no reason.