### PR TITLE
Disable depwarn in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,18 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-        with:
-          depwarn: error
+        #with:
+        #  depwarn: error # Had to disable it because DataStructures does
+        #    1 dependency had output during precompilation:
+        # ┌ DataStructures
+        # │  WARNING: DataStructures.DisjointSets is deprecated, use DisjointSet instead.
+        # │    likely near /home/blegat/.julia/dev/DataStructures/src/deprecations.jl:9
+        # │  WARNING: DataStructures.DisjointSets is deprecated, use DisjointSet instead.
+        # │    likely near /home/blegat/.julia/dev/DataStructures/src/deprecations.jl:9
+        # │  WARNING: DataStructures.DisjointSets is deprecated, use DisjointSet instead.
+        # │    likely near /home/blegat/.julia/dev/DataStructures/src/deprecations.jl:9
+        # └
+        # No idea why, try enabling it back later
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
I don't understand where these are coming from. I had the same issue in MultivariatePolynomials. I see then when doing `] test` but not when manually running the tests with `include` so they are difficult to reproduce.