### PR TITLE
prevent adding methods to the functions `>` and `>=`

### DIFF
--- a/src/variables.jl
+++ b/src/variables.jl
@@ -3403,7 +3403,7 @@ There are three common mistakes that lead to this.
     )
 end
 
-for sym in (:(<=), :(>=), :(<), :(>))
+for sym in (:(<=), :(<))
     err = _logic_error_exception(sym)
     @eval begin
         Base.$(sym)(::GenericVariableRef, ::Number) = throw($err)


### PR DESCRIPTION
As documented, the intended way to implement `>` is to add a method to `<`. Similarly with `>=`. A package should never add a method to either `>` or `>=`.