### PR TITLE
Use WeakKeyDict for the subexpression dictionary

### DIFF
--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -127,6 +127,27 @@ function value_type(::Type{T}) where {T}
     )
 end
 
+mutable struct _WeakCache{V}
+    data::Dict{WeakRef,V}
+    size_at_last_filter::Int
+    _WeakCache{V}() where {V} = new(Dict{WeakRef,V}(), 0)
+end
+
+Base.get(cache::_WeakCache, key, default) = get(cache.data, key, default)
+
+Base.getindex(cache::_WeakCache, key) = getindex(cache.data, WeakRef(key))
+
+Base.length(cache::_WeakCache) = length(cache.data)
+
+function Base.setindex!(cache::_WeakCache{V}, value::V, key) where {V}
+    cache.data[WeakRef(key)] = value
+    if length(cache.data) >= max(5 * cache.size_at_last_filter, 100)
+        filter!(kv -> !isnothing(first(kv).value), cache.data)
+        cache.size_at_last_filter = length(cache.data)
+    end
+    return value
+end
+
 mutable struct GenericModel{T<:Real} <: AbstractModel
     # In MANUAL and AUTOMATIC modes, CachingOptimizer.
     # In DIRECT mode, will hold an AbstractOptimizer.
@@ -163,7 +184,7 @@ mutable struct GenericModel{T<:Real} <: AbstractModel
     enable_macro_timing::Bool
     macro_times::Dict{Tuple{LineNumberNode,String},Float64}
     # A cache to track common subexpressions based on their `objectid`.
-    subexpressions::Dict{UInt64,MOI.ScalarNonlinearFunction}
+    subexpressions::_WeakCache{MOI.ScalarNonlinearFunction}
 end
 
 value_type(::Type{GenericModel{T}}) where {T} = T
@@ -278,7 +299,7 @@ function direct_generic_model(
         Dict{Any,MOI.ConstraintIndex}(),
         false,
         Dict{Tuple{LineNumberNode,String},Float64}(),
-        Dict{UInt64,MOI.ScalarNonlinearFunction}(),
+        _WeakCache{MOI.ScalarNonlinearFunction}(),
     )
 end
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -127,27 +127,6 @@ function value_type(::Type{T}) where {T}
     )
 end
 
-mutable struct _WeakCache{V}
-    data::Dict{WeakRef,V}
-    size_at_last_filter::Int
-    _WeakCache{V}() where {V} = new(Dict{WeakRef,V}(), 0)
-end
-
-Base.get(cache::_WeakCache, key, default) = get(cache.data, WeakRef(key), default)
-
-Base.getindex(cache::_WeakCache, key) = getindex(cache.data, WeakRef(key))
-
-Base.length(cache::_WeakCache) = length(cache.data)
-
-function Base.setindex!(cache::_WeakCache{V}, value::V, key) where {V}
-    cache.data[WeakRef(key)] = value
-    if length(cache.data) >= max(5 * cache.size_at_last_filter, 100)
-        filter!(kv -> !isnothing(first(kv).value), cache.data)
-        cache.size_at_last_filter = length(cache.data)
-    end
-    return value
-end
-
 mutable struct GenericModel{T<:Real} <: AbstractModel
     # In MANUAL and AUTOMATIC modes, CachingOptimizer.
     # In DIRECT mode, will hold an AbstractOptimizer.
@@ -184,7 +163,7 @@ mutable struct GenericModel{T<:Real} <: AbstractModel
     enable_macro_timing::Bool
     macro_times::Dict{Tuple{LineNumberNode,String},Float64}
     # A cache to track common subexpressions based on their `objectid`.
-    subexpressions::_WeakCache{MOI.ScalarNonlinearFunction}
+    subexpressions::WeakKeyDict{Any,MOI.ScalarNonlinearFunction}
 end
 
 value_type(::Type{GenericModel{T}}) where {T} = T
@@ -299,7 +278,7 @@ function direct_generic_model(
         Dict{Any,MOI.ConstraintIndex}(),
         false,
         Dict{Tuple{LineNumberNode,String},Float64}(),
-        _WeakCache{MOI.ScalarNonlinearFunction}(),
+        WeakKeyDict{Any,MOI.ScalarNonlinearFunction}(),
     )
 end
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -127,6 +127,27 @@ function value_type(::Type{T}) where {T}
     )
 end
 
+mutable struct _WeakCache{V}
+    data::Dict{WeakRef,V}
+    size_at_last_filter::Int
+    _WeakCache{V}() where {V} = new(Dict{WeakRef,V}(), 0)
+end
+
+Base.get(cache::_WeakCache, key, default) = get(cache.data, WeakRef(key), default)
+
+Base.getindex(cache::_WeakCache, key) = getindex(cache.data, WeakRef(key))
+
+Base.length(cache::_WeakCache) = length(cache.data)
+
+function Base.setindex!(cache::_WeakCache{V}, value::V, key) where {V}
+    cache.data[WeakRef(key)] = value
+    if length(cache.data) >= max(5 * cache.size_at_last_filter, 100)
+        filter!(kv -> !isnothing(first(kv).value), cache.data)
+        cache.size_at_last_filter = length(cache.data)
+    end
+    return value
+end
+
 mutable struct GenericModel{T<:Real} <: AbstractModel
     # In MANUAL and AUTOMATIC modes, CachingOptimizer.
     # In DIRECT mode, will hold an AbstractOptimizer.
