### PR TITLE
Add quick reference to supported solvers

### DIFF
--- a/docs/src/packages/solvers.md
+++ b/docs/src/packages/solvers.md
@@ -21,3 +21,6 @@ README contents in the JuMP documentation for the benefit of users.
 Written a solver? Add it to this section of the JuMP documentation by making
 a pull request to the [`docs/packages.toml`](https://github.com/jump-dev/JuMP.jl/blob/master/docs/packages.toml)
 file.
+
+!!! tip
+    [Supported solvers](@ref) lists all solvers supported by JuMP.


### PR DESCRIPTION
I always find myself looking for this page under 'solvers'.