### PR TITLE
Fix primal_feasibility_report with skip_missing in a vector

### DIFF
--- a/src/feasibility_checker.jl
+++ b/src/feasibility_checker.jl
@@ -231,4 +231,18 @@ function _add_infeasible_nonlinear_constraints(
 end
 
 _distance_to_set(::Missing, set, ::Type{T}) where {T} = zero(T)
-_distance_to_set(point, set, ::Type) = MOI.Utilities.distance_to_set(point, set)
+
+function _distance_to_set(
+    point::AbstractVector,
+    set::MOI.AbstractVectorSet,
+    ::Type{T},
+) where {T}
+    if any(ismissing, point)
+        return zero(T)
+    end
+    return MOI.Utilities.distance_to_set(point, set, T)
+end
+
+function _distance_to_set(point, set::MOI.AbstractScalarSet, ::Type)
+    return MOI.Utilities.distance_to_set(point, set)
+end

--- a/src/feasibility_checker.jl
+++ b/src/feasibility_checker.jl
@@ -157,7 +157,8 @@ function _add_infeasible_constraints(
 ) where {T,F,S}
     for con in all_constraints(model, F, S)
         obj = constraint_object(con)
-        d = _distance_to_set(value.(point_f, obj.func), obj.set, T)
+        point = convert(Vector{T}, value.(point_f, obj.func))
+        d = _distance_to_set(point, obj.set, T)
         if d > atol
             violated_constraints[con] = d
         end
@@ -218,7 +219,7 @@ function _add_infeasible_nonlinear_constraints(
 ) where {T}
     evaluator = NLPEvaluator(model)
     MOI.initialize(evaluator, Symbol[])
-    g = zeros(num_nonlinear_constraints(model))
+    g = zeros(T, num_nonlinear_constraints(model))
     MOI.eval_constraint(evaluator, g, point_f.(all_variables(model)))
     for (i, (index, constraint)) in enumerate(evaluator.model.constraints)
         d = _distance_to_set(g[i], constraint.set, T)
@@ -230,10 +231,24 @@ function _add_infeasible_nonlinear_constraints(
     return
 end
 
-_distance_to_set(::Missing, set, ::Type{T}) where {T} = zero(T)
+function _distance_to_set(
+    ::Missing,
+    ::MOI.AbstractScalarSet,
+    ::Type{T},
+) where {T}
+    return zero(T)
+end
 
 function _distance_to_set(
-    point::AbstractVector,
+    point::T,
+    set::MOI.AbstractScalarSet,
+    ::Type{T},
+) where {T}
+    return MOI.Utilities.distance_to_set(point, set)
+end
+
+function _distance_to_set(
+    point::Vector{T},
     set::MOI.AbstractVectorSet,
     ::Type{T},
 ) where {T}
@@ -241,8 +256,4 @@ function _distance_to_set(
         return zero(T)
     end
     return MOI.Utilities.distance_to_set(point, set, T)
-end
-
-function _distance_to_set(point, set::MOI.AbstractScalarSet, ::Type)
-    return MOI.Utilities.distance_to_set(point, set)
 end

--- a/src/feasibility_checker.jl
+++ b/src/feasibility_checker.jl
@@ -157,54 +157,7 @@ function _add_infeasible_constraints(
 ) where {T,F,S}
     for con in all_constraints(model, F, S)
         obj = constraint_object(con)
-        point = convert(Vector{T}, value.(point_f, obj.func))
-        d = _distance_to_set(point, obj.set, T)
-        if d > atol
-            violated_constraints[con] = d
-        end
-    end
-    return
-end
-
-function _add_infeasible_constraints(
-    model::GenericModel{T},
-    ::Type{F},
-    ::Type{S},
-    violated_constraints::Dict{Any,T},
-    point_f::Function,
-    atol::T,
-) where {T,F<:GenericNonlinearExpr,S}
-    for con in all_constraints(model, F, S)
-        obj = constraint_object(con)
-        ret = value(point_f, obj.func)
-        if ismissing(ret)
-            continue
-        end
-        # value(::GenericNonlinearExpr) returns `Float64`. Convert it to `T` for
-        # the case where the model is a different number type.
-        d = _distance_to_set(convert(T, ret), obj.set, T)
-        if d > atol
-            violated_constraints[con] = d
-        end
-    end
-    return
-end
-
-function _add_infeasible_constraints(
-    model::GenericModel{T},
-    ::Type{F},
-    ::Type{S},
-    violated_constraints::Dict{Any,T},
-    point_f::Function,
-    atol::T,
-) where {T,F<:Vector{<:GenericNonlinearExpr},S}
-    for con in all_constraints(model, F, S)
-        obj = constraint_object(con)
-        # value(::GenericNonlinearExpr) returns `Float64`. Convert it to `T` for
-        # the case where the model is a different number type.
-        fn_value = convert(Vector{T}, value.(point_f, obj.func))
-        d = _distance_to_set(fn_value, obj.set, T)
-        if d > atol
+        if (d = _distance_to_set(point_f, obj.func, obj.set, T)) > atol
             violated_constraints[con] = d
         end
     end
@@ -222,8 +175,7 @@ function _add_infeasible_nonlinear_constraints(
     g = zeros(T, num_nonlinear_constraints(model))
     MOI.eval_constraint(evaluator, g, point_f.(all_variables(model)))
     for (i, (index, constraint)) in enumerate(evaluator.model.constraints)
-        d = _distance_to_set(g[i], constraint.set, T)
-        if d > atol
+        if (d = MOI.Utilities.distance_to_set(g[i], constraint.set)) > atol
             cref = ConstraintRef(model, index, ScalarShape())
             violated_constraints[cref] = d
         end
@@ -232,28 +184,27 @@ function _add_infeasible_nonlinear_constraints(
 end
 
 function _distance_to_set(
-    ::Missing,
-    ::MOI.AbstractScalarSet,
-    ::Type{T},
-) where {T}
-    return zero(T)
-end
-
-function _distance_to_set(
-    point::T,
+    point_f::F,
+    func,
     set::MOI.AbstractScalarSet,
     ::Type{T},
-) where {T}
-    return MOI.Utilities.distance_to_set(point, set)
+) where {F,T}
+    ret = value(point_f, func)
+    if ismissing(ret)
+        return zero(T)
+    end
+    return MOI.Utilities.distance_to_set(convert(T, ret), set)
 end
 
 function _distance_to_set(
-    point::Vector{T},
+    point_f::F,
+    func::AbstractVector,
     set::MOI.AbstractVectorSet,
     ::Type{T},
-) where {T}
-    if any(ismissing, point)
+) where {F,T}
+    ret = value.(point_f, func)
+    if any(ismissing, ret)
         return zero(T)
     end
-    return MOI.Utilities.distance_to_set(point, set, T)
+    return MOI.Utilities.distance_to_set(convert(Vector{T}, ret), set)
 end

--- a/test/test_feasibility_checker.jl
+++ b/test/test_feasibility_checker.jl
@@ -278,4 +278,13 @@ function test_nonlinear_expr_missing()
     return
 end
 
+function test_skip_missing_in_vector()
+    model = Model()
+    @variable(model, x[1:2])
+    @constraint(model, c, x in Nonnegatives())
+    point = Dict(x[1] => 1.0)
+    @test isempty(primal_feasibility_report(model, point; skip_missing = true))
+    return
+end
+
 end  # module


### PR DESCRIPTION
# `primal_feasibility_report(..., skip_missing=true)` errors instead of skipping for vector constraints

`src/feasibility_checker.jl:159` (generic `_add_infeasible_constraints`) and
`:233-234` (`_distance_to_set`).

The docstring for `primal_feasibility_report` promises: "If `skip_missing =
true`, constraints containing variables that are not in `point` will be
ignored." This works for scalar constraints via the
`_distance_to_set(::Missing, set, ::Type{T}) = zero(T)` fallback, but not for
vector constraints: `value.(point_f, obj.func)` broadcasts over the function
vector, producing a `Vector{Union{Missing,T}}`, which never matches the
`::Missing` method and instead falls through to
`MOI.Utilities.distance_to_set(point, set)` — where a `missing`-containing
vector produces a confusing `ErrorException` about `distance_to_set` not
being implemented, rather than being skipped.

## Repro

```julia
using JuMP
model = Model()
@variable(model, x[1:2])
@constraint(model, c1, x in MOI.Nonnegatives(2))
point = Dict(x[1] => -1.0)   # x[2] missing
primal_feasibility_report(model, point; skip_missing = true)
```
```
ERROR: distance_to_set using the distance metric MathOptInterface.Utilities.ProjectionUpperBoundDistance() for set type MathOptInterface.Nonnegatives has not been implemented yet.
```
(verified — reproduces exactly as shown)

No existing test covers this path: `test/test_feasibility_checker.jl`'s
`test_vector`/`test_vector_affine` exercise vector constraints but never
pass `skip_missing = true`, and every existing `skip_missing = true` test
(`test_missing`, `test_bounds`, etc.) only uses scalar constraints.

## Patch

```diff
--- a/src/feasibility_checker.jl
+++ b/src/feasibility_checker.jl
@@ -232,4 +232,9 @@
 _distance_to_set(::Missing, set, ::Type{T}) where {T} = zero(T)
+function _distance_to_set(point::AbstractVector, set, ::Type{T}) where {T}
+    if any(ismissing, point)
+        return zero(T)
+    end
+    return MOI.Utilities.distance_to_set(convert(Vector{T}, point), set)
+end
 _distance_to_set(point, set, ::Type) = MOI.Utilities.distance_to_set(point, set)
```
