### PR TITLE
Fix formatting of return value in tests

### DIFF
--- a/test/test_complex.jl
+++ b/test/test_complex.jl
@@ -22,6 +22,7 @@ include(joinpath(@__DIR__, "utilities.jl"))
 function _test_dot(a, b)
     @test LinearAlgebra.dot(a, b) == conj(a) * b
     @test LinearAlgebra.dot(b, a) == conj(b) * a
+    return
 end
 
 function test_complex_aff_expr()
@@ -117,6 +118,7 @@ function test_complex_vector_constraint()
     con_obj = constraint_object(con_ref)
     @test jump_function(con_obj) == [(1 + 2im) * x + 1]
     @test moi_set(con_obj) == MOI.Zeros(1)
+    return
 end
 
 function test_complex_vector_constraint_quadratic()
@@ -128,6 +130,7 @@ function test_complex_vector_constraint_quadratic()
     con_obj = constraint_object(con_ref)
     @test jump_function(con_obj) == [(1 + 2im) * x^2 + 1]
     @test moi_set(con_obj) == MOI.Zeros(1)
+    return
 end
 
 function test_complex_scalar_affine_constraint()
@@ -203,6 +206,7 @@ function test_complex_conj()
     @test conj(complex_quad) == (4 + 5im) * x^2 + (2 - im) * x + 3 + im
     @test real(complex_quad) == 4x^2 + 2x + 3
     @test imag(complex_quad) == -5x^2 + x - 1
+    return
 end
 
 function test_complex_abs2()
@@ -212,6 +216,7 @@ function test_complex_abs2()
     @test abs2(x + 2im) == x^2 + 4
     @test abs2(x + 2) == x^2 + 4x + 4
     @test abs2(x * im + 2) == x^2 + 4
+    return
 end
 
 function test_hermitian()

--- a/test/test_feasibility_checker.jl
+++ b/test/test_feasibility_checker.jl
@@ -36,6 +36,7 @@ function test_primal_solution()
     MOI.set(mock, MOI.VariablePrimal(), optimizer_index(x), 1.0)
     report = primal_feasibility_report(model)
     @test isempty(report)
+    return
 end
 
 function test_primal_solution_func()
@@ -62,6 +63,7 @@ function test_feasible()
     report =
         primal_feasibility_report(model, Dict(x => 0.0, y => 0.0, z => 0.5))
     @test isempty(report)
+    return
 end
 
 function test_missing()
@@ -74,6 +76,7 @@ function test_missing()
         primal_feasibility_report(model, Dict(z => 0.0); skip_missing = true)
     @test report[FixRef(z)] == 0.5
     @test length(report) == 1
+    return
 end
 
 function test_missing_error()
@@ -107,6 +110,7 @@ function test_bounds()
     @test report[IntegerRef(y)] ≈ 0.1
     @test report[FixRef(z)] ≈ 0.5
     @test length(report) == 4
+    return
 end
 
 function test_scalar_affine()
@@ -122,6 +126,7 @@ function test_scalar_affine()
     @test report[c3] ≈ 0.1
     @test report[c4] ≈ 0.5
     @test length(report) == 4
+    return
 end
 
 function test_scalar_affine_func()
@@ -155,6 +160,7 @@ function test_scalar_quadratic()
     @test report[c3] ≈ 0.9
     @test report[c4] ≈ 1.5
     @test length(report) == 4
+    return
 end
 
 function test_vector()
@@ -171,6 +177,7 @@ function test_vector()
     @test !haskey(report, c3)
     @test report[c4] ≈ sqrt(2)
     @test length(report) == 3
+    return
 end
 
 function test_vector_affine()
@@ -187,6 +194,7 @@ function test_vector_affine()
     @test !haskey(report, c3)
     @test report[c4] ≈ sqrt(8)
     @test length(report) == 3
+    return
 end
 
 function test_nonlinear()
@@ -201,6 +209,7 @@ function test_nonlinear()
     @test !haskey(report, c2)
     @test report[c3] ≈ 2 - exp(0.5)
     @test report[c4] ≈ 0.125
+    return
 end
 
 function test_nonlinear_missing()

