### PR TITLE
[docs] disable minted using custom.sty

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,6 +5,21 @@
 
 import Distributed
 
+if get(ENV, "GITHUB_EVENT_NAME", "") == "pull_request"
+    # To speed up the Documentation build during pull requests, over-write
+    # {minted} blocks by {verbatim}. In pushes to `master` and on tags, we don't
+    # do this.
+    write(
+        joinpath(@__DIR__, "src", "assets", "custom.sty"),
+        """
+        % Neutralize the minted environment so LaTeX doesn't invoke Pygments
+        \\let\\minted\\verbatim
+        \\let\\endminted\\endverbatim
+        \\let\\inputminted\\verbatiminput
+        """,
+    )
+end
+
 Distributed.@everywhere include(joinpath(@__DIR__, "make_utilities.jl"))
 
 # Needed to make Documenter think that there is a PDF in the right place when
@@ -22,13 +37,11 @@ end
 @time if _PDF || _IS_GITHUB_ACTIONS
     # Copy the src into a new directory for the latex build
     cp(joinpath(@__DIR__, "src"), joinpath(@__DIR__, "latex_src"); force = true)
-    # w = Distributed.workers()
-    # f_latex = Distributed.remotecall(make_latex, w[1])
-    # f_html = Distributed.remotecall(make_html, w[2])
-    # fetch(f_latex)
-    # fetch(f_html)
-    make_html()
-    make_latex()
+    w = Distributed.workers()
+    f_latex = Distributed.remotecall(make_latex, w[1])
+    f_html = Distributed.remotecall(make_html, w[2])
+    fetch(f_latex)
+    fetch(f_html)
     # Hack for deploying: copy the pdf (and only the PDF) into the HTML build
     # directory! We don't want to copy everything in `latex_build` because it
     # includes lots of extraneous LaTeX files.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -37,11 +37,13 @@ end
 @time if _PDF || _IS_GITHUB_ACTIONS
     # Copy the src into a new directory for the latex build
     cp(joinpath(@__DIR__, "src"), joinpath(@__DIR__, "latex_src"); force = true)
-    w = Distributed.workers()
-    f_latex = Distributed.remotecall(make_latex, w[1])
-    f_html = Distributed.remotecall(make_html, w[2])
-    fetch(f_latex)
-    fetch(f_html)
+    # w = Distributed.workers()
+    # f_latex = Distributed.remotecall(make_latex, w[1])
+    # f_html = Distributed.remotecall(make_html, w[2])
+    # fetch(f_latex)
+    # fetch(f_html)
+    make_html()
+    make_latex()
     # Hack for deploying: copy the pdf (and only the PDF) into the HTML build
     # directory! We don't want to copy everything in `latex_build` because it
     # includes lots of extraneous LaTeX files.

--- a/docs/make_utilities.jl
+++ b/docs/make_utilities.jl
@@ -187,10 +187,14 @@ function add_solver_readmes()
         filename = get(data, "filename", "README.md")
         out_filename = joinpath(@__DIR__, "src", "packages", "$solver.md")
         user_repo = string(user, "/", solver, get(data, "ext", ".jl"))
+        headers = Dict{String,Any}()
+        if haskey(ENV, "GITHUB_TOKEN")
+            headers["Authorization"] = "token " * ENV["GITHUB_TOKEN"]
+        end
         Downloads.download(
             "https://raw.githubusercontent.com/$user_repo/$tag/$filename",
             out_filename;
-            headers = Dict("Authorization" => "token " * ENV["GITHUB_TOKEN"]),
+            headers,
         )
         _add_edit_url(
             out_filename,

--- a/docs/make_utilities.jl
+++ b/docs/make_utilities.jl
@@ -187,15 +187,13 @@ function add_solver_readmes()
         filename = get(data, "filename", "README.md")
         out_filename = joinpath(@__DIR__, "src", "packages", "$solver.md")
         user_repo = string(user, "/", solver, get(data, "ext", ".jl"))
-        headers = Dict{String,Any}()
+        url = "https://raw.githubusercontent.com/$user_repo/$tag/$filename"
         if haskey(ENV, "GITHUB_TOKEN")
-            headers["Authorization"] = "token " * ENV["GITHUB_TOKEN"]
+            headers = Dict("Authorization" => "token " * ENV["GITHUB_TOKEN"])
+            Downloads.download(url, out_filename; headers)
+        else
+            Downloads.download(url, out_filename)
         end
-        Downloads.download(
-            "https://raw.githubusercontent.com/$user_repo/$tag/$filename",
-            out_filename;
-            headers,
-        )
         _add_edit_url(
             out_filename,
             "https://github.com/$user_repo/blob/$tag/$filename",

--- a/docs/src/assets/custom.sty
+++ b/docs/src/assets/custom.sty
@@ -1,4 +1,0 @@
-% Neutralize the minted environment so LaTeX doesn't invoke Pygments
-\let\minted\verbatim
-\let\endminted\endverbatim
-\let\inputminted\verbatiminput

--- a/docs/src/assets/custom.sty
+++ b/docs/src/assets/custom.sty
@@ -1,0 +1,4 @@
+% Neutralize the minted environment so LaTeX doesn't invoke Pygments
+\let\minted\verbatim
+\let\endminted\endverbatim
+\let\inputminted\verbatiminput

--- a/docs/src/tutorials/conic/logistic_regression.jl
+++ b/docs/src/tutorials/conic/logistic_regression.jl
@@ -195,7 +195,7 @@ model = build_logit_model(X, y, λ)
 set_optimizer(model, Clarabel.Optimizer)
 set_silent(model)
 optimize!(model)
-assert_is_solved_and_feasible(model)
+assert_is_solved_and_feasible(model; allow_almost = true)
 
 #-
 
@@ -238,7 +238,7 @@ sparse_model = build_sparse_logit_model(X, y, λ)
 set_optimizer(sparse_model, Clarabel.Optimizer)
 set_silent(sparse_model)
 optimize!(sparse_model)
-assert_is_solved_and_feasible(sparse_model)
+assert_is_solved_and_feasible(sparse_model; allow_almost = true)
 
 #-
 


### PR DESCRIPTION
The majority of the documentation build time is spent in code highlighting. I'm making this PR to get a qualitative estimate for the time in CI.

If it makes a bit difference, we could figure out how to disable this for PRs, and keep it for pushes to `master` (and tags).