### PR TITLE
use new syntax in state discrimination tutorial

### DIFF
--- a/docs/src/tutorials/conic/quantum_discrimination.jl
+++ b/docs/src/tutorials/conic/quantum_discrimination.jl
@@ -92,7 +92,7 @@ E = [@variable(model, [1:d, 1:d] in HermitianPSDCone()) for i in 1:N]
 @objective(
     model,
     Max,
-    sum(real(LinearAlgebra.tr(ρ[i] * E[i])) for i in 1:N) / N,
+    sum(real(LinearAlgebra.dot(ρ[i], E[i])) for i in 1:N) / N,
 )
 
 # Now we optimize:
@@ -113,7 +113,7 @@ objective_value(model)
 
 # Finally, the optimal POVM is:
 
-solution = [value.(e) for e in E]
+solution = value.(E)
 
 # !!! tip
 #     Duality plays a large role in solving conic optimization models. Depending


### PR DESCRIPTION
I'll also update the MATLAB tutorial after `value` gets extended to vectors and matrices.