--- a/test/test_file_formats.jl
+++ b/test/test_file_formats.jl
@@ -54,6 +54,7 @@ function test_mof_io()
     seekstart(io)
     model_2 = read(io, Model; format = MOI.FileFormats.FORMAT_MOF)
     @test sprint(print, model) == sprint(print, model_2)
+    return
 end
 
 function test_mof_nlp()

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -58,14 +58,14 @@ function _test_result_attributes(; test_empty = false)
     @test_throws err value(x)
     @test_throws err value(c)
     @test_throws err dual(c)
+    return
 end
 
-function test_result_attributes()
-    return _test_result_attributes()
-end
+test_result_attributes() = _test_result_attributes()
 
 function test_result_attributes_after_empty()
-    return _test_result_attributes(; test_empty = true)
+    _test_result_attributes(; test_empty = true)
+    return
 end
 
 function fill_small_test_model!(model)
@@ -109,17 +109,20 @@ function test_empty!_model()
     @test model.optimize_hook === hook # empty! does not touch the hook
     @test isa(backend(model), backend_type)
     @test fill_small_test_model!(model) === model
+    return
 end
 
 function test_innermost_error()
     model = Model()
     @test_throws ErrorException unsafe_backend(model)
+    return
 end
 
 function test_innermost()
     model = Model(() -> MOIU.MockOptimizer(MOIU.Model{Float64}()))
     MOI.Utilities.attach_optimizer(model)
     @test unsafe_backend(model) isa MOIU.MockOptimizer{MOIU.Model{Float64}}
+    return
 end
 
 function test_hygiene_variable()
@@ -131,6 +134,7 @@ function test_hygiene_variable()
     @test_throws err @constraint(model_x, y in MOI.EqualTo(1.0))
     @test_throws err @constraint(model_x, [x, y] in MOI.Zeros(2))
     @test_throws err @objective(model_x, Min, y)
+    return
 end
 
 function test_hygiene_linear()
@@ -139,11 +143,11 @@ function test_hygiene_linear()
     model_y = Model()
     @variable(model_y, y)
     err = VariableNotOwned(y)
-
     @test_throws err @constraint(model_x, x + y == 1)
     @test_throws err @constraint(model_x, [x, x + y] in MOI.Zeros(2))
     @test_throws err @constraint(model_x, [x + y, x] in MOI.Zeros(2))
     @test_throws err @objective(model_x, Min, x + y)
+    return
 end
 
 function test_hygiene_quadratic()
@@ -152,7 +156,6 @@ function test_hygiene_quadratic()
     model_y = Model()
     @variable(model_y, y)
     err = VariableNotOwned(y)
-
     @test_throws err @constraint(model_x, x * y >= 1)
     @test_throws err @constraint(model_x, [x, x * y] in MOI.Zeros(2))
     @test_throws err @constraint(model_x, [x * y, x] in MOI.Zeros(2))
@@ -161,6 +164,7 @@ function test_hygiene_quadratic()
     @test_throws err @constraint(model_x, [x * x + x + y, x] in MOI.Zeros(2))
     @test_throws err @objective(model_x, Min, x * y)
     @test_throws err @objective(model_x, Min, x * x + x + y)
+    return
 end
 
 function test_hygiene_attribute()
@@ -169,14 +173,13 @@ function test_hygiene_attribute()
     model_y = Model()
     @variable(model_y, y)
     err = VariableNotOwned(y)
-
     cy = @constraint(model_y, y in MOI.EqualTo(1.0))
     cerr = ConstraintNotOwned(cy)
-
     @test_throws err MOI.get(model_x, MOI.VariablePrimalStart(), y)
     @test_throws cerr MOI.get(model_x, MOI.ConstraintPrimalStart(), cy)
     @test_throws err MOI.set(model_x, MOI.VariablePrimalStart(), y, 1.0)
     @test_throws cerr MOI.set(model_x, MOI.ConstraintPrimalStart(), cy, 1.0)
+    return
 end
 
 function test_optimize_hook()
@@ -190,7 +193,6 @@ function test_optimize_hook()
     @test !called
     optimize!(m)
     @test called
