### PR TITLE
Fix string indexing error in print_macro_timing_summary

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -559,7 +559,8 @@ function _string_summary(x)
     if length(x) <= 75
         return x
     end
-    return x[1:32] * " [...] " * x[(end-31):end]
+    # Don't use `x[1:32]` type indexing here because it's not safe with unicode.
+    return first(x, 32) * " [...] " * last(x, 32)
 end
 
 _format_time(x::Float64) = string(_format(x), " seconds")

--- a/test/test_macros.jl
+++ b/test/test_macros.jl
@@ -3167,6 +3167,9 @@ function test_print_macro_timing_summary()
     @test all(>=(0), values(model.macro_times))
     @test !occursin("@variable(model, x[1:2])", contents)
     @test !occursin("@expression(model, expr, x[1] + x[2])", contents)
+    #
+    @test occursin("[...]", JuMP._string_summary("x"^29 * "≥" * "y"^60))
+    @test occursin("[...]", JuMP._string_summary("x"^60 * "≥" * "y"^30))
     return
 end
 


### PR DESCRIPTION
This would error if a multi-byte unicode operator lay across the boundary. And that's pretty plausible because people often use unicode like `≥` and `∈` in the macros.