@@ -163,7 +184,7 @@ mutable struct GenericModel{T<:Real} <: AbstractModel
     enable_macro_timing::Bool
     macro_times::Dict{Tuple{LineNumberNode,String},Float64}
     # A cache to track common subexpressions based on their `objectid`.
-    subexpressions::Dict{UInt64,MOI.ScalarNonlinearFunction}
+    subexpressions::_WeakCache{MOI.ScalarNonlinearFunction}
 end
 
 value_type(::Type{GenericModel{T}}) where {T} = T
@@ -278,7 +299,7 @@ function direct_generic_model(
         Dict{Any,MOI.ConstraintIndex}(),
         false,
         Dict{Tuple{LineNumberNode,String},Float64}(),
-        Dict{UInt64,MOI.ScalarNonlinearFunction}(),
+        _WeakCache{MOI.ScalarNonlinearFunction}(),
     )
 end
 

--- a/src/JuMP.jl
+++ b/src/JuMP.jl
@@ -133,7 +133,7 @@ mutable struct _WeakCache{V}
     _WeakCache{V}() where {V} = new(Dict{WeakRef,V}(), 0)
 end
 
-Base.get(cache::_WeakCache, key, default) = get(cache.data, key, default)
+Base.get(cache::_WeakCache, key, default) = get(cache.data, WeakRef(key), default)
 
 Base.getindex(cache::_WeakCache, key) = getindex(cache.data, WeakRef(key))
 

--- a/src/jump_moi_function.jl
+++ b/src/jump_moi_function.jl
@@ -167,10 +167,9 @@ end
 moi_function_type(::Type{<:GenericNonlinearExpr}) = MOI.ScalarNonlinearFunction
 
 function moi_function(model::GenericModel, f::GenericNonlinearExpr{V}) where {V}
-    # key = objectid(f)
-    # if haskey(model.subexpressions, key)
-    #     return model.subexpressions[key]
-    # end
+    if (cache = get(model.subexpressions, f, nothing)) !== nothing
+        return cache
+    end
     ret = MOI.ScalarNonlinearFunction(f.head, similar(f.args))
     stack = Tuple{MOI.ScalarNonlinearFunction,Int,GenericNonlinearExpr{V}}[]
     for i in length(f.args):-1:1
@@ -182,11 +181,10 @@ function moi_function(model::GenericModel, f::GenericNonlinearExpr{V}) where {V}
     end
     while !isempty(stack)
         parent, i, arg = pop!(stack)
-        # arg_key = objectid(arg)
-        # if haskey(model.subexpressions, arg_key)
-        #     parent.args[i] = model.subexpressions[arg_key]
-        #     continue
-        # end
+        if (cache = get(model.subexpressions, arg, nothing)) !== nothing
+            parent.args[i] = cache
+            continue
+        end
         child = MOI.ScalarNonlinearFunction(arg.head, similar(arg.args))
         parent.args[i] = child
         for j in length(arg.args):-1:1
@@ -196,9 +194,9 @@ function moi_function(model::GenericModel, f::GenericNonlinearExpr{V}) where {V}
                 child.args[j] = moi_function(model, arg.args[j])
             end
         end
-        # model.subexpressions[arg_key] = child
+        model.subexpressions[arg] = child
     end
-    # model.subexpressions[key] = ret
+    model.subexpressions[f] = ret
     return ret
 end
 

--- a/src/macros/@force_nonlinear.jl
+++ b/src/macros/@force_nonlinear.jl
@@ -84,10 +84,10 @@ julia> @expression(model, @force_nonlinear(x * 2.0 * (1 + x) * x))
 x * 2 * (1 + x) * x
 
 julia> @allocated @expression(model, x * 2.0 * (1 + x) * x)
-3264
+3200
 
 julia> @allocated @expression(model, @force_nonlinear(x * 2.0 * (1 + x) * x))
-944
+784
 ```
 """
 macro force_nonlinear(expr)

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -77,7 +77,7 @@ julia> f = GenericNonlinearExpr{VariableRef}(
 sin(x) ^ 2
 ```
 """
-struct GenericNonlinearExpr{V<:AbstractVariableRef} <: AbstractJuMPScalar
+mutable struct GenericNonlinearExpr{V<:AbstractVariableRef} <: AbstractJuMPScalar
     head::Symbol
     args::Vector{Any}
 

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -77,7 +77,8 @@ julia> f = GenericNonlinearExpr{VariableRef}(
 sin(x) ^ 2
 ```
 """
-mutable struct GenericNonlinearExpr{V<:AbstractVariableRef} <: AbstractJuMPScalar
+mutable struct GenericNonlinearExpr{V<:AbstractVariableRef} <:
+               AbstractJuMPScalar
     head::Symbol
     args::Vector{Any}
 