-
     m = Model()
     err = ErrorException(
         """
@@ -205,12 +207,14 @@ function test_optimize_hook()
     set_optimize_hook(m, (m; my_new_arg = nothing) -> my_new_arg)
     @test optimize!(m) === nothing
     @test optimize!(m; my_new_arg = 1) == 1
+    return
 end
 
 function test_universal_fallback()
     m = Model()
     MOI.set(m, MOI.Test.UnknownModelAttribute(), 1)
     @test MOI.get(m, MOI.Test.UnknownModelAttribute()) == 1
+    return
 end
 
 function test_bridges_automatic()
@@ -229,7 +233,8 @@ function test_bridges_automatic()
             MOI.Interval{Float64},
         },
     }
-    return optimize!(model)
+    optimize!(model)
+    return
 end
 
 function test_bridges_automatic_disabled()
@@ -254,6 +259,7 @@ function test_bridges_automatic_disabled()
         """,
     )
     @test_throws err @constraint model 0 <= x + 1 <= 1
+    return
 end
 
 function test_bridges_direct()
@@ -274,6 +280,7 @@ function test_bridges_direct()
         """,
     )
     @test_throws err @constraint model 0 <= x + 1 <= 1
+    return
 end
 
 function test_direct_generic_model()
@@ -312,6 +319,7 @@ function test_bridges_add_before_con_model_optimizer()
     @test 1.0 == @inferred value(x)
     @test 1.0 == @inferred value(c)
     @test 2.0 == @inferred dual(c)
+    return
 end
 
 function test_bridges_add_before_con_set_optimizer()
@@ -324,6 +332,7 @@ function test_bridges_add_before_con_set_optimizer()
     @test 1.0 == @inferred value(x)
     @test 1.0 == @inferred value(c)
     @test 2.0 == @inferred dual(c)
+    return
 end
 
 function test_bridges_remove_bridge()
@@ -434,6 +443,7 @@ function test_bridges_add_bridgeable_con_model_optimizer()
     @test 1.0 == @inferred value(x)
     @test 1.0 == @inferred value(c)
     @test 2.0 == @inferred dual(c)
+    return
 end
 
 function test_macro_bridgeable()
@@ -506,6 +516,7 @@ function test_bridges_add_bridgeable_con_set_optimizer()
     @test 1.0 == @inferred value(x)
     @test 1.0 == @inferred value(c)
     @test 2.0 == @inferred dual(c)
+    return
 end
 
 function test_bridge_graph_false()
@@ -537,6 +548,7 @@ function test_bridge_graph_false()
     )
     optimize!(model)
     @test 1.0 == @inferred value(x)
+    return
 end
 
 function test_bridge_graph_true()
@@ -572,6 +584,7 @@ function test_solver_name()
 
     model = Model(() -> MOIU.MockOptimizer(SimpleLPModel{Float64}()))
     @test "Mock" == @inferred solver_name(model)
+    return
 end
 
 function test_set_silent()
@@ -594,6 +607,7 @@ function test_set_optimizer_attribute()
     @test set_optimizer_attribute(model, "aaa", "bbb") === nothing
     @test MOI.get(backend(model), MOI.RawOptimizerAttribute("aaa")) == "bbb"
     @test MOI.get(model, MOI.RawOptimizerAttribute("aaa")) == "bbb"
+    return
 end
 
 function test_set_optimizer_attributes()
@@ -602,6 +616,7 @@ function test_set_optimizer_attributes()
     set_optimizer_attributes(model, "aaa" => "bbb", "abc" => 10)
     @test MOI.get(model, MOI.RawOptimizerAttribute("aaa")) == "bbb"
     @test MOI.get(model, MOI.RawOptimizerAttribute("abc")) == 10
+    return
 end
 
 function test_get_optimizer_attribute()
@@ -609,6 +624,7 @@ function test_get_optimizer_attribute()
     model = Model(() -> MOIU.MockOptimizer(mock))
     @test set_optimizer_attribute(model, "aaa", "bbb") === nothing
     @test get_optimizer_attribute(model, "aaa") == "bbb"
+    return
 end
 
 function test_optimizer_attribute_abstract_string()
@@ -731,6 +747,7 @@ function test_compute_conflict()
     err = NoOptimizer()
     model = Model()
     @test_throws err compute_conflict!(model)
+    return
 end
 
 function test_copy_model_base_auto()
@@ -767,6 +784,7 @@ function test_direct_mode_using_OptimizerWithAttributes()
     @test model.moi_backend isa MOIU.MockOptimizer
     @test MOI.get(model.moi_backend, MOI.RawOptimizerAttribute("a")) == 1
     @test MOI.get(model.moi_backend, MOI.RawOptimizerAttribute("b")) == 2
+    return
 end
 
 function test_copy_expr_aff()
@@ -776,6 +794,7 @@ function test_copy_expr_aff()
     new_model, ref_map = copy_model(model)
     @test ref_map[ex] == new_model[:ex]
     @test new_model[:ex] == 2 * new_model[:x] + 1
+    return
 end
 
 function test_copy_expr_quad()
@@ -785,6 +804,7 @@ function test_copy_expr_quad()
     new_model, ref_map = copy_model(model)
     @test ref_map[ex] == new_model[:ex]
     @test new_model[:ex] == 2 * new_model[:x]^2 + new_model[:x] + 1
+    return
 end
 
 function test_copy_dense()
@@ -792,6 +812,7 @@ function test_copy_dense()
     @variable(model, x[[:a, :b]])
     new_model, ref_map = copy_model(model)
     @test ref_map[x] == new_model[:x]
+    return
 end
 
 function test_copy_sparse()
@@ -799,6 +820,7 @@ function test_copy_sparse()
     @variable(model, x[i = 1:4; isodd(i)])
     new_model, ref_map = copy_model(model)
     @test ref_map[x] == new_model[:x]
+    return
 end
 
 function test_copy_object_fail()
@@ -807,6 +829,7 @@ function test_copy_object_fail()
     model[:d] = Dict(x => 2)
     new_model, ref_map = copy_model(model)
     @test !haskey(new_model, :d)
+    return
 end
 
 function test_copy_extension()
@@ -823,6 +846,7 @@ function test_haskey()
     @variable(model, p[i=1:10] >= 0)
     @test haskey(model, :p)
     @test !haskey(model, :i)
+    return
 end
 
 function test_copy_refmap_expr()
@@ -842,6 +866,7 @@ function test_copy_dict_expr()
     @expression(model, dictExpr[i=1:2, j=1:2], Dict(i => x, j => 2x))
     new_model, ref_map = copy_model(model)
     @test !haskey(new_model, :dictExpr)
+    return
 end
 
 function test_copy_filter()
@@ -874,6 +899,7 @@ function test_copy_filter_array()
     cref_2_new = reference_map[cref[2]]
     @test cref_2_new.model === new_model
     @test "cref[2]" == @inferred name(cref_2_new)
+    return
 end
 
 function test_copy_filter_denseaxisarray()
@@ -902,6 +928,7 @@ function test_copy_filter_denseaxisarray()
     cref_2_new = reference_map[cref[2]]
     @test cref_2_new.model === new_model
     @test "cref[2]" == @inferred name(cref_2_new)
+    return
 end
 
 function test_copy_filter_sparseaxisarray()
@@ -930,6 +957,7 @@ function test_copy_filter_sparseaxisarray()
     cref_2_new = reference_map[cref[2]]
     @test cref_2_new.model === new_model
     @test "cref[2]" == @inferred name(cref_2_new)
+    return
 end
 
 function test_copy_conflict()

--- a/test/test_nlp.jl
+++ b/test/test_nlp.jl
@@ -22,6 +22,7 @@ function test_univariate_error()
     model = Model()
     @variable(model, x >= 0)
     @test_throws ErrorException @NLobjective(model, Min, g_doesnotexist(x))
+    return
 end
 
 function test_univariate_error_existing()
@@ -29,6 +30,7 @@ function test_univariate_error_existing()
     @variable(model, x >= 0)
     @NLexpression(model, ex, x^2)
     @test_throws ErrorException @NLobjective(model, Min, g_doestnotexist(ex))
+    return
 end
 
 function test_univariate()
@@ -40,6 +42,7 @@ function test_univariate()
     MOI.initialize(d, Symbol[])
     x = [2.0]
     @test MOI.eval_objective(d, x) == 4.0
+    return
 end
 
 function test_univariate_register_twice()
@@ -54,6 +57,7 @@ function test_univariate_register_twice()
     y = [NaN]
     MOI.eval_constraint(d, y, x)
     @test y == [3.0]
+    return
 end
 
 function test_univariate_register_twice_error()
@@ -63,6 +67,7 @@ function test_univariate_register_twice_error()
     g(x, y) = x^2 + x^2
     @test_logs (:warn,) @NLobjective(model, Min, g(x))
     @test_throws ErrorException @NLconstraint(model, g(x, x) <= 1)
+    return
 end
 
 function test_univariate_existing_nlpdata()
@@ -75,6 +80,7 @@ function test_univariate_existing_nlpdata()
     MOI.initialize(d, Symbol[])
     x = [2.0]
     @test MOI.eval_objective(d, x) == 16.0
+    return
 end
 
 function test_univariate_redefine()
@@ -90,12 +96,14 @@ function test_univariate_redefine()
 
     g = (x) -> 2x^2
     @test MOI.eval_objective(d, x) == 4.0
+    return
 end
 
 function test_multivariate_error()
     model = Model()
     @variable(model, x >= 0)
     @test_throws ErrorException @NLobjective(model, Min, g_doesnotexist(x, x))
+    return
 end
 
 function test_multivariate_error_existing()
@@ -103,6 +111,7 @@ function test_multivariate_error_existing()
     @variable(model, x >= 0)
     @NLexpression(model, ex, x^2)
     @test_throws ErrorException @NLobjective(model, Min, g_doestnotexist(ex, x))
+    return
 end
 
 function test_multivariate()
@@ -114,6 +123,7 @@ function test_multivariate()
     MOI.initialize(d, Symbol[])
     x = [2.0]
     @test MOI.eval_objective(d, x) == 8.0
+    return
 end
 
 function test_multivariate_register_warn()
@@ -125,6 +135,7 @@ function test_multivariate_register_warn()
         return
     end
     @test_logs (:warn,) register(model, :g, 2, g, ∇g; autodiff = true)
+    return
 end
 
 function test_multivariate_existing_nlpdata()
@@ -137,6 +148,7 @@ function test_multivariate_existing_nlpdata()
     MOI.initialize(d, Symbol[])
     x = [2.0]
     @test MOI.eval_objective(d, x) == 20.0
+    return
 end
 
 function test_multivariate_redefine()
@@ -152,6 +164,7 @@ function test_multivariate_redefine()
 
     g = (x, y) -> x^2 + y
     @test MOI.eval_objective(d, x) == 20.0
+    return
 end
 
 function test_multivariate_register_splat()
@@ -171,6 +184,7 @@ function test_multivariate_register_splat()
         ```
         """)
     @test_throws err @NLexpression(model, ex, f(x...))
+    return
 end
 
 function test_multivariate_register_splat_existing()
@@ -191,6 +205,7 @@ function test_multivariate_register_splat_existing()
         ```
         """)
     @test_throws err @NLexpression(model, ex, f(x...))
+    return
 end
 
 function test_multivariate_max()

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -852,6 +852,7 @@ function test_print_summary_min_sense()
     @variable(model, x)
     @objective(model, Min, x)
     @test occursin("objective_sense: MIN_SENSE", sprint(show, model))
+    return
 end
 
 function test_show_latex_parameter()

--- a/test/test_variable.jl
+++ b/test/test_variable.jl
@@ -1279,6 +1279,7 @@ function _test_Hermitian(model, H)
     @test Q[2, 2] == 1v[3]
     @test Q[2, 1] == conj(Q[1, 2])
     @test H[2, 1] == conj(H[1, 2])
+    return
 end
 
 function test_extension_variable_Hermitian_tag(


### PR DESCRIPTION
x-ref #4209

This is a very minor nit but it is one of my pet peeves. JuliaFormatter cannot add a return after @test because it doesn't know what the macro will expand to.