### PR TITLE
[docs] add ConicIP.jl to the solvers list

### DIFF
--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -144,6 +144,9 @@
     user = "oxfordcontrol"
     rev = "v0.11.1"
     has_html = true
+[ConicIP]
+    user = "MPF-Optimization-Laboratory"
+    rev = "82e0e6d60a5aae96c9d9373c6deed933ec6743bb"
 [CoolPDLP]
     user = "JuliaDecisionFocusedLearning"
     rev = "v0.2.1"

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -146,7 +146,7 @@
     has_html = true
 [ConicIP]
     user = "MPF-Optimization-Laboratory"
-    rev = "v0.3.1"
+    rev = "v0.3.2"
 [CoolPDLP]
     user = "JuliaDecisionFocusedLearning"
     rev = "v0.2.1"

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -146,7 +146,7 @@
     has_html = true
 [ConicIP]
     user = "MPF-Optimization-Laboratory"
-    rev = "82e0e6d60a5aae96c9d9373c6deed933ec6743bb"
+    rev = "v0.3.0"
 [CoolPDLP]
     user = "JuliaDecisionFocusedLearning"
     rev = "v0.2.1"

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -47,7 +47,7 @@
 [CSDP]
     rev = "v1.1.2"
 [cuOpt]
-    rev = "v0.3.0"
+    rev = "v0.3.1"
 [DiffOpt]
     rev = "v0.6.2"
     extension = true
@@ -146,7 +146,7 @@
     has_html = true
 [ConicIP]
     user = "MPF-Optimization-Laboratory"
-    rev = "v0.3.0"
+    rev = "v0.3.1"
 [CoolPDLP]
     user = "JuliaDecisionFocusedLearning"
     rev = "v0.2.1"
@@ -162,7 +162,7 @@
     has_html = true
 [CuPDLPx]
     user = "MIT-Lu-Lab"
-    rev = "v0.3.0"
+    rev = "v0.3.1"
 [DAQP]
     user = "darnstrom"
     rev = "v0.9.0"

--- a/docs/packages.toml
+++ b/docs/packages.toml
@@ -47,7 +47,7 @@
 [CSDP]
     rev = "v1.1.2"
 [cuOpt]
-    rev = "v0.3.1"
+    rev = "v0.3.0"
 [DiffOpt]
     rev = "v0.6.2"
     extension = true
@@ -162,7 +162,7 @@
     has_html = true
 [CuPDLPx]
     user = "MIT-Lu-Lab"
-    rev = "v0.3.1"
+    rev = "v0.3.0"
 [DAQP]
     user = "darnstrom"
     rev = "v0.9.0"

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -119,6 +119,7 @@ The link in the `Solver` column is the corresponding Julia package.
 | [CDD](https://github.com/cddlib/cddlib)                                        | [CDDLib.jl](https://github.com/JuliaPolyhedra/CDDLib.jl)                         |        | GPL      | LP                        |
 | [Clarabel.jl](https://github.com/oxfordcontrol/Clarabel.jl)                    |                                                                                  |        | Apache   | LP, QP, SOCP, SDP         |
 | [Clp](https://github.com/coin-or/Clp)                                          | [Clp.jl](https://github.com/jump-dev/Clp.jl)                                     |        | EPL      | LP                        |
+| [ConicIP.jl](https://github.com/MPF-Optimization-Laboratory/ConicIP.jl)        |                                                                                  |        | MIT      | LP, SOCP, SDP             |
 | [CONOPT](https://conopt.gams.com/)                                             | [CONOPT.jl](https://github.com/GAMS-dev/CONOPT.jl)                               | Manual | Comm.    | LP, QP, NLP               |
 | [CoolPDLP.jl](https://github.com/JuliaDecisionFocusedLearning/CoolPDLP.jl)     |                                                                                  |        | MIT      | LP                        |
 | [COPT](https://www.shanshu.ai/copt)                                            | [COPT.jl](https://github.com/COPT-Public/COPT.jl)                                |        | Comm.    | (MI)LP, SOCP, SDP         |


### PR DESCRIPTION
Adds [ConicIP.jl](https://github.com/MPF-Optimization-Laboratory/ConicIP.jl), a pure-Julia conic interior-point solver (LP, SOCP, and experimental SDP through JuMP), to the supported-solvers table and to `docs/packages.toml`.

Checklist from [Adding a new solver to the documentation](https://jump.dev/JuMP.jl/stable/developers/checklists/#Adding-a-new-solver-to-the-documentation):

- [x] Registered in General (v0.2.0 in JuliaRegistries/General#166492; v0.3.0 in JuliaRegistries/General#166849; v0.3.1 in JuliaRegistries/General#166856; v0.3.2 in JuliaRegistries/General#166868)
- [x] Supports the Julia LTS (compat `julia = "1.10"`, CI matrix 1.10 / 1 / nightly)
- [x] MathOptInterface wrapper (`ConicIP.Optimizer`, `src/MOI_wrapper.jl`)
- [x] Tests call `MOI.Test.runtests`; each exclude is documented in-line (no quadratic objective through MOI, no integer/SOS/indicator/nonlinear support, `CachingOptimizer` rather than direct `copy_to`)
- [x] README has a JuMP usage example
- [x] Row added to `docs/src/installation.md`
- [x] `docs/packages.toml` entry, pinned to tag `v0.3.2` (the README with the `## Affiliation`, `## Getting help` and `## Installation` sections)

Closes MPF-Optimization-Laboratory/ConicIP.jl#24.

Drafted with Claude Code; reviewed by a maintainer.
