### PR TITLE
Add cuOpt to list of solvers

### DIFF
--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -46,6 +46,8 @@
     rev = "v1.1.1"
 [CSDP]
     rev = "v1.1.2"
+[cuOpt]
+    rev = "v0.1.0"
 [DiffOpt]
     rev = "v0.5.0"
     extension = true

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -47,7 +47,7 @@
 [CSDP]
     rev = "v1.1.2"
 [cuOpt]
-    rev = "v0.1.0"
+    rev = "51d58b848a1743ba943fd4f887a2cf8db93e21b0"
 [DiffOpt]
     rev = "v0.5.0"
     extension = true

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -122,6 +122,7 @@ The link in the `Solver` column is the corresponding Julia package.
 | [Couenne](http://github.com/coin-or/Couenne)                                   | [AmplNLWriter.jl](https://github.com/jump-dev/AmplNLWriter.jl)                   |        | EPL      | (MI)NLP                   |
 | [CPLEX](https://www.ibm.com/analytics/cplex-optimizer/)                        | [CPLEX.jl](https://github.com/jump-dev/CPLEX.jl)                                 | Manual | Comm.    | (MI)LP, (MI)SOCP          |
 | [CSDP](https://github.com/coin-or/Csdp)                                        | [CSDP.jl](https://github.com/jump-dev/CSDP.jl)                                   |        | EPL      | LP, SDP                   |
+| [NVIDIA cuOpt](https://github.com/NVIDIA/cuOpt)                                | [cuOpt.jl](https://github.com/jump-dev/cuOpt.jl)                                 |        | Apache   | (MI)LP                    |
 | [DAQP](https://github.com/darnstrom/daqp)                                      | [DAQP.jl](https://github.com/darnstrom/DAQP.jl)                                  |        | MIT      | (Mixed-binary) QP         |
 | [DSDP](http://www.mcs.anl.gov/hs/software/DSDP/)                               | [DSDP.jl](https://github.com/jump-dev/DSDP.jl)                                   |        | DSDP     | LP, SDP                   |
 | [EAGO.jl](https://github.com/psorlab/EAGO.jl)                                  |                                                                                  |        | MIT      | (MI)NLP                   |

--- a/docs/styles/config/vocabularies/JuMP/accept.txt
+++ b/docs/styles/config/vocabularies/JuMP/accept.txt
@@ -135,6 +135,7 @@ CPLEXLink
 (cosmo|COSMO)
 COSMOAccelerators
 Couenne
+cuOpt
 Divio
 Dualization
 EAGO

--- a/docs/styles/config/vocabularies/JuMP/accept.txt
+++ b/docs/styles/config/vocabularies/JuMP/accept.txt
@@ -132,6 +132,7 @@ Artelys
 Clarabel
 Clp
 CPLEXLink
+Colab
 (cosmo|COSMO)
 COSMOAccelerators
 Couenne


### PR DESCRIPTION
## Basic

 - [x] Check that the solver is a registered Julia package
 - [x] Check that the solver supports the long-term support release of Julia
 - [x] Check that the solver has a MathOptInterface wrapper
 - [x] Check that the tests call `MOI.Test.runtests`. Some test excludes are
       permissible, but the reason for skipping a particular test should be
       documented.
 - [x] Check that the README and/or documentation provides an example of how to
       use the solver with JuMP

## Documentation

 - [x] Add a new row to the table in `docs/src/installation.md`

## Optional

 - [x] Add package metadata to `docs/packages.toml`