### PR TITLE
Fix incorrect Base.imag(::GenericQuadExpr{<:Real})

### DIFF
--- a/src/quad_expr.jl
+++ b/src/quad_expr.jl
@@ -180,7 +180,7 @@ Base.broadcastable(q::GenericQuadExpr) = Ref(q)
 
 Base.conj(a::GenericQuadExpr{<:Real}) = a
 Base.real(a::GenericQuadExpr{<:Real}) = a
-Base.imag(a::GenericQuadExpr{<:Real}) = a
+Base.imag(a::GenericQuadExpr{<:Real}) = zero(a)
 Base.isreal(::GenericQuadExpr{<:Real}) = true
 
 Base.conj(a::GenericQuadExpr{<:Complex}) = map_coefficients(conj, a)

--- a/test/test_complex.jl
+++ b/test/test_complex.jl
@@ -201,7 +201,7 @@ function test_complex_conj()
     real_quad = 4x^2 + 2 * x + 3
     @test conj(real_quad) === real_quad
     @test real(real_quad) === real_quad
-    @test imag(real_quad) === real_quad
+    @test imag(real_quad) == 0
     complex_quad = (4 - 5im) * x^2 + (2 + im) * x + 3 - im
     @test conj(complex_quad) == (4 + 5im) * x^2 + (2 - im) * x + 3 + im
     @test real(complex_quad) == 4x^2 + 2x + 3


### PR DESCRIPTION
Here's an interesting one @blegat! 

Added by https://github.com/jump-dev/JuMP.jl/pull/2899

The similar change for AffExpr was fixed in https://github.com/jump-dev/JuMP.jl/pull/3154#discussion_r1054918700

But we missed the corresponding QuadExpr function.