### PR TITLE
Fix kwarg indexing of DenseAxisArray with wrong number of kwargs

### DIFF
--- a/src/Containers/DenseAxisArray.jl
+++ b/src/Containers/DenseAxisArray.jl
@@ -419,6 +419,19 @@ _is_range(::Colon) = true
 _is_range(::AbstractVector{<:Integer}) = true
 
 function _kwargs_to_args(A::DenseAxisArray{T,N}; kwargs...) where {T,N}
+    if length(kwargs) != N
+        error(
+            """
+            Number of keyword arguments ($(length(kwargs))) does not match the \
+            number of dimensions ($N).
+
+            When using keyword indexing, the indices must match the exact \
+            name and order used when creating the container.
+
+            Check the index names and their order in the container definition.
+            """,
+        )
+    end
     return ntuple(N) do i
         kw = keys(kwargs)[i]
         if A.names[i] != kw

--- a/test/Containers/test_DenseAxisArray.jl
+++ b/test/Containers/test_DenseAxisArray.jl
@@ -1104,7 +1104,7 @@ function test_getindex_kwargs()
             Check the index names and their order in the container definition.
             """,
         ),
-        A[x = :a, y = 2, z = 99],
+        A[x=:a, y=2, z=99],
     )
     @test_throws(
         ErrorException(
@@ -1117,7 +1117,7 @@ function test_getindex_kwargs()
             Check the index names and their order in the container definition.
             """,
         ),
-        A[x = :a],
+        A[x=:a],
     )
     return
 end

--- a/test/Containers/test_DenseAxisArray.jl
+++ b/test/Containers/test_DenseAxisArray.jl
@@ -1091,4 +1091,35 @@ function test_issue_4213()
     return
 end
 
+function test_getindex_kwargs()
+    A = Containers.DenseAxisArray([1 2; 3 4], [:a, :b], 2:3; names = (:x, :y))
+    @test_throws(
+        ErrorException(
+            """
+            Number of keyword arguments (3) does not match the number of dimensions (2).
+
+            When using keyword indexing, the indices must match the exact \
+            name and order used when creating the container.
+
+            Check the index names and their order in the container definition.
+            """,
+        ),
+        A[x = :a, y = 2, z = 99],
+    )
+    @test_throws(
+        ErrorException(
+            """
+            Number of keyword arguments (1) does not match the number of dimensions (2).
+
+            When using keyword indexing, the indices must match the exact \
+            name and order used when creating the container.
+
+            Check the index names and their order in the container definition.
+            """,
+        ),
+        A[x = :a],
+    )
+    return
+end
+
 end  # module


### PR DESCRIPTION
This fixes the DenseAxisArray case. I need to think a bit more about the DenseAxisArrayView. There's a few weird behaviours once you start playing with it.