--- a/src/nlp_expr.jl
+++ b/src/nlp_expr.jl
@@ -77,7 +77,8 @@ julia> f = GenericNonlinearExpr{VariableRef}(
 sin(x) ^ 2
 ```
 """
-struct GenericNonlinearExpr{V<:AbstractVariableRef} <: AbstractJuMPScalar
+mutable struct GenericNonlinearExpr{V<:AbstractVariableRef} <:
+               AbstractJuMPScalar
     head::Symbol
     args::Vector{Any}
 

--- a/test/test_nlp_expr.jl
+++ b/test/test_nlp_expr.jl
@@ -1390,38 +1390,38 @@ function test_custom_array()
     return
 end
 
-# function test_scalar_nonlinear_moi_function()
-#     model = Model()
-#     @variable(model, x)
-#     y1 = atan(x, 2)
-#     y1_moi = MOI.ScalarNonlinearFunction(:atan, Any[index(x), 2])
-#     y2 = y1 + y1
-#     y2_moi = MOI.ScalarNonlinearFunction(:+, Any[y1_moi, y1_moi])
-#     y3 = exp(y2)
-#     y3_moi = MOI.ScalarNonlinearFunction(:exp, Any[y2_moi])
-#     # Test y1
-#     @test isapprox(moi_function(y1), y1_moi)
-#     @test length(model.subexpressions) == 1
-#     @test isapprox(moi_function(model, y1), y1_moi)
-#     @test length(model.subexpressions) == 1
-#     @test isapprox(model.subexpressions[objectid(y1)], y1_moi)
-#     # Test y2
-#     @test isapprox(moi_function(y2), y2_moi)
-#     @test length(model.subexpressions) == 2
-#     @test isapprox(moi_function(model, y2), y2_moi)
-#     @test length(model.subexpressions) == 2
-#     @test isapprox(model.subexpressions[objectid(y1)], y1_moi)
-#     @test isapprox(model.subexpressions[objectid(y2)], y2_moi)
-#     # Test y3
-#     @test isapprox(moi_function(y3), y3_moi)
-#     @test length(model.subexpressions) == 3
-#     @test isapprox(moi_function(model, y3), y3_moi)
-#     @test length(model.subexpressions) == 3
-#     @test isapprox(model.subexpressions[objectid(y1)], y1_moi)
-#     @test isapprox(model.subexpressions[objectid(y2)], y2_moi)
-#     @test isapprox(model.subexpressions[objectid(y3)], y3_moi)
-#     return
-# end
+function test_scalar_nonlinear_moi_function()
+    model = Model()
+    @variable(model, x)
+    y1 = atan(x, 2)
+    y1_moi = MOI.ScalarNonlinearFunction(:atan, Any[index(x), 2])
+    y2 = y1 + y1
+    y2_moi = MOI.ScalarNonlinearFunction(:+, Any[y1_moi, y1_moi])
+    y3 = exp(y2)
+    y3_moi = MOI.ScalarNonlinearFunction(:exp, Any[y2_moi])
+    # Test y1
+    @test isapprox(moi_function(y1), y1_moi)
+    @test length(model.subexpressions) == 1
+    @test isapprox(moi_function(model, y1), y1_moi)
+    @test length(model.subexpressions) == 1
+    @test isapprox(model.subexpressions[y1], y1_moi)
+    # Test y2
+    @test isapprox(moi_function(y2), y2_moi)
+    @test length(model.subexpressions) == 2
+    @test isapprox(moi_function(model, y2), y2_moi)
+    @test length(model.subexpressions) == 2
+    @test isapprox(model.subexpressions[y1], y1_moi)
+    @test isapprox(model.subexpressions[y2], y2_moi)
+    # Test y3
+    @test isapprox(moi_function(y3), y3_moi)
+    @test length(model.subexpressions) == 3
+    @test isapprox(moi_function(model, y3), y3_moi)
+    @test length(model.subexpressions) == 3
+    @test isapprox(model.subexpressions[y1], y1_moi)
+    @test isapprox(model.subexpressions[y2], y2_moi)
+    @test isapprox(model.subexpressions[y3], y3_moi)
+    return
+end
 
 function test_addition_with_zero_Base_sum()
     model = Model()
@@ -1480,6 +1480,17 @@ function test_extension_expression_bedmas_parentheses(
     @test string(@expression(model, y - 2 ^ y)) == "sin(x) - 2 ^ sin(x)"
     @test string(@expression(model, y - 2 + y)) == "(sin(x) - 2) + sin(x)"
     return
+end
+
+function test_issue_4203()
+    n = 25_000
+    model = Model()
+    @variable(model, x)
+    cons = @constraint(model, [i in 1:n], sin(x) * i <= 0)
+    for i in 1:n
+        @test isequal_canonical(constraint_object(cons[i]).func, sin(x) * i - 0)
+    end
+    return model
 end
 
 end  # module


### PR DESCRIPTION
A variant of #4204 that closes #4203

The downside to this approach is that we need to decide how frequently to filter the subexpression dictionary. If an element has been GC'd, it cannot be referenced in the future, so it is safe to remove.