### PR TITLE
Add vector version for setting constraint attributes

### DIFF
--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -1295,6 +1295,20 @@ function MOI.set(
     return
 end
 
+function MOI.set(
+    model::GenericModel,
+    attr::MOI.AbstractConstraintAttribute,
+    crs::Vector{<:ConstraintRef},
+    value::Vector,
+)
+    for con_ref in crs
+        check_belongs_to_model(con_ref, model)
+    end
+    model.is_model_dirty = true
+    MOI.set(backend(model), attr, index.(crs), value)
+    return
+end
+
 """
     get_attribute(model::GenericModel, attr::MOI.AbstractModelAttribute)
     get_attribute(x::GenericVariableRef, attr::MOI.AbstractVariableAttribute)


### PR DESCRIPTION
The user could also write the `my_set_lower_bound` of https://github.com/jump-dev/JuMP.jl/issues/4030#issuecomment-3094854001
However, calling this version is a bit easier to write but also a bit safer since it still calls `check_belongs_to_model` and takes care of the `is_model_dirty` flag.
One caveat is that users might then try doing it with JuMP containers so we may need at some point to also add support for `AbstractArray` that then collects and redirect to this method.
We could also check that the `Vector` have the same length here.

Closes https://github.com/jump-dev/JuMP.jl/issues/4030