### PR TITLE
[Containers] fix getindex when a custom subtype of <:Integer is used

### DIFF
--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -114,6 +114,9 @@ function Base.getindex(
     x::_AxisLookup{Tuple{T,T}},
     key::Integer,
 ) where {T<:Integer}
+    if !isequal(key, convert(T, key))
+        throw(KeyError(key))
+    end
     i = key - x.data[1] + 1
     if !(1 <= i <= x.data[2])
         throw(KeyError(key))
@@ -133,6 +136,9 @@ function Base.get(
     key::Integer,
     default,
 ) where {T<:Integer}
+    if !isequal(key, convert(T, key))
+        return default
+    end
     i = key - x.data[1] + 1
     if !(1 <= i <= x.data[2])
         return default

--- a/test/Containers/test_DenseAxisArray.jl
+++ b/test/Containers/test_DenseAxisArray.jl
@@ -979,12 +979,16 @@ Base.Int(x::Int4053) = x.x
 function test_issue_4053()
     Containers.@container(A[i in Int4053(1):Int4053(3)], i.x)
     @test_throws KeyError A[1]
+    @test !isassigned(A, 1)
     @test_throws KeyError A[0x01]
+    @test !isassigned(A, 0x01)
     @test A[Int4053(1)] === 1
+    @test !isassigned(A, Int4053(1))
     Containers.@container(B[i in 2:4], i)
     @test B[2] === 2
     @test B[0x02] === 2
-    @test KeyError B[Int4053(2)]
+    @test_throws KeyError B[Int4053(2)]
+    @test !isassigned(B, Int4053(2))
     return
 end
 

--- a/test/Containers/test_DenseAxisArray.jl
+++ b/test/Containers/test_DenseAxisArray.jl
@@ -952,4 +952,40 @@ function test_conntainer_AbstractUnitRange_Integer()
     return
 end
 
+struct Int4053 <: Integer
+    x::Int
+end
+
+Int4053(f::Int4053) = f
+
+Base.:<(a::Int4053, b::Int4053) = a.x < b.x
+
+Base.:+(a::Int4053, b::Int4053) = Int4053(a.x + b.x)
+
+Base.:-(a::Int4053, b::Int4053) = Int4053(a.x - b.x)
+
+Base.:(==)(a::Int4053, b::Int4053) = a.x == b.x
+
+Base.hash(a::Int4053, h::UInt) = hash((Int4053, a.x), h)
+
+Base.:(==)(a::Int4053, b::Integer) = false
+
+Base.:(==)(a::Integer, b::Int4053) = false
+
+Base.promote_rule(T::Type{<:Integer}, ::Type{Int4053}) = T
+
+Base.Int(x::Int4053) = x.x
+
+function test_issue_4053()
+    Containers.@container(A[i in Int4053(1):Int4053(3)], i.x)
+    @test_throws KeyError A[1]
+    @test_throws KeyError A[0x01]
+    @test A[Int4053(1)] === 1
+    Containers.@container(B[i in 2:4], i)
+    @test B[2] === 2
+    @test B[0x02] === 2
+    @test KeyError B[Int4053(2)]
+    return
+end
+
 end  # module

--- a/test/Containers/test_DenseAxisArray.jl
+++ b/test/Containers/test_DenseAxisArray.jl
@@ -960,6 +960,8 @@ Int4053(f::Int4053) = f
 
 Base.:<(a::Int4053, b::Int4053) = a.x < b.x
 
+Base.:<=(a::Int4053, b::Int4053) = a.x <= b.x
+
 Base.:+(a::Int4053, b::Int4053) = Int4053(a.x + b.x)
 
 Base.:-(a::Int4053, b::Int4053) = Int4053(a.x - b.x)

--- a/test/Containers/test_DenseAxisArray.jl
+++ b/test/Containers/test_DenseAxisArray.jl
@@ -983,7 +983,7 @@ function test_issue_4053()
     @test_throws KeyError A[0x01]
     @test !isassigned(A, 0x01)
     @test A[Int4053(1)] === 1
-    @test !isassigned(A, Int4053(1))
+    @test isassigned(A, Int4053(1))
     Containers.@container(B[i in 2:4], i)
     @test B[2] === 2
     @test B[0x02] === 2


### PR DESCRIPTION
Closes https://github.com/jump-dev/JuMP.jl/issues/4053

I'm going to merge this with a view that this is a bug fix, but I reserve the right to revert it in a subsequent release if it turns out to be breaking.

It's pretty niche though, so I don't see it being a problem in the real world. It requires:

 1. Someone to have defined a new type `Foo <: Integer`
 2. To have defined `==` between `Foo` and `T<:Integer` to be `false`
 3. To have created a `DenseAxisArray` with `Foo` as an axis element
 4. Try to index into the `DenseAxisArray` with a `T` and expect things to work.