### PR TITLE
[docs] remove tectonic_jll and switch to Docker for LaTeX build

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -46,7 +46,6 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Wavelets = "29a6e085-ba6d-5f35-a997-948ac2efa89a"
-tectonic_jll = "d7dd28d6-a5e6-559c-9131-7eb760cdacc5"
 
 [compat]
 CDDLib = "=0.10.3"

--- a/docs/make_utilities.jl
+++ b/docs/make_utilities.jl
@@ -12,7 +12,6 @@ import Literate
 import MathOptInterface
 import Pkg
 import TOML
-import tectonic_jll
 import Test
 
 using JuMP
@@ -757,10 +756,7 @@ function make_latex()
     Documenter.makedocs(;
         sitename = "JuMP",
         authors = "The JuMP core developers and contributors",
-        format = Documenter.LaTeX(;
-            platform = "tectonic",
-            tectonic = tectonic_jll.tectonic(),
-        ),
+        format = Documenter.LaTeX(; platform = "docker"),
         source = joinpath(@__DIR__, "latex_src"),
         build = joinpath(@__DIR__, "latex_build"),
         pages,


### PR DESCRIPTION
We're getting a bunch of failures of the LaTeX build:

<img width="1134" height="162" alt="image" src="https://github.com/user-attachments/assets/b77bb3d2-3adf-46ca-8a0c-965d5a2081c6" />

Testing if this makes a difference.